### PR TITLE
Optimize data structure usage a bit

### DIFF
--- a/Fluid.Benchmarks/DotLiquidBenchmarks.cs
+++ b/Fluid.Benchmarks/DotLiquidBenchmarks.cs
@@ -1,12 +1,10 @@
 ﻿using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Attributes.Jobs;
 using DotLiquid;
 
 namespace Fluid.Benchmarks
 {
     [MemoryDiagnoser]
-    [ShortRunJob]
     public class DotLiquidBenchmarks : BaseBenchmarks
     {
         

--- a/Fluid.Benchmarks/Fluid.Benchmarks.csproj
+++ b/Fluid.Benchmarks/Fluid.Benchmarks.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.9" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.3" />
     <PackageReference Include="DotLiquid" Version="2.0.174" />
     <PackageReference Include="Liquid.NET" Version="0.10.0" />
   </ItemGroup>

--- a/Fluid.Benchmarks/FluidBenchmarks.cs
+++ b/Fluid.Benchmarks/FluidBenchmarks.cs
@@ -1,11 +1,9 @@
 ﻿using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Attributes.Jobs;
 
 namespace Fluid.Benchmarks
 {
     [MemoryDiagnoser]
-    [ShortRunJob]
     public class FluidBenchmarks : BaseBenchmarks
     {
         private FluidTemplate _sampleTemplateFluid;

--- a/Fluid.Benchmarks/LiquidNetBenchmarks.cs
+++ b/Fluid.Benchmarks/LiquidNetBenchmarks.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Attributes.Jobs;
 using Liquid.NET;
 using Liquid.NET.Constants;
 using Liquid.NET.Utils;
@@ -8,7 +7,6 @@ using Liquid.NET.Utils;
 namespace Fluid.Benchmarks
 {
     [MemoryDiagnoser]
-    [ShortRunJob]
     public class LiquidNetBenchmarks : BaseBenchmarks
     {
         private LiquidParsingResult _sampleTemplateLiquidNet;

--- a/Fluid.Tests/CaseStatementTests.cs
+++ b/Fluid.Tests/CaseStatementTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Fluid.Ast;
@@ -14,9 +15,9 @@ namespace Fluid.Tests
         private LiteralExpression C = new LiteralExpression(new StringValue("c"));
         private LiteralExpression D = new LiteralExpression(new StringValue("d"));
 
-        private Statement[] TEXT(string text)
+        private List<Statement> TEXT(string text)
         {
-            return new Statement[] { new TextStatement(text) };
+            return new List<Statement> { new TextStatement(text) };
         }
 
         [Fact]
@@ -26,7 +27,7 @@ namespace Fluid.Tests
                 A,
                 null,
                 new[] {
-                    new WhenStatement(new [] { A }, TEXT("x"))
+                    new WhenStatement(new List<Expression> { A }, TEXT("x"))
                 }
             );
 
@@ -43,7 +44,7 @@ namespace Fluid.Tests
                 A,
                 null,
                 new[] {
-                    new WhenStatement(new [] { A, B, C }, TEXT("x"))
+                    new WhenStatement(new List<Expression> { A, B, C }, TEXT("x"))
                 }
             );
 
@@ -60,7 +61,7 @@ namespace Fluid.Tests
                 A,
                 null,
                 new[] {
-                    new WhenStatement(new [] { B, C, D }, TEXT("x"))
+                    new WhenStatement(new List<Expression> { B, C, D }, TEXT("x"))
                 }
             );
 
@@ -75,9 +76,9 @@ namespace Fluid.Tests
         {
             var e = new CaseStatement(
                 A,
-                new ElseStatement(new[] { new TextStatement("y")}),
+                new ElseStatement(new List<Statement> { new TextStatement("y")}),
                 new[] {
-                    new WhenStatement(new [] { A }, TEXT("x"))
+                    new WhenStatement(new List<Expression> { A }, TEXT("x"))
                 }
             );
 
@@ -92,9 +93,9 @@ namespace Fluid.Tests
         {
             var e = new CaseStatement(
                 A,
-                new ElseStatement(new[] { new TextStatement("y") }),
+                new ElseStatement(new List<Statement> { new TextStatement("y") }),
                 new[] {
-                    new WhenStatement(new [] { B, C }, TEXT("x"))
+                    new WhenStatement(new List<Expression> { B, C }, TEXT("x"))
                 }
             );
 
@@ -109,11 +110,11 @@ namespace Fluid.Tests
         {
             var e = new CaseStatement(
                 B,
-                new ElseStatement(new[] { new TextStatement("y") }),
+                new ElseStatement(new List<Statement> { new TextStatement("y") }),
                 new[] {
-                    new WhenStatement(new [] { A, C }, TEXT("1")),
-                    new WhenStatement(new [] { B, C }, TEXT("2")),
-                    new WhenStatement(new [] { C }, TEXT("3"))
+                    new WhenStatement(new List<Expression> { A, C }, TEXT("1")),
+                    new WhenStatement(new List<Expression> { B, C }, TEXT("2")),
+                    new WhenStatement(new List<Expression> { C }, TEXT("3"))
                 }
             );
 
@@ -130,8 +131,8 @@ namespace Fluid.Tests
                 A,
                 null,
                 new[] {
-                    new WhenStatement(new [] { B }, TEXT("2")),
-                    new WhenStatement(new [] { C }, TEXT("3"))
+                    new WhenStatement(new List<Expression> { B }, TEXT("2")),
+                    new WhenStatement(new List<Expression> { C }, TEXT("3"))
                 }
             );
 

--- a/Fluid.Tests/CustomGrammarTests.cs
+++ b/Fluid.Tests/CustomGrammarTests.cs
@@ -68,7 +68,7 @@ namespace Fluid.Tests
             var range = node.ChildNodes[0].ChildNodes[1];
 
             return new ForStatement(
-                new[] { new OutputStatement(new LiteralExpression(new StringValue(identifier))) },
+                new List<Statement> { new OutputStatement(new LiteralExpression(new StringValue(identifier))) },
                 identifier,
                 DefaultFluidParser.BuildRangeExpression(range),
                 null,

--- a/Fluid.Tests/ForStatementTests.cs
+++ b/Fluid.Tests/ForStatementTests.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Fluid.Ast;
@@ -17,7 +15,7 @@ namespace Fluid.Tests
         public async Task ShouldLoopRange()
         {
             var e = new ForStatement(
-                new[] { new TextStatement("x") },
+                new List<Statement> { new TextStatement("x") },
                 "i",
                 new RangeExpression(
                     new LiteralExpression(new NumberValue(1)),
@@ -36,7 +34,7 @@ namespace Fluid.Tests
         public async Task ShouldUseCurrentContext()
         {
             var e = new ForStatement(
-                new Statement[] {
+                new List<Statement> {
                     new AssignStatement("z", new LiteralExpression(new NumberValue(1)))
                     },
                 "i",
@@ -62,7 +60,7 @@ namespace Fluid.Tests
         public async Task ShouldLoopArrays()
         {
             var e = new ForStatement(
-                new[] { new TextStatement("x") },
+                new List<Statement> { new TextStatement("x") },
                 "i",
                 new MemberExpression(
                     new IdentifierSegment("items")
@@ -82,7 +80,7 @@ namespace Fluid.Tests
         public async Task ShouldHandleBreak()
         {
             var e = new ForStatement(
-                new Statement[] {
+                new List<Statement> {
                     new TextStatement("x"),
                     new BreakStatement(),
                     new TextStatement("y")
@@ -106,7 +104,7 @@ namespace Fluid.Tests
         public async Task ShouldHandleContinue()
         {
             var e = new ForStatement(
-                new Statement[] {
+                new List<Statement> {
                     new TextStatement("x"),
                     new ContinueStatement(),
                     new TextStatement("y")
@@ -131,7 +129,7 @@ namespace Fluid.Tests
         {
 
             var e = new ForStatement(
-                new Statement[] {
+                new List<Statement> {
                     CreateMemberStatement("forloop.length"),
                     CreateMemberStatement("forloop.index"),
                     CreateMemberStatement("forloop.index0"),
@@ -159,7 +157,7 @@ namespace Fluid.Tests
         public async Task ForEvaluatesOptions()
         {
             var e = new ForStatement(
-                new[] { CreateMemberStatement("i") },
+                new List<Statement> { CreateMemberStatement("i") },
                 "i",
                 new RangeExpression(
                     new LiteralExpression(new NumberValue(1)),

--- a/Fluid.Tests/IfStatementTests.cs
+++ b/Fluid.Tests/IfStatementTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Fluid.Ast;
@@ -12,9 +13,9 @@ namespace Fluid.Tests
         private Expression TRUE = new LiteralExpression(new BooleanValue(true));
         private Expression FALSE = new LiteralExpression(new BooleanValue(false));
 
-        private Statement[] TEXT(string text)
+        private List<Statement> TEXT(string text)
         {
-            return new Statement[] { new TextStatement(text) };
+            return new List<Statement> { new TextStatement(text) };
         }
 
         [Fact]
@@ -22,7 +23,7 @@ namespace Fluid.Tests
         {
             var e = new IfStatement(
                 TRUE,
-                new[] { new TextStatement("x") }
+                new List<Statement> { new TextStatement("x") }
                 );
 
             var sw = new StringWriter();
@@ -36,7 +37,7 @@ namespace Fluid.Tests
         {
             var e = new IfStatement(
                 FALSE,
-                new[] { new TextStatement("x") }
+                new List<Statement> { new TextStatement("x") }
                 );
 
             var sw = new StringWriter();
@@ -50,10 +51,10 @@ namespace Fluid.Tests
         {
             var e = new IfStatement(
                 TRUE,
-                new Statement[] {
+                new List<Statement> {
                     new TextStatement("x")
                 },
-                new ElseStatement(new[] {
+                new ElseStatement(new List<Statement> {
                         new TextStatement("y")
                     }));
 
@@ -68,10 +69,10 @@ namespace Fluid.Tests
         {
             var e = new IfStatement(
                 FALSE,
-                new Statement[] {
+                new List<Statement> {
                     new TextStatement("x")
                 },
-                new ElseStatement(new[] {
+                new ElseStatement(new List<Statement> {
                         new TextStatement("y")
                     })
                 );
@@ -89,7 +90,7 @@ namespace Fluid.Tests
                 FALSE,
                 TEXT("a"),
                 new ElseStatement(TEXT("b")),
-                new[] { new ElseIfStatement(FALSE, TEXT("c")) }
+                new List<ElseIfStatement> { new ElseIfStatement(FALSE, TEXT("c")) }
                 );
 
             var sw = new StringWriter();
@@ -105,7 +106,7 @@ namespace Fluid.Tests
                 FALSE,
                 TEXT("a"),
                 new ElseStatement(TEXT("b")),
-                new[] { new ElseIfStatement(TRUE, TEXT("c")) }
+                new List<ElseIfStatement> { new ElseIfStatement(TRUE, TEXT("c")) }
                 );
 
             var sw = new StringWriter();
@@ -121,7 +122,7 @@ namespace Fluid.Tests
                 FALSE,
                 TEXT("a"),
                 new ElseStatement(TEXT("b")),
-                new[] {
+                new List<ElseIfStatement> {
                     new ElseIfStatement(FALSE, TEXT("c")),
                     new ElseIfStatement(TRUE, TEXT("d"))}
                 );
@@ -139,7 +140,7 @@ namespace Fluid.Tests
                 FALSE,
                 TEXT("a"),
                 new ElseStatement(TEXT("b")),
-                new[] {
+                new List<ElseIfStatement> {
                     new ElseIfStatement(TRUE, TEXT("c")),
                     new ElseIfStatement(TRUE, TEXT("d"))}
                 );
@@ -157,7 +158,7 @@ namespace Fluid.Tests
                 FALSE,
                 TEXT("a"),
                 null,
-                new[] {
+                new List<ElseIfStatement> {
                     new ElseIfStatement(FALSE, TEXT("c")),
                     new ElseIfStatement(FALSE, TEXT("d"))}
                 );

--- a/Fluid.Tests/ParserTests.cs
+++ b/Fluid.Tests/ParserTests.cs
@@ -84,7 +84,7 @@ namespace Fluid.Tests
 {% endfor %}");
 
             Assert.Equal(1, statements.Count);
-            Assert.Equal(0, ((ForStatement)statements[0]).Statements.Count);
+            Assert.Empty(((ForStatement)statements[0]).Statements);
         }
 
         [Fact]
@@ -163,9 +163,9 @@ namespace Fluid.Tests
 
             var ifStatement = statements.ElementAt(0) as IfStatement;
             Assert.NotNull(ifStatement);
-            Assert.Equal(1, ifStatement.Statements.Count);
+            Assert.Single(ifStatement.Statements);
             Assert.NotNull(ifStatement.Else);
-            Assert.Equal(0, ifStatement.ElseIfs.Count);
+            Assert.Empty(ifStatement.ElseIfs);
         }
 
         [Fact]
@@ -175,7 +175,7 @@ namespace Fluid.Tests
 
             var ifStatement = statements.ElementAt(0) as IfStatement;
             Assert.NotNull(ifStatement);
-            Assert.Equal(1, ifStatement.Statements.Count);
+            Assert.Single(ifStatement.Statements);
             Assert.NotNull(ifStatement.Else);
             Assert.NotNull(ifStatement.ElseIfs);
         }

--- a/Fluid.Tests/UnlessStatementTests.cs
+++ b/Fluid.Tests/UnlessStatementTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Fluid.Ast;
@@ -22,7 +23,7 @@ namespace Fluid.Tests
         {
             var e = new UnlessStatement(
                 TRUE,
-                new[] { new TextStatement("x") }
+                new List<Statement> { new TextStatement("x") }
                 );
 
             var sw = new StringWriter();
@@ -36,7 +37,7 @@ namespace Fluid.Tests
         {
             var e = new UnlessStatement(
                 FALSE,
-                new[] { new TextStatement("x") }
+                new List<Statement> { new TextStatement("x") }
                 );
 
             var sw = new StringWriter();

--- a/Fluid/Ast/ElseIfStatement.cs
+++ b/Fluid/Ast/ElseIfStatement.cs
@@ -7,7 +7,7 @@ namespace Fluid.Ast
 {
     public class ElseIfStatement : TagStatement
     {
-        public ElseIfStatement(Expression condition, IList<Statement> statements):base(statements)
+        public ElseIfStatement(Expression condition, List<Statement> statements) : base(statements)
         {
             Condition = condition;
         }

--- a/Fluid/Ast/ElseStatement.cs
+++ b/Fluid/Ast/ElseStatement.cs
@@ -7,14 +7,15 @@ namespace Fluid.Ast
 {
     public class ElseStatement : TagStatement
     {
-        public ElseStatement(IList<Statement> statements) : base(statements)
+        public ElseStatement(List<Statement> statements) : base(statements)
         {
         }
 
         public override async Task<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
-            foreach (var statement in Statements)
+            for (var i = 0; i < Statements.Count; i++)
             {
+                var statement = Statements[i];
                 var completion = await statement.WriteToAsync(writer, encoder, context);
 
                 if (completion != Completion.Normal)

--- a/Fluid/Ast/ForStatement.cs
+++ b/Fluid/Ast/ForStatement.cs
@@ -11,7 +11,7 @@ namespace Fluid.Ast
     public class ForStatement : TagStatement
     {
         public ForStatement(
-            IList<Statement> statements, 
+            List<Statement> statements,
             string identifier, 
             MemberExpression member,
             LiteralExpression limit,
@@ -25,7 +25,7 @@ namespace Fluid.Ast
             Reversed = reversed;
         }
         public ForStatement(
-            IList<Statement> statements, 
+            List<Statement> statements,
             string identifier, 
             RangeExpression range,
             LiteralExpression limit,
@@ -115,8 +115,9 @@ namespace Fluid.Ast
 
                     Completion completion = Completion.Normal;
 
-                    foreach (var statement in Statements)
+                    for (var index = 0; index < Statements.Count; index++)
                     {
+                        var statement = Statements[index];
                         completion = await statement.WriteToAsync(writer, encoder, context);
 
                         if (completion != Completion.Normal)

--- a/Fluid/Ast/IncludeStatement.cs
+++ b/Fluid/Ast/IncludeStatement.cs
@@ -101,7 +101,7 @@ namespace Fluid.Ast
             }
         }
 
-        private static IFluidTemplate CreateTemplate(TemplateContext context, IList<Statement> statements)
+        private static IFluidTemplate CreateTemplate(TemplateContext context, List<Statement> statements)
         {
             IFluidTemplate template;
             if (context.AmbientValues.TryGetValue(FluidTemplateFactoryKey, out var factory))

--- a/Fluid/Ast/TagStatement.cs
+++ b/Fluid/Ast/TagStatement.cs
@@ -1,15 +1,21 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace Fluid.Ast
 {
     public abstract class TagStatement : Statement
     {
+        private readonly List<Statement> _statements;
 
-        public TagStatement(IList<Statement> statements)
+        protected TagStatement(List<Statement> statements)
         {
-            Statements = statements;
+            _statements = statements;
         }
 
-        public IList<Statement> Statements { get; }        
+        public List<Statement> Statements
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _statements;
+        }
     }
 }

--- a/Fluid/Ast/UnlessStatement.cs
+++ b/Fluid/Ast/UnlessStatement.cs
@@ -9,8 +9,7 @@ namespace Fluid.Ast
     {
         public UnlessStatement(
             Expression condition,
-            IList<Statement> statements
-            ) : base(statements)
+            List<Statement> statements) : base(statements)
         {
             Condition = condition;
         }
@@ -23,8 +22,9 @@ namespace Fluid.Ast
 
             if (!result)
             {
-                foreach (var statement in Statements)
+                for (var i = 0; i < Statements.Count; i++)
                 {
+                    var statement = Statements[i];
                     var completion = await statement.WriteToAsync(writer, encoder, context);
 
                     if (completion != Completion.Normal)

--- a/Fluid/Ast/WhenStatement.cs
+++ b/Fluid/Ast/WhenStatement.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 
@@ -7,12 +8,18 @@ namespace Fluid.Ast
 {
     public class WhenStatement : TagStatement
     {
-        public WhenStatement(IList<Expression> options, IList<Statement> statements) : base(statements)
+        private readonly List<Expression> _options;
+
+        public WhenStatement(List<Expression> options, List<Statement> statements) : base(statements)
         {
-            Options = options;
+            _options = options;
         }
 
-        public IList<Expression> Options { get; }
+        public List<Expression> Options
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _options;
+        }
 
         public override async Task<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {

--- a/Fluid/BaseFluidTemplate.cs
+++ b/Fluid/BaseFluidTemplate.cs
@@ -18,7 +18,7 @@ namespace Fluid
 
         public static FluidParserFactory Factory { get; } = new FluidParserFactory();
 
-        public IList<Statement> Statements { get; set; } = new List<Statement>();
+        public List<Statement> Statements { get; set; } = new List<Statement>();
         
         public static bool TryParse(string template, out T result, out IEnumerable<string> errors)
         {

--- a/Fluid/BlockContext.cs
+++ b/Fluid/BlockContext.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Fluid.Ast;
 using Irony.Parsing;
 
@@ -10,10 +8,10 @@ namespace Fluid
     {
         // Some types of sub-block can be repeated (when, case)
         // This value is initialized the first time a sub-block is found
-        private Dictionary<string, IList<Statement>> _blocks;
+        private Dictionary<string, List<Statement>> _blocks;
 
         // Statements that are added while parsing a sub-block (else, elsif, when)
-        private IList<Statement> _transientStatements;
+        private List<Statement> _transientStatements;
 
         public BlockContext(ParseTreeNode tag)
         {
@@ -24,13 +22,13 @@ namespace Fluid
 
         public ParseTreeNode Tag { get; }
 
-        public IList<Statement> Statements { get; private set; }
+        public List<Statement> Statements { get; }
 
         public void EnterBlock(string name, TagStatement statement)
         {
             if (_blocks == null)
             {
-                _blocks = new Dictionary<string, IList<Statement>>();
+                _blocks = new Dictionary<string, List<Statement>>();
             }
 
             if (!_blocks.TryGetValue(name, out var blockStatements))
@@ -47,14 +45,24 @@ namespace Fluid
             _transientStatements.Add(statement);
         }
 
-        public IList<TStatement> GetBlockStatements<TStatement>(string name)
+        public List<TStatement> GetBlockStatements<TStatement>(string name) where TStatement : Statement
         {
             if (_blocks != null && _blocks.TryGetValue(name, out var statements))
             {
-                return statements.Cast<TStatement>().ToList();
+                var result = new List<TStatement>(statements.Count);
+                for (int i = 0; i < statements.Count; ++i)
+                {
+                    result.Add((TStatement) statements[i]);
+                }
+                return result;
             }
 
-            return Array.Empty<TStatement>();
+            return StatementList<TStatement>.Empty;
+        }
+
+        private static class StatementList<T>
+        {
+            internal static readonly List<T> Empty = new List<T>();
         }
     }
 }

--- a/Fluid/DefaultFluidParser.cs
+++ b/Fluid/DefaultFluidParser.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Fluid.Ast;
 using Fluid.Ast.BinaryExpressions;
@@ -29,7 +30,7 @@ namespace Fluid
             _blocks = blocks;
         }
 
-        public bool TryParse(string template, out IList<Statement> result, out IEnumerable<string> errors)
+        public bool TryParse(string template, out List<Statement> result, out IEnumerable<string> errors)
         {
             errors = Array.Empty<string>();
             var segment = new StringSegment(template);
@@ -182,6 +183,7 @@ namespace Fluid
             return false;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ConsumeTextStatement(StringSegment segment, int start, int end, bool trimStart, bool trimEnd)
         {
             var textSatement = CreateTextStatement(segment, start, end, trimStart, trimEnd);
@@ -364,7 +366,7 @@ namespace Fluid
                         // Start tag found
                         var endTag = c == '{' ? "}}" : "%}";
 
-                        end = template.Value.IndexOf(endTag, start + 2);
+                        end = template.Value.IndexOf(endTag, start + 2, StringComparison.Ordinal);
 
                         if (end == -1)
                         {

--- a/Fluid/FilterArguments.cs
+++ b/Fluid/FilterArguments.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Fluid.Values;
 
 namespace Fluid
@@ -15,6 +16,7 @@ namespace Fluid
 
         public int Count => _positional != null ? _positional.Count : 0;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public FluidValue At(int index)
         {
             if (_positional == null || index >= _positional.Count)

--- a/Fluid/Filters/MiscFilters.cs
+++ b/Fluid/Filters/MiscFilters.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
-using System.Text;
 using System.Text.RegularExpressions;
 using Fluid.Values;
 
@@ -137,70 +136,75 @@ namespace Fluid.Filters
 
             var format = arguments.At(0).ToStringValue();
 
-            var result = new StringBuilder(format.Length * 2);
-            var percent = false;
-
-            for (var i = 0; i < format.Length; i++)
+            using (var sb = StringBuilderPool.GetInstance())
             {
-                var c = format[i];
-                if (!percent)
+                sb.Builder.EnsureCapacity(format.Length * 2);
+                var result = sb.Builder;
+                var percent = false;
+    
+                for (var i = 0; i < format.Length; i++)
                 {
-                    if (c == '%')
+                    var c = format[i];
+                    if (!percent)
                     {
-                        percent = true;
+                        if (c == '%')
+                        {
+                            percent = true;
+                        }
+                        else
+                        {
+                            result.Append(c);
+                        }
                     }
                     else
                     {
-                        result.Append(c);
-                    }
-                }
-                else
-                {
-                    switch (c)
-                    {
-                        case 'a': result.Append(context.CultureInfo.DateTimeFormat.AbbreviatedDayNames[(int)value.DayOfWeek]); break;
-                        case 'A': result.Append(context.CultureInfo.DateTimeFormat.DayNames[(int)value.DayOfWeek]); break;
-                        case 'b': result.Append(context.CultureInfo.DateTimeFormat.AbbreviatedMonthNames[value.Month - 1]); break;
-                        case 'B': result.Append(context.CultureInfo.DateTimeFormat.MonthNames[value.Month - 1]); break;
-                        case 'c': result.Append(value.ToString("F", context.CultureInfo)); break;
-                        case 'C': result.Append(value.Year / 100); break;
-                        case 'd': result.Append(value.Day.ToString(context.CultureInfo).PadLeft(2, '0')); break;
-                        case 'D': result.Append(value.ToString("d", context.CultureInfo)); break;
-                        case 'e': result.Append(value.Day.ToString(context.CultureInfo).PadLeft(2, ' ')); break;
-                        case 'F': result.Append(value.ToString("yyyy-MM-dd", context.CultureInfo)); break;
-                        case 'H': result.Append(value.Hour.ToString(context.CultureInfo).PadLeft(2, '0')); break;
-                        case 'I': result.Append((value.Hour % 12).ToString(context.CultureInfo).PadLeft(2, '0')); break;
-                        case 'j': result.Append(value.DayOfYear.ToString(context.CultureInfo).PadLeft(3, '0')); break;
-                        case 'k': result.Append(value.Hour); break;
-                        case 'l': result.Append((value.Hour % 12).ToString(context.CultureInfo).PadLeft(2, ' ')); break;
-                        case 'L': result.Append(value.Millisecond.ToString(context.CultureInfo).PadLeft(3, '0')); break;
-                        case 'm': result.Append(value.Month.ToString(context.CultureInfo).PadLeft(2, '0')); break;
-                        case 'M': result.Append(value.Minute.ToString(context.CultureInfo).PadLeft(2, '0')); break;
-                        case 'p': result.Append(value.ToString("tt", context.CultureInfo).ToUpper()); break;
-                        case 'P': result.Append(value.ToString("tt", context.CultureInfo).ToLower()); break;
-                        case 'T':
-                        case 'r': result.Append(value.ToString("T", context.CultureInfo).ToUpper()); break;
-                        case 'R': result.Append(value.ToString("t", context.CultureInfo).ToUpper()); break;
-                        case 's': result.Append(value.ToUnixTimeSeconds()); break;
-                        case 'S': result.Append(value.Second.ToString(context.CultureInfo).PadLeft(2, '0')); break;
-                        case 'u': result.Append((int)value.DayOfWeek); break;
-                        case 'U': result.Append(context.CultureInfo.Calendar.GetWeekOfYear(value.DateTime, CalendarWeekRule.FirstDay, DayOfWeek.Sunday).ToString().PadLeft(2, '0')); break;
-                        case 'v': result.Append(value.ToString("D", context.CultureInfo)); break;
-                        case 'V': result.Append((value.DayOfYear / 7 + 1).ToString(context.CultureInfo).PadLeft(2, '0')); break;
-                        case 'W': result.Append(context.CultureInfo.Calendar.GetWeekOfYear(value.DateTime, CalendarWeekRule.FirstDay, DayOfWeek.Monday).ToString().PadLeft(2, '0')); break;
-                        case 'y': result.Append(value.ToString("yy", context.CultureInfo)); break;
-                        case 'Y': result.Append(value.Year); break;
-                        case 'z': result.Append(value.ToString("zzz", context.CultureInfo)); break;
-                        case 'Z': goto default; // unsupported
-                        case '%': result.Append('%'); break;
-                        default: result.Append('%').Append(c); break;
-                    }
+                        switch (c)
+                        {
+                            case 'a': result.Append(context.CultureInfo.DateTimeFormat.AbbreviatedDayNames[(int)value.DayOfWeek]); break;
+                            case 'A': result.Append(context.CultureInfo.DateTimeFormat.DayNames[(int)value.DayOfWeek]); break;
+                            case 'b': result.Append(context.CultureInfo.DateTimeFormat.AbbreviatedMonthNames[value.Month - 1]); break;
+                            case 'B': result.Append(context.CultureInfo.DateTimeFormat.MonthNames[value.Month - 1]); break;
+                            case 'c': result.Append(value.ToString("F", context.CultureInfo)); break;
+                            case 'C': result.Append(value.Year / 100); break;
+                            case 'd': result.Append(value.Day.ToString(context.CultureInfo).PadLeft(2, '0')); break;
+                            case 'D': result.Append(value.ToString("d", context.CultureInfo)); break;
+                            case 'e': result.Append(value.Day.ToString(context.CultureInfo).PadLeft(2, ' ')); break;
+                            case 'F': result.Append(value.ToString("yyyy-MM-dd", context.CultureInfo)); break;
+                            case 'H': result.Append(value.Hour.ToString(context.CultureInfo).PadLeft(2, '0')); break;
+                            case 'I': result.Append((value.Hour % 12).ToString(context.CultureInfo).PadLeft(2, '0')); break;
+                            case 'j': result.Append(value.DayOfYear.ToString(context.CultureInfo).PadLeft(3, '0')); break;
+                            case 'k': result.Append(value.Hour); break;
+                            case 'l': result.Append((value.Hour % 12).ToString(context.CultureInfo).PadLeft(2, ' ')); break;
+                            case 'L': result.Append(value.Millisecond.ToString(context.CultureInfo).PadLeft(3, '0')); break;
+                            case 'm': result.Append(value.Month.ToString(context.CultureInfo).PadLeft(2, '0')); break;
+                            case 'M': result.Append(value.Minute.ToString(context.CultureInfo).PadLeft(2, '0')); break;
+                            case 'p': result.Append(value.ToString("tt", context.CultureInfo).ToUpper()); break;
+                            case 'P': result.Append(value.ToString("tt", context.CultureInfo).ToLower()); break;
+                            case 'T':
+                            case 'r': result.Append(value.ToString("T", context.CultureInfo).ToUpper()); break;
+                            case 'R': result.Append(value.ToString("t", context.CultureInfo).ToUpper()); break;
+                            case 's': result.Append(value.ToUnixTimeSeconds()); break;
+                            case 'S': result.Append(value.Second.ToString(context.CultureInfo).PadLeft(2, '0')); break;
+                            case 'u': result.Append((int)value.DayOfWeek); break;
+                            case 'U': result.Append(context.CultureInfo.Calendar.GetWeekOfYear(value.DateTime, CalendarWeekRule.FirstDay, DayOfWeek.Sunday).ToString().PadLeft(2, '0')); break;
+                            case 'v': result.Append(value.ToString("D", context.CultureInfo)); break;
+                            case 'V': result.Append((value.DayOfYear / 7 + 1).ToString(context.CultureInfo).PadLeft(2, '0')); break;
+                            case 'W': result.Append(context.CultureInfo.Calendar.GetWeekOfYear(value.DateTime, CalendarWeekRule.FirstDay, DayOfWeek.Monday).ToString().PadLeft(2, '0')); break;
+                            case 'y': result.Append(value.ToString("yy", context.CultureInfo)); break;
+                            case 'Y': result.Append(value.Year); break;
+                            case 'z': result.Append(value.ToString("zzz", context.CultureInfo)); break;
+                            case 'Z': goto default; // unsupported
+                            case '%': result.Append('%'); break;
+                            default: result.Append('%').Append(c); break;
+                        }
 
-                    percent = false;
+                        percent = false;
+                    }
                 }
+
+                return new StringValue(result.ToString());
             }
 
-            return new StringValue(result.ToString());
         }
 
         public static FluidValue FormatDate(FluidValue input, FilterArguments arguments, TemplateContext context)

--- a/Fluid/Filters/NumberFilters.cs
+++ b/Fluid/Filters/NumberFilters.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 using Fluid.Values;
 
 namespace Fluid.Filters

--- a/Fluid/Filters/StringFilters.cs
+++ b/Fluid/Filters/StringFilters.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using Fluid.Values;
 
 namespace Fluid.Filters
@@ -36,21 +35,20 @@ namespace Fluid.Filters
             return new StringValue(input.ToStringValue() + arguments.At(0).ToStringValue());
         }
 
-        public static char[] CapitalizeDelimiters = new char [] { '-', '.' };
-
         public static FluidValue Capitalize(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
             var source = input.ToStringValue().ToCharArray();
 
             for (var i = 0; i < source.Length; i++)
             {
-                if (i == 0 || Char.IsWhiteSpace(source[i - 1]) || CapitalizeDelimiters.Contains(source[i - 1]))
+                char c;
+                if (i == 0 || char.IsWhiteSpace(c = source[i - 1]) || c == '-' || c == '.')
                 {
                     source[i] = char.ToUpper(source[i]);
                 }
             }
 
-            return new StringValue(new String(source));
+            return new StringValue(new string(source));
         }
 
         public static FluidValue Downcase(FluidValue input, FilterArguments arguments, TemplateContext context)
@@ -132,11 +130,16 @@ namespace Fluid.Filters
 
         public static FluidValue Split(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            return new ArrayValue(input.ToStringValue()
-                .Split(new [] { arguments.At(0).ToStringValue() }, StringSplitOptions.RemoveEmptyEntries)
-                .Select(FluidValue.Create)
-                .ToArray()
-            );
+            var strings = input.ToStringValue()
+                .Split(new [] { arguments.At(0).ToStringValue() }, StringSplitOptions.RemoveEmptyEntries);
+
+            var values = new FluidValue[strings.Length];
+            for (var i = 0; i < strings.Length; i++)
+            {
+                values[i] = FluidValue.Create(strings[i]);
+            }
+
+            return new ArrayValue(values);
         }
 
         public static FluidValue Strip(FluidValue input, FilterArguments arguments, TemplateContext context)
@@ -181,8 +184,8 @@ namespace Fluid.Filters
             {
                 for (var i = 0; i < source.Length;)
                 {
-                    while (i < source.Length && Char.IsWhiteSpace(source[i])) i++;
-                    while (i < source.Length && !Char.IsWhiteSpace(source[i])) i++;
+                    while (i < source.Length && char.IsWhiteSpace(source[i])) i++;
+                    while (i < source.Length && !char.IsWhiteSpace(source[i])) i++;
                     words++;
 
                     if (words >= size)

--- a/Fluid/Fluid.csproj
+++ b/Fluid/Fluid.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>

--- a/Fluid/FluidTemplateExtensions.cs
+++ b/Fluid/FluidTemplateExtensions.cs
@@ -29,10 +29,13 @@ namespace Fluid
                 throw new ArgumentNullException(nameof(template));
             }
 
-            using (var writer = new StringWriter())
+            using (var sb = StringBuilderPool.GetInstance())
             {
-                await template.RenderAsync(writer, encoder, context);
-                return writer.ToString();
+                using (var writer = new StringWriter(sb.Builder))
+                {
+                    await template.RenderAsync(writer, encoder, context);
+                    return writer.ToString();
+                }
             }
         }
 

--- a/Fluid/IFluidParser.cs
+++ b/Fluid/IFluidParser.cs
@@ -5,6 +5,6 @@ namespace Fluid
 {
     public interface IFluidParser
     {
-        bool TryParse(string template, out IList<Statement> result, out IEnumerable<string> errors);
+        bool TryParse(string template, out List<Statement> result, out IEnumerable<string> errors);
     }
 }

--- a/Fluid/IFluidTemplate.cs
+++ b/Fluid/IFluidTemplate.cs
@@ -8,7 +8,7 @@ namespace Fluid
 {
     public interface IFluidTemplate
     {
-        IList<Statement> Statements { get; set; }
+        List<Statement> Statements { get; set; }
         Task RenderAsync(TextWriter writer, TextEncoder encoder, TemplateContext context);
     }
 }

--- a/Fluid/Pooling.cs
+++ b/Fluid/Pooling.cs
@@ -1,0 +1,345 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+// define TRACE_LEAKS to get additional diagnostics that can lead to the leak sources. note: it will
+// make everything about 2-3x slower
+//
+// #define TRACE_LEAKS
+
+// define DETECT_LEAKS to detect possible leaks
+// #if DEBUG
+// #define DETECT_LEAKS  //for now always enable DETECT_LEAKS in debug.
+// #endif
+
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+
+#if DETECT_LEAKS
+using System.Runtime.CompilerServices;
+#endif
+
+namespace Fluid
+{
+    /// <summary>
+    /// Generic implementation of object pooling pattern with predefined pool size limit. The main
+    /// purpose is that limited number of frequently used objects can be kept in the pool for
+    /// further recycling.
+    ///
+    /// Notes:
+    /// 1) it is not the goal to keep all returned objects. Pool is not meant for storage. If there
+    ///    is no space in the pool, extra returned objects will be dropped.
+    ///
+    /// 2) it is implied that if object was obtained from a pool, the caller will return it back in
+    ///    a relatively short time. Keeping checked out objects for long durations is ok, but
+    ///    reduces usefulness of pooling. Just new up your own.
+    ///
+    /// Not returning objects to the pool in not detrimental to the pool's work, but is a bad practice.
+    /// Rationale:
+    ///    If there is no intent for reusing the object, do not use pool - just use "new".
+    /// </summary>
+    internal class ObjectPool<T> where T : class
+    {
+        [DebuggerDisplay("{Value,nq}")]
+        private struct Element
+        {
+            internal T Value;
+        }
+
+        /// <remarks>
+        /// Not using System.Func{T} because this file is linked into the (debugger) Formatter,
+        /// which does not have that type (since it compiles against .NET 2.0).
+        /// </remarks>
+        internal delegate T Factory();
+
+        // Storage for the pool objects. The first item is stored in a dedicated field because we
+        // expect to be able to satisfy most requests from it.
+        private T _firstItem;
+        private readonly Element[] _items;
+
+        // factory is stored for the lifetime of the pool. We will call this only when pool needs to
+        // expand. compared to "new T()", Func gives more flexibility to implementers and faster
+        // than "new T()".
+        private readonly Factory _factory;
+
+#if DETECT_LEAKS
+        private static readonly ConditionalWeakTable<T, LeakTracker> leakTrackers = new ConditionalWeakTable<T, LeakTracker>();
+
+        private class LeakTracker : IDisposable
+        {
+            private volatile bool disposed;
+
+#if TRACE_LEAKS
+            internal volatile object Trace = null;
+#endif
+
+            public void Dispose()
+            {
+                disposed = true;
+                GC.SuppressFinalize(this);
+            }
+
+            private string GetTrace()
+            {
+#if TRACE_LEAKS
+                return Trace == null ? "" : Trace.ToString();
+#else
+                return "Leak tracing information is disabled. Define TRACE_LEAKS on ObjectPool`1.cs to get more info \n";
+#endif
+            }
+
+            ~LeakTracker()
+            {
+                if (!this.disposed && !Environment.HasShutdownStarted)
+                {
+                    var trace = GetTrace();
+
+                    // If you are seeing this message it means that object has been allocated from the pool
+                    // and has not been returned back. This is not critical, but turns pool into rather
+                    // inefficient kind of "new".
+                    Debug.WriteLine($"TRACEOBJECTPOOLLEAKS_BEGIN\nPool detected potential leaking of {typeof(T)}. \n Location of the leak: \n {GetTrace()} TRACEOBJECTPOOLLEAKS_END");
+                }
+            }
+        }
+#endif
+
+        internal ObjectPool(Factory factory)
+            : this(factory, Environment.ProcessorCount * 2)
+        { }
+
+        internal ObjectPool(Factory factory, int size)
+        {
+            Debug.Assert(size >= 1);
+            _factory = factory;
+            _items = new Element[size - 1];
+        }
+
+        private T CreateInstance()
+        {
+            var inst = _factory();
+            return inst;
+        }
+
+        /// <summary>
+        /// Produces an instance.
+        /// </summary>
+        /// <remarks>
+        /// Search strategy is a simple linear probing which is chosen for it cache-friendliness.
+        /// Note that Free will try to store recycled objects close to the start thus statistically
+        /// reducing how far we will typically search.
+        /// </remarks>
+        internal T Allocate()
+        {
+            // PERF: Examine the first element. If that fails, AllocateSlow will look at the remaining elements.
+            // Note that the initial read is optimistically not synchronized. That is intentional.
+            // We will interlock only when we have a candidate. in a worst case we may miss some
+            // recently returned objects. Not a big deal.
+            T inst = _firstItem;
+            if (!ReferenceEquals(inst, null))
+            {
+                _firstItem = null;
+                return inst;
+            }
+
+            inst = AllocateSlow();
+
+#if DETECT_LEAKS
+            var tracker = new LeakTracker();
+            leakTrackers.Add(inst, tracker);
+
+#if TRACE_LEAKS
+            var frame = CaptureStackTrace();
+            tracker.Trace = frame;
+#endif
+#endif
+            return inst;
+        }
+
+        private T AllocateSlow()
+        {
+            var items = _items;
+
+            for (int i = 0; i < items.Length; i++)
+            {
+                T inst = items[i].Value;
+                if (!ReferenceEquals(inst, null))
+                {
+                    items[i].Value = null;
+                    return inst;
+                }
+            }
+
+            return CreateInstance();
+        }
+
+        /// <summary>
+        /// Returns objects to the pool.
+        /// </summary>
+        /// <remarks>
+        /// Search strategy is a simple linear probing which is chosen for it cache-friendliness.
+        /// Note that Free will try to store recycled objects close to the start thus statistically
+        /// reducing how far we will typically search in Allocate.
+        /// </remarks>
+        internal void Free(T obj)
+        {
+            Validate(obj);
+            ForgetTrackedObject(obj);
+
+            if (ReferenceEquals(_firstItem, null))
+            {
+                // Intentionally not using interlocked here.
+                // In a worst case scenario two objects may be stored into same slot.
+                // It is very unlikely to happen and will only mean that one of the objects will get collected.
+                _firstItem = obj;
+            }
+            else
+            {
+                FreeSlow(obj);
+            }
+        }
+
+        private void FreeSlow(T obj)
+        {
+            var items = _items;
+            for (int i = 0; i < items.Length; i++)
+            {
+                if (ReferenceEquals(items[i].Value, null))
+                {
+                    // Intentionally not using interlocked here.
+                    // In a worst case scenario two objects may be stored into same slot.
+                    // It is very unlikely to happen and will only mean that one of the objects will get collected.
+                    items[i].Value = obj;
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Removes an object from leak tracking.
+        ///
+        /// This is called when an object is returned to the pool.  It may also be explicitly
+        /// called if an object allocated from the pool is intentionally not being returned
+        /// to the pool.  This can be of use with pooled arrays if the consumer wants to
+        /// return a larger array to the pool than was originally allocated.
+        /// </summary>
+        [Conditional("DEBUG")]
+        internal void ForgetTrackedObject(T old, T replacement = null)
+        {
+#if DETECT_LEAKS
+            LeakTracker tracker;
+            if (leakTrackers.TryGetValue(old, out tracker))
+            {
+                tracker.Dispose();
+                leakTrackers.Remove(old);
+            }
+            else
+            {
+                var trace = CaptureStackTrace();
+                Debug.WriteLine($"TRACEOBJECTPOOLLEAKS_BEGIN\nObject of type {typeof(T)} was freed, but was not from pool. \n Callstack: \n {trace} TRACEOBJECTPOOLLEAKS_END");
+            }
+
+            if (replacement != null)
+            {
+                tracker = new LeakTracker();
+                leakTrackers.Add(replacement, tracker);
+            }
+#endif
+        }
+
+#if DETECT_LEAKS
+        private static Lazy<Type> _stackTraceType = new Lazy<Type>(() => Type.GetType("System.Diagnostics.StackTrace"));
+
+        private static object CaptureStackTrace()
+        {
+            return Activator.CreateInstance(_stackTraceType.Value);
+        }
+#endif
+
+        [Conditional("DEBUG")]
+        private void Validate(object obj)
+        {
+            Debug.Assert(obj != null, "freeing null?");
+
+            Debug.Assert(_firstItem != obj, "freeing twice?");
+
+            var items = _items;
+            for (int i = 0; i < items.Length; i++)
+            {
+                var value = items[i].Value;
+                if (ReferenceEquals(value, null))
+                {
+                    return;
+                }
+
+                Debug.Assert(value != obj, "freeing twice?");
+            }
+        }
+    }
+
+    /// <summary>
+    /// The usage is:
+    ///        var inst = PooledStringBuilder.GetInstance();
+    ///        var sb = inst.builder;
+    ///        ... Do Stuff...
+    ///        ... sb.ToString() ...
+    ///        inst.Free();
+    /// </summary>
+    internal sealed class StringBuilderPool : IDisposable
+    {
+        // global pool
+        private static readonly ObjectPool<StringBuilderPool> s_poolInstance = CreatePool();
+
+        public readonly StringBuilder Builder = new StringBuilder();
+        private readonly ObjectPool<StringBuilderPool> _pool;
+
+        private StringBuilderPool(ObjectPool<StringBuilderPool> pool)
+        {
+            Debug.Assert(pool != null);
+            _pool = pool;
+        }
+
+        public int Length => Builder.Length;
+
+        // if someone needs to create a private pool;
+        /// <summary>
+        /// If someone need to create a private pool
+        /// </summary>
+        /// <param name="size">The size of the pool.</param>
+        /// <returns></returns>
+        internal static ObjectPool<StringBuilderPool> CreatePool(int size = 32)
+        {
+            ObjectPool<StringBuilderPool> pool = null;
+            pool = new ObjectPool<StringBuilderPool>(() => new StringBuilderPool(pool), size);
+            return pool;
+        }
+
+        public static StringBuilderPool GetInstance()
+        {
+            var builder = s_poolInstance.Allocate();
+            Debug.Assert(builder.Builder.Length == 0);
+            return builder;
+        }
+
+        public override string ToString()
+        {
+            return Builder.ToString();
+        }
+
+        public void Dispose()
+        {
+            var builder = Builder;
+
+            // do not store builders that are too large.
+            if (builder.Capacity <= 1024)
+            {
+                builder.Clear();
+                _pool.Free(this);
+            }
+            else
+            {
+                _pool.ForgetTrackedObject(this);
+            }
+        }
+    }
+
+}

--- a/Fluid/Tags/ArgumentsBlock.cs
+++ b/Fluid/Tags/ArgumentsBlock.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Fluid.Ast;
@@ -18,7 +17,12 @@ namespace Fluid.Tags
         public override Statement Parse(ParseTreeNode node, ParserContext context)
         {
             var e = context.CurrentBlock.Tag.ChildNodes[0];
-            var arguments = e.ChildNodes.Select(DefaultFluidParser.BuildFilterArgument).ToArray();
+            var arguments = new FilterArgument[e.ChildNodes.Count];
+            for (var i = 0; i < e.ChildNodes.Count; i++)
+            {
+                arguments[i] = DefaultFluidParser.BuildFilterArgument(e.ChildNodes[i]);
+            }
+
             var statements = context.CurrentBlock.Statements;
             return new DelegateStatement((writer, encoder, ctx) => WriteToAsync(writer, encoder, ctx, arguments, statements));
         }

--- a/Fluid/Tags/ArgumentsTag.cs
+++ b/Fluid/Tags/ArgumentsTag.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using System.Linq;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Fluid.Ast;
@@ -16,7 +15,13 @@ namespace Fluid.Tags
 
         public Statement Parse(ParseTreeNode node, ParserContext context)
         {
-            var arguments = node.ChildNodes[0].ChildNodes.Select(DefaultFluidParser.BuildFilterArgument).ToArray();
+            var nodes = node.ChildNodes[0].ChildNodes;
+            var arguments = new FilterArgument[nodes.Count];
+            for (var i = 0; i < nodes.Count; i++)
+            {
+                arguments[i] = DefaultFluidParser.BuildFilterArgument(nodes[i]);
+            }
+
             return new DelegateStatement((writer, encoder, ctx) => WriteToAsync(writer, encoder, ctx, arguments));
         }
 

--- a/Fluid/Values/ArrayValue.cs
+++ b/Fluid/Values/ArrayValue.cs
@@ -9,13 +9,18 @@ namespace Fluid.Values
 {
     public class ArrayValue : FluidValue
     {
-        private readonly IList<FluidValue> _value;
+        private readonly List<FluidValue> _value;
 
         public override FluidValues Type => FluidValues.Array;
 
-        public ArrayValue(IList<FluidValue> value)
+        public ArrayValue(List<FluidValue> value)
         {
             _value = value;
+        }
+
+        public ArrayValue(FluidValue[] value)
+        {
+            _value = new List<FluidValue>(value);
         }
 
         public ArrayValue(IEnumerable<FluidValue> value)

--- a/Fluid/Values/BooleanValue.cs
+++ b/Fluid/Values/BooleanValue.cs
@@ -6,8 +6,11 @@ namespace Fluid.Values
 {
     public class BooleanValue : FluidValue
     {
-        public static BooleanValue False = new BooleanValue(false);
-        public static BooleanValue True = new BooleanValue(true);
+        public static readonly BooleanValue False = new BooleanValue(false);
+        public static readonly BooleanValue True = new BooleanValue(true);
+
+        private static readonly object BoxedTrue = true;
+        private static readonly object BoxedFalse = false;
 
         private readonly bool _value;
 
@@ -45,7 +48,7 @@ namespace Fluid.Values
 
         public override object ToObjectValue()
         {
-            return _value;
+            return _value ? BoxedTrue : BoxedFalse;
         }
 
         public override bool Equals(object other)

--- a/Fluid/Values/FluidValue.cs
+++ b/Fluid/Values/FluidValue.cs
@@ -104,8 +104,14 @@ namespace Fluid.Values
                         case DateTimeOffset dateTimeOffset:
                             return new DateTimeValue((DateTimeOffset)value);
 
+                        case Dictionary<string, object> dictionary:
+                            return new DictionaryValue(new ObjectDictionaryFluidIndexable(dictionary));
+
                         case IDictionary<string, object> dictionary:
                             return new DictionaryValue(new ObjectDictionaryFluidIndexable(dictionary));
+
+                        case Dictionary<string, FluidValue> fluidDictionary:
+                            return new DictionaryValue(new FluidValueDictionaryFluidIndexable(fluidDictionary));
 
                         case IDictionary<string, FluidValue> fluidDictionary:
                             return new DictionaryValue(new FluidValueDictionaryFluidIndexable(fluidDictionary));

--- a/Fluid/Values/FluidValueDictionaryFluidIndexable.cs
+++ b/Fluid/Values/FluidValueDictionaryFluidIndexable.cs
@@ -4,11 +4,16 @@ namespace Fluid.Values
 {
     public class FluidValueDictionaryFluidIndexable : IFluidIndexable
     {
-        private readonly IDictionary<string, FluidValue> _dictionary;
+        private readonly Dictionary<string, FluidValue> _dictionary;
+
+        public FluidValueDictionaryFluidIndexable(Dictionary<string, FluidValue> dictionary)
+        {
+            _dictionary = dictionary;
+        }
 
         public FluidValueDictionaryFluidIndexable(IDictionary<string, FluidValue> dictionary)
         {
-            _dictionary = dictionary;
+            _dictionary = new Dictionary<string, FluidValue>(dictionary);
         }
 
         public int Count => _dictionary.Count;

--- a/Fluid/Values/NilValue.cs
+++ b/Fluid/Values/NilValue.cs
@@ -23,7 +23,7 @@ namespace Fluid.Values
         public override bool ToBooleanValue()
         {
             // Empty is a NilValue that is Truthy
-            return this == Empty;
+            return ReferenceEquals(this, Empty);
         }
 
         public override double ToNumberValue()
@@ -53,12 +53,7 @@ namespace Fluid.Values
         public override bool Equals(object other)
         {
             // The is operator will return false if null
-            if (other is NilValue otherValue)
-            {
-                return true;
-            }
-
-            return false;
+            return other is NilValue;
         }
 
         public override int GetHashCode()

--- a/Fluid/Values/ObjectDictionaryFluidIndexable.cs
+++ b/Fluid/Values/ObjectDictionaryFluidIndexable.cs
@@ -4,12 +4,18 @@ namespace Fluid.Values
 {
     public class ObjectDictionaryFluidIndexable : IFluidIndexable
     {
-        private readonly IDictionary<string, object> _dictionary;
+        private readonly Dictionary<string, object> _dictionary;
 
-        public ObjectDictionaryFluidIndexable(IDictionary<string, object> dictionary)
+        public ObjectDictionaryFluidIndexable(Dictionary<string, object> dictionary)
         {
             _dictionary = dictionary;
         }
+
+        public ObjectDictionaryFluidIndexable(IDictionary<string, object> dictionary)
+        {
+            _dictionary = new Dictionary<string, object>(dictionary);
+        }
+
 
         public int Count => _dictionary.Count;
 

--- a/Fluid/Values/StringValue.cs
+++ b/Fluid/Values/StringValue.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Text.Encodings.Web;
 
 namespace Fluid.Values
@@ -111,7 +110,10 @@ namespace Fluid.Values
 
         public override IEnumerable<FluidValue> Enumerate()
         {
-            return _value.Select(x => new StringValue(x.ToString())).ToArray();
+            foreach (var c in _value)
+            {
+                yield return new StringValue(c.ToString());
+            }
         }
 
         public override bool Equals(object other)


### PR DESCRIPTION
* prefer concrete types
  * IList already allows mutation so List doesn't change things much, mostly showed array to IList boxing
* for is faster for list
* pool string builders

## Fluid.Benchmarks.FluidBenchmarks

| **Diff**|Method|Mean|Gen 0/1k Op|Gen 1/1k Op|Gen 2/1k Op|Allocated Memory/Op|
|------- |-------|-------:|-------:|-------:|-------:|-------|
| Old |ParseSample|40.604 us|6.4697|-|-|27152 B|
| **New** |	| **34.445 us (-15%)** | **6.4697 (0%)** | **-** | **-** | **27152 B (0%)** |
| Old |ParseAndRenderSample|52.659 us|8.4229|-|-|35515 B|
| **New** |	| **44.011 us (-16%)** | **8.1787 (-3%)** | **-** | **-** | **34483 B (-3%)** |
| Old |RenderSample|7.171 us|1.9913|-|-|8361 B|
| **New** |	| **6.685 us (-7%)** | **1.7471 (-12%)** | **-** | **-** | **7329 B (-12%)** |
| Old |ParseLoremIpsum|2.104 us|0.0839|-|-|360 B|
| **New** |	| **2.107 us (0%)** | **0.0839 (0%)** | **-** | **-** | **360 B (0%)** |
| Old |RenderSimpleOuput|6.534 us|1.6327|-|-|6864 B|
| **New** |	| **5.611 us (-14%)** | **1.5945 (-2%)** | **-** | **-** | **6720 B (-2%)** |
| Old |RenderLoremSimpleOuput|7.529 us|2.9984|-|-|12584 B|
| **New** |	| **6.489 us (-14%)** | **2.4948 (-17%)** | **-** | **-** | **10488 B (-17%)** |


