### PR TITLE
Fix generic Register not registering members

### DIFF
--- a/Fluid/MemberAccessStrategyExtensions.cs
+++ b/Fluid/MemberAccessStrategyExtensions.cs
@@ -59,7 +59,7 @@ namespace Fluid
         /// <typeparam name="T">The type to register.</typeparam>
         public static void Register<T>(this IMemberAccessStrategy strategy)
         {
-            strategy.Register(typeof(T));
+            Register(strategy, typeof(T));
         }
 
         /// <summary>


### PR DESCRIPTION
There was still a problem with the registration. The generic version didn't do what API was promising. It was only adding the type. Now calling the non-generic version which also adds the members.