### PR TITLE
Child and local scope handling by TemplateContext

### DIFF
--- a/Fluid.Tests/IncludeStatementTests.cs
+++ b/Fluid.Tests/IncludeStatementTests.cs
@@ -49,6 +49,7 @@ namespace Fluid.Tests
                 FileProvider = new MockFileProvider("Partials")
             };
             var expectedResult = @"Partial Content
+Partials: ''
 color: ''
 shape: ''";
 
@@ -72,6 +73,7 @@ shape: ''";
                 FileProvider = new MockFileProvider("Partials")
             };
             var expectedResult = @"Partial Content
+Partials: ''
 color: 'blue'
 shape: 'circle'";
 
@@ -91,6 +93,7 @@ shape: 'circle'";
                 FileProvider = new MockFileProvider("Partials")
             };
             var expectedResult = @"Partial Content
+Partials: ''
 color: 'blue'
 shape: ''";
 

--- a/Fluid.Tests/Mocks/MockFileInfo.cs
+++ b/Fluid.Tests/Mocks/MockFileInfo.cs
@@ -27,6 +27,7 @@ namespace Fluid.Tests.Mocks
         public Stream CreateReadStream()
         {
             var content = @"{{ 'Partial Content' }}
+Partials: '{{ Partials }}'
 color: '{{ color }}'
 shape: '{{ shape }}'";
             var data = Encoding.UTF8.GetBytes(content);

--- a/Fluid.Tests/TemplateTests.cs
+++ b/Fluid.Tests/TemplateTests.cs
@@ -493,11 +493,19 @@ namespace Fluid.Tests
         [Fact]
         public async Task IncludeParamsShouldNotBeSetInTheParentTemplate()
         {
-            var source = @"{% include 'Partials', color: 'red', shape: 'circle' %}
-{% assign color = 'blue' %}";
+            var source = @"{% assign color = 'blue' %}
+{% include 'Partials', color: 'red', shape: 'circle' %}
+
+Parent Content
+color: '{{ color }}'
+shape: '{{ shape }}'";
             var expected = @"Partial Content
+Partials: ''
 color: 'red'
-shape: 'circle'";
+shape: 'circle'
+Parent Content
+color: 'blue'
+shape: ''";
             FluidTemplate.TryParse(source, out var template, out var messages);
             var context = new TemplateContext
             {
@@ -511,12 +519,17 @@ shape: 'circle'";
         [Fact]
         public async Task IncludeWithTagParamShouldNotBeSetInTheParentTemplate()
         {
-            var source = @"{% include 'Partials' with 'value' %}
-{% assign Partials = 'another value' %}
+            var source = @"{% assign Partials = 'parent value' %}
+{% include 'Partials' with 'included value' %}
+
+Parent Content
 {{ Partials }}";
             var expected = @"Partial Content
+Partials: 'included value'
 color: ''
-shape: ''value";
+shape: ''
+Parent Content
+parent value";
             FluidTemplate.TryParse(source, out var template, out var messages);
             var context = new TemplateContext
             {

--- a/Fluid/Ast/ForStatement.cs
+++ b/Fluid/Ast/ForStatement.cs
@@ -93,20 +93,20 @@ namespace Fluid.Ast
                 return Completion.Normal;
             }
 
-            var forScope = context.EnterChildScope();
+            context.EnterChildScope();
 
             try
             {
                 var forloop = new Dictionary<string, FluidValue>();
                 forloop.Add("length", new NumberValue(list.Count));
-                forScope.SetValue("forloop", new DictionaryValue(new FluidValueDictionaryFluidIndexable(forloop)));
+                context.SetValue("forloop", new DictionaryValue(new FluidValueDictionaryFluidIndexable(forloop)));
 
 
                 for (var i = 0; i < list.Count; i++)
                 {
                     var item = list[i];
 
-                    forScope.SetValue(Identifier, item);
+                    context.SetValue(Identifier, item);
 
                     // Set helper variables
                     forloop["index"] = new NumberValue(i + 1);

--- a/Fluid/Ast/IncludeStatement.cs
+++ b/Fluid/Ast/IncludeStatement.cs
@@ -54,7 +54,8 @@ namespace Fluid.Ast
             using (var stream = fileInfo.CreateReadStream())
             using (var streamReader = new StreamReader(stream))
             {
-                var childScope = context.EnterChildScope();
+                context.EnterChildScope();
+
                 string partialTemplate = await streamReader.ReadToEndAsync();
                 var parser = CreateParser(context);
                 if (parser.TryParse(partialTemplate, out var statements, out var errors))
@@ -64,7 +65,7 @@ namespace Fluid.Ast
                     {
                         var identifier = System.IO.Path.GetFileNameWithoutExtension(relativePath);
                         var with = await With.EvaluateAsync(context);
-                        childScope.SetValue(identifier, with);
+                        context.SetValue(identifier, with);
                     }
 
                     if (AssignStatements != null)
@@ -82,7 +83,7 @@ namespace Fluid.Ast
                     throw new Exception(String.Join(Environment.NewLine, errors));
                 }
 
-                childScope.ReleaseScope();
+                context.ReleaseScope();
             }
 
             return Completion.Normal;

--- a/Fluid/TemplateContext.cs
+++ b/Fluid/TemplateContext.cs
@@ -79,11 +79,18 @@ namespace Fluid
             LocalScope = new Scope(GlobalScope);
         }
 
+        /// <summary>
+        /// Creates a new isolated scope. After than any value added to this content object will be released once
+        /// <see cref="ReleaseScope" /> is called. The previous scope is linked such that its values are still available.
+        /// </summary>
         public void EnterChildScope()
         {
             LocalScope = LocalScope.EnterChildScope();
         }
 
+        /// <summary>
+        /// Exits the current scope that has been created by <see cref="EnterChildScope" />
+        /// </summary>
         public void ReleaseScope()
         {
             LocalScope = LocalScope.ReleaseScope();

--- a/Fluid/TemplateContext.cs
+++ b/Fluid/TemplateContext.cs
@@ -9,7 +9,6 @@ namespace Fluid
 {
     public class TemplateContext
     {
-        protected Scope _scope;
         // Scopes
         public static Scope GlobalScope = new Scope();
 
@@ -77,13 +76,12 @@ namespace Fluid
 
         public TemplateContext()
         {
-            _scope = new Scope(GlobalScope);
-            LocalScope = _scope;
+            LocalScope = new Scope(GlobalScope);
         }
 
-        public Scope EnterChildScope()
+        public void EnterChildScope()
         {
-            return LocalScope = LocalScope.EnterChildScope();
+            LocalScope = LocalScope.EnterChildScope();
         }
 
         public void ReleaseScope()
@@ -98,12 +96,12 @@ namespace Fluid
 
         public FluidValue GetValue(string name)
         {
-            return _scope.GetValue(name);
+            return LocalScope.GetValue(name);
         }
 
         public void SetValue(string name, FluidValue value)
         {
-            _scope.SetValue(name, value);
+            LocalScope.SetValue(name, value);
         }
 
         public void SetValue(string name, int value)


### PR DESCRIPTION
I believe this addresses the source of variables leaking into parent scope like in issue #45. This affects the `include` and `for` statements.

One thing I did was change TemplateContext.EnterChildScope from returning a `Scope` to returning `void`. This is because the TemplateContext.ReleaseScope method should be called and not the `Scope` object's `ReleaseScope`. I want to encourage callers to use TemplateContext's Release Scope method. Calling code can still technically call the Scope object's ReleaseScope method directly by accessing it via the TemplateContext.LocalScope property, but the result of doing so is undefined behavior.

This could be further refactored by introducing an interface that the Scope class would implement. The interface would not surface the `ReleaseScope` method. The TemplateContext.LocalScope property would be of this type of interface instead of Scope, and further guarding calling code calling TemplateContext.LocalScope.ReleaseScope directly.