### PR TITLE
Truncate returns the input unmodified if the string is too short or nil

### DIFF
--- a/Fluid.Tests/StringFiltersTests.cs
+++ b/Fluid.Tests/StringFiltersTests.cs
@@ -208,6 +208,32 @@ namespace Fluid.Tests
         }
 
         [Fact]
+        public void TruncateShortString()
+        {
+            var input = new StringValue("Hello");
+
+            var arguments = new FilterArguments().Add(new NumberValue(5)).Add(new StringValue("..."));
+            var context = new TemplateContext();
+
+            var result = StringFilters.Truncate(input, arguments, context);
+
+            Assert.Equal("Hello", result.ToStringValue());
+        }
+
+        [Fact]
+        public void TruncateNullString()
+        {
+            var input = new StringValue(null);
+
+            var arguments = new FilterArguments().Add(new NumberValue(5)).Add(new StringValue("..."));
+            var context = new TemplateContext();
+
+            var result = StringFilters.Truncate(input, arguments, context);
+
+            Assert.Null(result.ToStringValue());
+        }
+
+        [Fact]
         public void TruncateWords()
         {
             var input = new StringValue("This is a nice story with a bad end.");

--- a/Fluid/Filters/StringFilters.cs
+++ b/Fluid/Filters/StringFilters.cs
@@ -145,14 +145,24 @@ namespace Fluid.Filters
 
         public static FluidValue Truncate(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            var source = input.ToStringValue().Substring(0, Convert.ToInt32(arguments.At(0).ToNumberValue()));
+            string text = input.ToStringValue();
+            int length = Convert.ToInt32(arguments.At(0).ToNumberValue());
 
-            if (arguments.Count > 1)
+            if (text == null || text.Length <= length)
             {
-                source += arguments.At(1).ToStringValue();
+                return input;
             }
+            else
+            {
+                var source = text.Substring(0, length);
 
-            return new StringValue(source);
+                if (arguments.Count > 1)
+                {
+                    source += arguments.At(1).ToStringValue();
+                }
+
+                return new StringValue(source);
+            }
         }
         public static FluidValue TruncateWords(FluidValue input, FilterArguments arguments, TemplateContext context)
         {


### PR DESCRIPTION
The truncate filter errors if the input is nil or shorter than length. This fixes that.