### PR TITLE
Override the Create method to accept encode paramter

### DIFF
--- a/Fluid/Values/FluidValue.cs
+++ b/Fluid/Values/FluidValue.cs
@@ -52,6 +52,11 @@ namespace Fluid.Values
 
         public static FluidValue Create(object value)
         {
+            return Create(value, true);
+        }
+
+        public static FluidValue Create(object value, bool encode)
+        {
             if (value == null)
             {
                 return NilValue.Instance;
@@ -121,7 +126,7 @@ namespace Fluid.Values
 
                         case IEnumerable enumerable:
                             var fluidValues = new List<FluidValue>();
-                            foreach(var item in enumerable)
+                            foreach (var item in enumerable)
                             {
                                 fluidValues.Add(Create(item));
                             }
@@ -134,7 +139,7 @@ namespace Fluid.Values
                     return new DateTimeValue((DateTime)value);
                 case TypeCode.Char:
                 case TypeCode.String:
-                    return new StringValue(Convert.ToString(value, CultureInfo.InvariantCulture));
+                    return new StringValue(Convert.ToString(value, CultureInfo.InvariantCulture), encode);
                 default:
                     throw new InvalidOperationException();
             }


### PR DESCRIPTION
In Orchard.Core, https://github.com/OrchardCMS/OrchardCore/blob/dev/src/OrchardCore.Modules/OrchardCore.Liquid/Startup.cs

we need to specify the encode parameter as by default, it encodes all input strings.