### PR TITLE
Feature/money filter

### DIFF
--- a/Fluid.Tests/Fluid.Tests.csproj
+++ b/Fluid.Tests/Fluid.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />

--- a/Fluid.Tests/MoneyFilterTests.cs
+++ b/Fluid.Tests/MoneyFilterTests.cs
@@ -1,0 +1,73 @@
+﻿using System.Globalization;
+using Fluid.Filters;
+using Fluid.Values;
+using Shouldly;
+using Xunit;
+
+namespace Fluid.Tests
+{
+    public class MoneyFilterTests
+    {
+        [Theory]
+        [InlineData("59.65", "59.65", "en-AU")]
+        [InlineData("59.65", "59.65", "en-GB")]
+        [InlineData("59.65", "59.65", "en-US")]
+        public void Money(string format, string expected, string cultureInfo)
+        {
+            // Shopify syntax for Money is configuration based, but default appears to be money_without_currency so matching
+            var culture = new CultureInfo(cultureInfo);
+            var context = new TemplateContext { CultureInfo = culture };
+            var input = new StringValue(format);
+            var arguments = new FilterArguments(new StringValue(format));
+            var result = MiscFilters.Money(input, arguments, context);
+            result.ToStringValue().ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData("59.65", "59.65", "en-AU")]
+        [InlineData("59.65", "59.65", "en-GB")]
+        [InlineData("59.65", "59.65", "en-US")]
+        public void Money_Without_Currency(string format, string expected, string cultureInfo)
+        {
+            var culture = new CultureInfo(cultureInfo);
+            var context = new TemplateContext { CultureInfo = culture };
+            var input = new StringValue(format);
+            var arguments = new FilterArguments(new StringValue(format));
+            var result = MiscFilters.MoneyWithOutCurrency(input, arguments, context);
+            result.ToStringValue().ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData("59.65", "$59.65", "en-AU")]
+        [InlineData("59.65", "£59.65", "en-GB")]
+        [InlineData("59.65", "$59.65", "en-US")]
+        public void MoneyWithCurrency(string format, string expected, string cultureInfo)
+        {
+            //Shopify syntax for Money is configuration based (in shopify), default appears to be money_without_currency
+            var culture = new CultureInfo(cultureInfo);
+            var context = new TemplateContext { CultureInfo = culture };
+            var input = new StringValue(format);
+            var arguments = new FilterArguments(new StringValue(format));
+            var result = MiscFilters.MoneyWithCurrency(input, arguments, context);
+            result.ToStringValue().ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData("59.65", "$59.65", "en-AU")]
+        [InlineData("59.65", "£59.65", "en-GB")]
+        [InlineData("59.65", "$59.65", "en-US")]
+        [InlineData("59.01", "$59.01", "en-US")]
+        [InlineData("59.00", "$59", "en-US")]
+        [InlineData("59.000001", "$59", "en-US")] //currency rounding 2 decimals
+        [InlineData("59.009", "$59.01", "en-US")] //currency rounding 2 decimals
+        public void MoneyWithoutTrailingZeros(string format, string expected, string cultureInfo)
+        {
+            var culture = new CultureInfo(cultureInfo);
+            var context = new TemplateContext { CultureInfo = culture };
+            var input = new StringValue(format);
+            var arguments = new FilterArguments(new StringValue(format));
+            var result = MiscFilters.MoneyWithoutTrailingZeros(input, arguments, context);
+            result.ToStringValue().ShouldBe(expected);
+        }
+    }
+}

--- a/Fluid.Tests/MoneyFilterTests.cs
+++ b/Fluid.Tests/MoneyFilterTests.cs
@@ -19,7 +19,7 @@ namespace Fluid.Tests
             var context = new TemplateContext { CultureInfo = culture };
             var input = new StringValue(format);
             var arguments = new FilterArguments(new StringValue(format));
-            var result = MiscFilters.Money(input, arguments, context);
+            var result = MoneyFilters.Money(input, arguments, context);
             result.ToStringValue().ShouldBe(expected);
         }
 
@@ -33,7 +33,7 @@ namespace Fluid.Tests
             var context = new TemplateContext { CultureInfo = culture };
             var input = new StringValue(format);
             var arguments = new FilterArguments(new StringValue(format));
-            var result = MiscFilters.MoneyWithOutCurrency(input, arguments, context);
+            var result = MoneyFilters.MoneyWithOutCurrency(input, arguments, context);
             result.ToStringValue().ShouldBe(expected);
         }
 
@@ -48,7 +48,7 @@ namespace Fluid.Tests
             var context = new TemplateContext { CultureInfo = culture };
             var input = new StringValue(format);
             var arguments = new FilterArguments(new StringValue(format));
-            var result = MiscFilters.MoneyWithCurrency(input, arguments, context);
+            var result = MoneyFilters.MoneyWithCurrency(input, arguments, context);
             result.ToStringValue().ShouldBe(expected);
         }
 
@@ -66,7 +66,7 @@ namespace Fluid.Tests
             var context = new TemplateContext { CultureInfo = culture };
             var input = new StringValue(format);
             var arguments = new FilterArguments(new StringValue(format));
-            var result = MiscFilters.MoneyWithoutTrailingZeros(input, arguments, context);
+            var result = MoneyFilters.MoneyWithoutTrailingZeros(input, arguments, context);
             result.ToStringValue().ShouldBe(expected);
         }
     }

--- a/Fluid/Filters/MiscFilters.cs
+++ b/Fluid/Filters/MiscFilters.cs
@@ -33,10 +33,6 @@ namespace Fluid.Filters
             filters.AddFilter("escape_once", EscapeOnce);
             filters.AddFilter("handle", Handleize);
             filters.AddFilter("handleize", Handleize);
-            filters.AddFilter("money", Money);
-            filters.AddFilter("money_with_currency", MoneyWithCurrency);
-            filters.AddFilter("money_without_currency", MoneyWithOutCurrency);
-            filters.AddFilter("money_without_currency", MoneyWithoutTrailingZeros);
 
             return filters;
         }
@@ -124,52 +120,6 @@ namespace Fluid.Filters
         public static FluidValue EscapeOnce(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
             return new StringValue(WebUtility.HtmlEncode(WebUtility.HtmlDecode(input.ToStringValue())));
-        }
-
-        /// <summary>
-        /// Alias for Money Without Currency
-        /// </summary>
-        public static FluidValue Money(FluidValue input, FilterArguments arguments, TemplateContext context)
-        {
-            return MoneyWithOutCurrency(input, arguments, context);
-        }
-
-        public static FluidValue MoneyWithCurrency(FluidValue input, FilterArguments arguments, TemplateContext context)
-        {
-            if (!decimal.TryParse(input.ToStringValue(), out decimal result))
-            {
-                return NilValue.Instance;
-            }
-
-            return new StringValue(result.ToString("C", context.CultureInfo));
-        }
-
-        public static FluidValue MoneyWithoutTrailingZeros(FluidValue input, FilterArguments arguments, TemplateContext context)
-        {
-            if (!decimal.TryParse(input.ToStringValue(), out decimal result))
-            {
-                return NilValue.Instance;
-            }
-
-            var currencyValue = result.ToString("C", context.CultureInfo);
-            if (currencyValue.Contains(context.CultureInfo.NumberFormat.CurrencyDecimalSeparator))
-            {
-                currencyValue = currencyValue.TrimEnd('0');
-                if (currencyValue.EndsWith(context.CultureInfo.NumberFormat.CurrencyDecimalSeparator))
-                    currencyValue = currencyValue.Replace(context.CultureInfo.NumberFormat.CurrencyDecimalSeparator, "");
-            }
-            return new StringValue(currencyValue);
-
-        }
-
-
-        public static FluidValue MoneyWithOutCurrency(FluidValue input, FilterArguments arguments, TemplateContext context)
-        {
-            if (!decimal.TryParse(input.ToStringValue(), out decimal result))
-            {
-                return NilValue.Instance;
-            }
-            return new StringValue(result.ToString("C", context.CultureInfo).Replace(context.CultureInfo.NumberFormat.CurrencySymbol,""));
         }
 
         public static FluidValue Date(FluidValue input, FilterArguments arguments, TemplateContext context)

--- a/Fluid/Filters/MiscFilters.cs
+++ b/Fluid/Filters/MiscFilters.cs
@@ -33,6 +33,10 @@ namespace Fluid.Filters
             filters.AddFilter("escape_once", EscapeOnce);
             filters.AddFilter("handle", Handleize);
             filters.AddFilter("handleize", Handleize);
+            filters.AddFilter("money", Money);
+            filters.AddFilter("money_with_currency", MoneyWithCurrency);
+            filters.AddFilter("money_without_currency", MoneyWithOutCurrency);
+            filters.AddFilter("money_without_currency", MoneyWithoutTrailingZeros);
 
             return filters;
         }
@@ -120,6 +124,52 @@ namespace Fluid.Filters
         public static FluidValue EscapeOnce(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
             return new StringValue(WebUtility.HtmlEncode(WebUtility.HtmlDecode(input.ToStringValue())));
+        }
+
+        /// <summary>
+        /// Alias for Money Without Currency
+        /// </summary>
+        public static FluidValue Money(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            return MoneyWithOutCurrency(input, arguments, context);
+        }
+
+        public static FluidValue MoneyWithCurrency(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            if (!decimal.TryParse(input.ToStringValue(), out decimal result))
+            {
+                return NilValue.Instance;
+            }
+
+            return new StringValue(result.ToString("C", context.CultureInfo));
+        }
+
+        public static FluidValue MoneyWithoutTrailingZeros(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            if (!decimal.TryParse(input.ToStringValue(), out decimal result))
+            {
+                return NilValue.Instance;
+            }
+
+            var currencyValue = result.ToString("C", context.CultureInfo);
+            if (currencyValue.Contains(context.CultureInfo.NumberFormat.CurrencyDecimalSeparator))
+            {
+                currencyValue = currencyValue.TrimEnd('0');
+                if (currencyValue.EndsWith(context.CultureInfo.NumberFormat.CurrencyDecimalSeparator))
+                    currencyValue = currencyValue.Replace(context.CultureInfo.NumberFormat.CurrencyDecimalSeparator, "");
+            }
+            return new StringValue(currencyValue);
+
+        }
+
+
+        public static FluidValue MoneyWithOutCurrency(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            if (!decimal.TryParse(input.ToStringValue(), out decimal result))
+            {
+                return NilValue.Instance;
+            }
+            return new StringValue(result.ToString("C", context.CultureInfo).Replace(context.CultureInfo.NumberFormat.CurrencySymbol,""));
         }
 
         public static FluidValue Date(FluidValue input, FilterArguments arguments, TemplateContext context)

--- a/Fluid/Filters/MoneyFilters.cs
+++ b/Fluid/Filters/MoneyFilters.cs
@@ -1,0 +1,68 @@
+﻿using Fluid.Values;
+
+namespace Fluid.Filters
+{
+    public static class MoneyFilters
+    {
+        public static FilterCollection WithMoneyFilters(this FilterCollection filters)
+        {
+            filters.AddFilter("money", Money);
+            filters.AddFilter("money_with_currency", MoneyWithCurrency);
+            filters.AddFilter("money_without_currency", MoneyWithOutCurrency);
+            filters.AddFilter("money_without_currency", MoneyWithoutTrailingZeros);
+
+            return filters;
+        }
+
+        /// <summary>
+        /// Alias for Money Without Currency
+        /// </summary>
+        public static FluidValue Money(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            return MoneyWithOutCurrency(input, arguments, context);
+        }
+
+        public static FluidValue MoneyWithCurrency(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            if (!decimal.TryParse(input.ToStringValue(), out decimal result))
+            {
+                return NilValue.Instance;
+            }
+
+            return new StringValue(result.ToString("C", context.CultureInfo));
+        }
+
+        public static FluidValue MoneyWithoutTrailingZeros(FluidValue input, FilterArguments arguments,
+            TemplateContext context)
+        {
+            if (!decimal.TryParse(input.ToStringValue(), out decimal result))
+            {
+                return NilValue.Instance;
+            }
+
+            var currencyValue = result.ToString("C", context.CultureInfo);
+            if (currencyValue.Contains(context.CultureInfo.NumberFormat.CurrencyDecimalSeparator))
+            {
+                currencyValue = currencyValue.TrimEnd('0');
+                if (currencyValue.EndsWith(context.CultureInfo.NumberFormat.CurrencyDecimalSeparator))
+                    currencyValue =
+                        currencyValue.Replace(context.CultureInfo.NumberFormat.CurrencyDecimalSeparator, "");
+            }
+
+            return new StringValue(currencyValue);
+        }
+
+
+        public static FluidValue MoneyWithOutCurrency(FluidValue input, FilterArguments arguments,
+            TemplateContext context)
+        {
+            if (!decimal.TryParse(input.ToStringValue(), out decimal result))
+            {
+                return NilValue.Instance;
+            }
+
+            return new StringValue(result.ToString("C", context.CultureInfo)
+                .Replace(context.CultureInfo.NumberFormat.CurrencySymbol, ""));
+        }
+    }
+}

--- a/Fluid/TemplateContext.cs
+++ b/Fluid/TemplateContext.cs
@@ -105,7 +105,8 @@ namespace Fluid
                 .WithArrayFilters()
                 .WithStringFilters()
                 .WithNumberFilters()
-                .WithMiscFilters();
+                .WithMiscFilters()
+                .WithMoneyFilters();
         }
 
         public TemplateContext()


### PR DESCRIPTION
Add money filters similar to https://help.shopify.com/en/themes/liquid/filters/money-filters  (except conversion expects compatible decimal type, shopify uses integer)

Differences to above implementation, if it makes more sense to conform to spec & match to use integers instead of decimals then can do the change.

**Shopify**

```
{{ 145 | money_with_currency }}
```

**returns**
```
$1.45
```

**this PR;**
```
{{ 1.45 | money_with_currency }}
```

**returns**
```
$1.45
```
