### PR TITLE
Adding test to ensure parsed numbers are culture insensitive

### DIFF
--- a/Fluid.Benchmarks/Fluid.Benchmarks.csproj
+++ b/Fluid.Benchmarks/Fluid.Benchmarks.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.10.7" />
     <PackageReference Include="DotLiquid" Version="2.0.99" />
-    <PackageReference Include="Irony.Core" Version="1.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Fluid.Tests/TemplateTests.cs
+++ b/Fluid.Tests/TemplateTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text.Encodings.Web;
+using System.Threading;
 using System.Threading.Tasks;
 using Fluid.Tests.Domain;
 using Fluid.Values;
@@ -388,6 +389,27 @@ namespace Fluid.Tests
 
             Assert.Equal(expectedFR, resultFR);
             Assert.Equal(expectedUS, resultUS);
+        }
+
+        [Fact]
+        public async Task NumbersAreCultureInvariant()
+        {
+            var source = "{{ 1234.567 }}";
+
+            var expected = "1234.567";
+            CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
+            FluidTemplate.TryParse(source, out var templateFR, out var messages);
+
+            CultureInfo.CurrentCulture = new CultureInfo("en-US");
+            FluidTemplate.TryParse(source, out var templateUS, out messages);
+
+            var context = new TemplateContext();
+
+            var resultUS = await templateUS.RenderAsync(context);
+            var resultFR = await templateFR.RenderAsync(context);
+
+            Assert.Equal(expected, resultFR);
+            Assert.Equal(expected, resultUS);
         }
     }
 }

--- a/Fluid/Fluid.csproj
+++ b/Fluid/Fluid.csproj
@@ -5,16 +5,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-
-  <ItemGroup Condition="'$(TargetFramework)'=='net46'">
-    <PackageReference Include="Irony" Version="0.9.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6'">
-    <PackageReference Include="Irony.Core" Version="1.0.6" />
-  </ItemGroup>
-
   <ItemGroup>
+    <PackageReference Include="Irony.Core" Version="1.0.7" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="1.1.1" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.3.1" />

--- a/Fluid/FluidTemplate.cs
+++ b/Fluid/FluidTemplate.cs
@@ -28,16 +28,23 @@ namespace Fluid
                 throw new ArgumentNullException(nameof(context));
             }
 
-             using(var writer = new StringWriter())
+            if (template == null)
+            {
+                throw new ArgumentNullException(nameof(template));
+            }
+
+            using (var writer = new StringWriter())
             {
                 await template.RenderAsync(writer, HtmlEncoder.Default, context);
                 return writer.ToString();
             }
         }
+
         public static string Render(this IFluidTemplate template, TemplateContext context)
         {
             return template.RenderAsync(context).GetAwaiter().GetResult();
-        }        
+        }
+
         public static Task<string> RenderAsync(this IFluidTemplate template)
         {
             return template.RenderAsync(new TemplateContext());
@@ -85,19 +92,19 @@ namespace Fluid
         {
             if (_factory.CreateParser().TryParse(text, out var statements, out errors))
             {
-                result =  new FluidTemplate<T>(statements);
+                result = new FluidTemplate<T>(statements);
                 return true;
             }
             else
             {
                 result = null;
                 return false;
-            }            
+            }
         }
 
         public async Task RenderAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
-            foreach(var statement in Statements)
+            foreach (var statement in Statements)
             {
                 await statement.WriteToAsync(writer, encoder, context);
             }


### PR DESCRIPTION
Changed Irony to support custom cultures when parsing. Default culture is `InvariantCulture` which is the one used in Fluid.

Here is the corresponding change in Irony: https://github.com/sebastienros/irony/commit/4388b1fa9d79bb2d037ab6b7afd6b22fe4520aca