### PR TITLE
Add error handling for blocks.

### DIFF
--- a/Fluid.Tests/ParserTests.cs
+++ b/Fluid.Tests/ParserTests.cs
@@ -240,5 +240,35 @@ def", "at line:2, col:6")]
 
             Assert.EndsWith(expectedErrorEndString, errors.FirstOrDefault());
         }
+
+        [Theory]
+        [InlineData("{% for a in b %}")]
+        [InlineData("{% if true %}")]
+        [InlineData("{% unless true %}")]
+        [InlineData("{% case a %}")]
+        [InlineData("{% capture myVar %}")]
+        public void ShouldFailNotClosedBlock(string source)
+        {
+            var result = FluidTemplate.TryParse(source, out var template, out var errors);
+
+            Assert.False(result);
+            Assert.NotEmpty(errors);
+        }
+
+        [Theory]
+        [InlineData("{% for a in b %} {% endfor %}")]
+        [InlineData("{% if true %} {% endif %}")]
+        [InlineData("{% unless true %} {% endunless %}")]
+        [InlineData("{% case a %} {% when 'cake' %} blah {% endcase %}")]
+        [InlineData("{% capture myVar %} capture me! {% endcapture %}")]
+        public void ShouldSucceedClosedBlock(string source)
+        {
+            var result = FluidTemplate.TryParse(source, out var template, out var errors);
+
+            Assert.True(result);
+            Assert.NotNull(template);
+            Assert.Empty(errors);
+        }
+
     }
 }

--- a/Fluid/DefaultFluidParser.cs
+++ b/Fluid/DefaultFluidParser.cs
@@ -166,7 +166,11 @@ namespace Fluid
                         }
                     }
                 }
-
+                // Make sure we aren't still in a block
+                if(_context.AreInBlock())
+                {
+                    throw (new ParseException($"Expected end of block: {_context.CurrentBlock.Tag}"));
+                }
                 return true;
             }
             catch (ParseException e)

--- a/Fluid/DefaultFluidParser.cs
+++ b/Fluid/DefaultFluidParser.cs
@@ -167,7 +167,7 @@ namespace Fluid
                     }
                 }
                 // Make sure we aren't still in a block
-                if(_context.AreInBlock())
+                if(_context._blocks.Count > 0)
                 {
                     throw (new ParseException($"Expected end of block: {_context.CurrentBlock.Tag}"));
                 }

--- a/Fluid/DefaultFluidParser.cs
+++ b/Fluid/DefaultFluidParser.cs
@@ -166,8 +166,9 @@ namespace Fluid
                         }
                     }
                 }
+                
                 // Make sure we aren't still in a block
-                if(_context._blocks.Count > 0)
+                if (_context._blocks.Count > 0)
                 {
                     throw (new ParseException($"Expected end of block: {_context.CurrentBlock.Tag}"));
                 }

--- a/Fluid/ParserContext.cs
+++ b/Fluid/ParserContext.cs
@@ -6,7 +6,7 @@ namespace Fluid
 {
     public class ParserContext
     {
-        private Stack<BlockContext> _blocks { get; } = new Stack<BlockContext>();
+        internal Stack<BlockContext> _blocks { get; } = new Stack<BlockContext>();
 
         public BlockContext CurrentBlock { get; private set; } = new BlockContext(null);
 
@@ -36,13 +36,6 @@ namespace Fluid
         public void ExitBlock()
         {
             CurrentBlock = _blocks.Pop();
-        }
-        /// <summary>
-        /// Invoked at the end of parsing to ensure we closed all blocks
-        /// </summary>
-        public bool AreInBlock()
-        {
-            return(_blocks.Count > 0);
         }
     }
 }

--- a/Fluid/ParserContext.cs
+++ b/Fluid/ParserContext.cs
@@ -37,5 +37,12 @@ namespace Fluid
         {
             CurrentBlock = _blocks.Pop();
         }
+        /// <summary>
+        /// Invoked at the end of parsing to ensure we closed all blocks
+        /// </summary>
+        public bool AreInBlock()
+        {
+            return(_blocks.Count > 0);
+        }
     }
 }


### PR DESCRIPTION
This throws an error if after parsing we are still in a block waiting for the end of it. Not sure if the terminology is what you would want with AreInBlock, maybe IsInBlock would be better, or just InBlock maybe. Feel free to change as needed. This will help my support people very much to have some idea what they did wrong.