### PR TITLE
Make view extension optional

### DIFF
--- a/Fluid.MvcSample/Views/Home/Index.liquid
+++ b/Fluid.MvcSample/Views/Home/Index.liquid
@@ -6,7 +6,7 @@ Hello World from Liquid 2
   <p>{{ p.Firstname }} {{ p.Lastname }}</p>
 {% endfor %}
 
-{% include '_Partial.liquid' %}
+{% include '_Partial' %}
 
 {% section footer %}
 This is the footer

--- a/Fluid.MvcSample/Views/_ViewStart.liquid
+++ b/Fluid.MvcSample/Views/_ViewStart.liquid
@@ -1,2 +1,2 @@
-{% layout '_Layout.liquid' %}
+{% layout '_Layout' %}
 From /Views/_ViewStart.liquid

--- a/Fluid.MvcViewEngine/Statements/LayoutStatement.cs
+++ b/Fluid.MvcViewEngine/Statements/LayoutStatement.cs
@@ -3,7 +3,6 @@ using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Fluid.Ast;
 using FluidMvcViewEngine;
-using Microsoft.Extensions.FileProviders;
 
 namespace Fluid.MvcViewEngine.Statements
 {
@@ -19,6 +18,11 @@ namespace Fluid.MvcViewEngine.Statements
         public override async Task<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
             var relativeLayoutPath = (await Path.EvaluateAsync(context)).ToStringValue();
+            if (!relativeLayoutPath.EndsWith(FluidViewEngine.ViewExtension))
+            {
+                relativeLayoutPath += FluidViewEngine.ViewExtension;
+            }
+
             var currentViewPath = context.AmbientValues[FluidRendering.ViewPath] as string;
             var currentDirectory = System.IO.Path.GetDirectoryName(currentViewPath);
             var layoutPath = System.IO.Path.Combine(currentDirectory, relativeLayoutPath);

--- a/Fluid/Ast/IncludeStatement.cs
+++ b/Fluid/Ast/IncludeStatement.cs
@@ -6,6 +6,8 @@ namespace Fluid.Ast
 {
     public class IncludeStatement : Statement
     {
+        public static readonly string ViewExtension = ".liquid";
+
         public IncludeStatement(Expression path)
         {
             Path = path;
@@ -16,6 +18,11 @@ namespace Fluid.Ast
         public override async Task<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
             var relativePath = (await Path.EvaluateAsync(context)).ToStringValue();
+            if (!relativePath.EndsWith(ViewExtension))
+            {
+                relativePath += ViewExtension;
+            }
+
             var fileProvider = context.FileProvider ?? TemplateContext.GlobalFileProvider;
             var fileInfo = fileProvider.GetFileInfo(relativePath);
             string partialContent;


### PR DESCRIPTION
According to spec [here](https://help.shopify.com/themes/liquid/tags/theme-tags) it would be nice if we make the `.liquid` optional for both `include` and `layout` tags