### PR TITLE
Add Support for .NET 4.6

### DIFF
--- a/Fluid.Tests/Fluid.Tests.csproj
+++ b/Fluid.Tests/Fluid.Tests.csproj
@@ -17,16 +17,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net461'">
-		<Reference Include="Microsoft.CSharp" />
-	</ItemGroup>
-
-
-  <ItemGroup>
-    <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Fluid.Tests/Fluid.Tests.csproj
+++ b/Fluid.Tests/Fluid.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFrameworks>netcoreapp1.1;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,10 +16,20 @@
     <ProjectReference Include="..\Fluid\Fluid.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)'=='net461'">
+		<Reference Include="Microsoft.CSharp" />
+	</ItemGroup>
+
+
   <ItemGroup>
     <None Update="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/Fluid/Fluid.csproj
+++ b/Fluid/Fluid.csproj
@@ -7,7 +7,7 @@
 
 
   <ItemGroup Condition="'$(TargetFramework)'=='net46'">
-      <PackageReference Include="Irony" Version="0.9.1" />
+    <PackageReference Include="Irony" Version="0.9.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6'">

--- a/Fluid/Fluid.csproj
+++ b/Fluid/Fluid.csproj
@@ -1,12 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net46'">
+      <PackageReference Include="Irony" Version="0.9.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6'">
     <PackageReference Include="Irony.Core" Version="1.0.6" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="1.1.1" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.3.1" />


### PR DESCRIPTION
Hello:

I made a little modification to Support for .NET 4.6. 

All tests are passed successfully in both .NET Standard target and .NET 4.6 target.

Hope it helps.