### PR TITLE
First and Last now return NilValue when passed an empty array

### DIFF
--- a/Fluid.Tests/ArrayFiltersTests.cs
+++ b/Fluid.Tests/ArrayFiltersTests.cs
@@ -42,6 +42,19 @@ namespace Fluid.Tests
         }
 
         [Fact]
+        public void First_EmptyArray()
+        {
+            var input = new ArrayValue(new StringValue[0]);
+
+            var arguments = new FilterArguments();
+            var context = new TemplateContext();
+
+            var result = ArrayFilters.First(input, arguments, context);
+
+            Assert.IsType<NilValue>(result);
+        }
+
+        [Fact]
         public void Last()
         {
             var input = new ArrayValue(new[] {
@@ -56,6 +69,19 @@ namespace Fluid.Tests
             var result = ArrayFilters.Last(input, arguments, context);
 
             Assert.Equal(new StringValue("c"), result);
+        }
+
+        [Fact]
+        public void Last_EmptyArray()
+        {
+            var input = new ArrayValue(new StringValue[0]);
+
+            var arguments = new FilterArguments();
+            var context = new TemplateContext();
+
+            var result = ArrayFilters.Last(input, arguments, context);
+
+            Assert.IsType<NilValue>(result);
         }
 
         [Fact]

--- a/Fluid/Filters/ArrayFilters.cs
+++ b/Fluid/Filters/ArrayFilters.cs
@@ -39,7 +39,7 @@ namespace Fluid.Filters
                 return input;
             }
 
-            return input.Enumerate().First();
+            return input.Enumerate().FirstOrDefault() ?? NilValue.Instance;
         }
 
         public static FluidValue Last(FluidValue input, FilterArguments arguments, TemplateContext context)
@@ -49,7 +49,7 @@ namespace Fluid.Filters
                 return input;
             }
 
-            return input.Enumerate().Last();
+            return input.Enumerate().LastOrDefault() ?? NilValue.Instance;
         }
 
         public static FluidValue Concat(FluidValue input, FilterArguments arguments, TemplateContext context)


### PR DESCRIPTION
Fixes #52.

If returning NilValue is not correct (I guessed because I couldn't find any documentation), I can change it.