### PR TITLE
Add missing Math filters

### DIFF
--- a/Fluid.Tests/NumberFiltersTests.cs
+++ b/Fluid.Tests/NumberFiltersTests.cs
@@ -8,6 +8,51 @@ namespace Fluid.Tests
 {
     public class NumberFiltersTests
     {
+        [Theory]
+        [InlineData(4, 4)]
+        [InlineData(-4, 4)]
+        public void Abs(int value, int expectedResult)
+        {
+            var input = NumberValue.Create(value);
+
+            var arguments = new FilterArguments();
+            var context = new TemplateContext();
+
+            var result = NumberFilters.Abs(input, arguments, context);
+
+            Assert.Equal(expectedResult, result.ToNumberValue());
+        }
+
+        [Theory]
+        [InlineData(4, 5, 5)]
+        [InlineData(4, 3, 4)]
+        public void AtLeast(int value1, object value2, int expectedResult)
+        {
+            var input = NumberValue.Create(value1);
+
+            var arguments = new FilterArguments(NumberValue.Create(Convert.ToDouble(value2), value2 is int));
+            var context = new TemplateContext();
+
+            var result = NumberFilters.AtLeast(input, arguments, context);
+
+            Assert.Equal(expectedResult, result.ToNumberValue());
+        }
+
+        [Theory]
+        [InlineData(4, 5, 4)]
+        [InlineData(4, 3, 3)]
+        public void AtMost(int value1, object value2, int expectedResult)
+        {
+            var input = NumberValue.Create(value1);
+
+            var arguments = new FilterArguments(NumberValue.Create(Convert.ToDouble(value2), value2 is int));
+            var context = new TemplateContext();
+
+            var result = NumberFilters.AtMost(input, arguments, context);
+
+            Assert.Equal(expectedResult, result.ToNumberValue());
+        }
+
         [Fact]
         public void Ceil()
         {

--- a/Fluid.Tests/NumberFiltersTests.cs
+++ b/Fluid.Tests/NumberFiltersTests.cs
@@ -10,8 +10,10 @@ namespace Fluid.Tests
     {
         [Theory]
         [InlineData(4, 4)]
+        [InlineData(4.2, 4.2)]
         [InlineData(-4, 4)]
-        public void Abs(int value, int expectedResult)
+        [InlineData(-4.2, 4.2)]
+        public void Abs(double value, double expectedResult)
         {
             var input = NumberValue.Create(value);
 

--- a/Fluid/Filters/NumberFilters.cs
+++ b/Fluid/Filters/NumberFilters.cs
@@ -24,23 +24,23 @@ namespace Fluid.Filters
 
         public static FluidValue Abs(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            return NumberValue.Create(Math.Abs(input.ToNumberValue()), true);
+            var integral = input is NumberValue numberValue && numberValue.IsIntegral;
+
+            return NumberValue.Create(Math.Abs(input.ToNumberValue()), integral);
         }
 
         public static FluidValue AtLeast(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
             var first = arguments.At(0);
-            double num = first.ToNumberValue();
 
-            return NumberValue.Create(Math.Max(input.ToNumberValue(), num), true);
+            return input.ToNumberValue() < first.ToNumberValue() ? first : input;
         }
 
         public static FluidValue AtMost(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
             var first = arguments.At(0);
-            double num = first.ToNumberValue();
 
-            return NumberValue.Create(Math.Min(input.ToNumberValue(), num), true);
+            return input.ToNumberValue() > first.ToNumberValue() ? first : input;
         }
 
         public static FluidValue Ceil(FluidValue input, FilterArguments arguments, TemplateContext context)

--- a/Fluid/Filters/NumberFilters.cs
+++ b/Fluid/Filters/NumberFilters.cs
@@ -32,15 +32,7 @@ namespace Fluid.Filters
             var first = arguments.At(0);
             double num = first.ToNumberValue();
 
-            if (first is NumberValue number)
-            {
-                if (number.IsIntegral)
-                {
-                    return NumberValue.Create(Math.Max(input.ToNumberValue(), num), true);
-                }
-            }
-
-            return NumberValue.Create(input.ToNumberValue());
+            return NumberValue.Create(Math.Max(input.ToNumberValue(), num), true);
         }
 
         public static FluidValue AtMost(FluidValue input, FilterArguments arguments, TemplateContext context)
@@ -48,15 +40,7 @@ namespace Fluid.Filters
             var first = arguments.At(0);
             double num = first.ToNumberValue();
 
-            if (first is NumberValue number)
-            {
-                if (number.IsIntegral)
-                {
-                    return NumberValue.Create(Math.Min(input.ToNumberValue(), num), true);
-                }
-            }
-
-            return NumberValue.Create(input.ToNumberValue());
+            return NumberValue.Create(Math.Min(input.ToNumberValue(), num), true);
         }
 
         public static FluidValue Ceil(FluidValue input, FilterArguments arguments, TemplateContext context)

--- a/Fluid/Filters/NumberFilters.cs
+++ b/Fluid/Filters/NumberFilters.cs
@@ -7,6 +7,9 @@ namespace Fluid.Filters
     {
         public static FilterCollection WithNumberFilters(this FilterCollection filters)
         {
+            filters.AddFilter("abs", Abs);
+            filters.AddFilter("at_least", AtLeast);
+            filters.AddFilter("at_most", AtMost);
             filters.AddFilter("ceil", Ceil);
             filters.AddFilter("divided_by", DividedBy);
             filters.AddFilter("floor", Floor);
@@ -17,6 +20,43 @@ namespace Fluid.Filters
             filters.AddFilter("times", Times);
 
             return filters;
+        }
+
+        public static FluidValue Abs(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            return NumberValue.Create(Math.Abs(input.ToNumberValue()), true);
+        }
+
+        public static FluidValue AtLeast(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            var first = arguments.At(0);
+            double num = first.ToNumberValue();
+
+            if (first is NumberValue number)
+            {
+                if (number.IsIntegral)
+                {
+                    return NumberValue.Create(Math.Max(input.ToNumberValue(), num), true);
+                }
+            }
+
+            return NumberValue.Create(input.ToNumberValue());
+        }
+
+        public static FluidValue AtMost(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            var first = arguments.At(0);
+            double num = first.ToNumberValue();
+
+            if (first is NumberValue number)
+            {
+                if (number.IsIntegral)
+                {
+                    return NumberValue.Create(Math.Min(input.ToNumberValue(), num), true);
+                }
+            }
+
+            return NumberValue.Create(input.ToNumberValue());
         }
 
         public static FluidValue Ceil(FluidValue input, FilterArguments arguments, TemplateContext context)


### PR DESCRIPTION
According to the [Liquid docs](https://help.shopify.com/en/themes/liquid/filters/math-filters), I think we missed the top 3 math filters: `abs`, `at_least` and `at_most`. This PR is to add them to the `NumberFilters`