### PR TITLE
allow dot in names to target deep properties

### DIFF
--- a/Fluid.Tests/ArrayFiltersTests.cs
+++ b/Fluid.Tests/ArrayFiltersTests.cs
@@ -131,6 +131,30 @@ namespace Fluid.Tests
         }
 
         [Fact]
+        public void Map_DeepProperties() 
+        {
+            var sample = new { Title = new { Text = "a" } };
+            var input = new ArrayValue(new[] {
+                new ObjectValue(new { Title = new { Text = "a" }}),
+                new ObjectValue(new { Title = new { Text = "b" }}),
+                new ObjectValue(new { Title = new { Text = "c" }})
+                });
+
+            var arguments = new FilterArguments().Add(new StringValue("Title.Text"));
+
+            var context = new TemplateContext();
+            context.MemberAccessStrategy.Register(sample.GetType());
+            context.MemberAccessStrategy.Register(sample.Title.GetType());
+
+            var result = ArrayFilters.Map(input, arguments, context);
+
+            Assert.Equal(3, result.Enumerate().Count());
+            Assert.Equal(new StringValue("a"), result.Enumerate().ElementAt(0));
+            Assert.Equal(new StringValue("b"), result.Enumerate().ElementAt(1));
+            Assert.Equal(new StringValue("c"), result.Enumerate().ElementAt(2));
+        }
+
+        [Fact]
         public void Reverse()
         {
             var input = new ArrayValue(new[] {

--- a/Fluid/Filters/ArrayFilters.cs
+++ b/Fluid/Filters/ArrayFilters.cs
@@ -129,19 +129,7 @@ namespace Fluid.Filters
 
             return new ArrayValue(input.Enumerate().OrderBy(x =>
             {
-                if (member.Contains("."))
-                {
-                    foreach(var prop in member.Split('.'))
-                    {
-                        x = x.GetValueAsync(prop, context).GetAwaiter().GetResult();
-                    }
-
-                    return x.ToObjectValue();
-                }
-                else
-                {
-                    return x.GetValueAsync(member, context).GetAwaiter().GetResult().ToObjectValue();
-                }
+                return x.GetValueAsync(member, context).GetAwaiter().GetResult().ToObjectValue();
             }).ToArray());
         }
 


### PR DESCRIPTION
Not sure if this is the right place.  Intend to address  OrchardCMS/OrchardCore#2096.

I thought about adding directly in `ArrayFilters.Map`.  But I think putting the code in `ObjectValue` can empower the other filters as well.  E.g., the sort filter.