### PR TITLE
feat(DateFormat): Add flag parameters to date formats  fixes #14

### DIFF
--- a/Fluid.Tests/MiscFiltersTests.cs
+++ b/Fluid.Tests/MiscFiltersTests.cs
@@ -121,12 +121,19 @@ namespace Fluid.Tests
 
         [Theory]
         [InlineData("%a", "Tue")]
+        [InlineData("%^a", "TUE")]
         [InlineData("%A", "Tuesday")]
+        [InlineData("%^A", "TUESDAY")]
         [InlineData("%b", "Aug")]
+        [InlineData("%^b", "AUG")]
         [InlineData("%B", "August")]
+        [InlineData("%^B", "AUGUST")]
         [InlineData("%c", "Tuesday, August 1, 2017 5:04:36 PM")]
+        [InlineData("%^c", "TUESDAY, AUGUST 1, 2017 5:04:36 PM")]
         [InlineData("%C", "20")]
         [InlineData("%d", "01")]
+        [InlineData("%_d", " 1")]
+        [InlineData("%-d", "1")]
         [InlineData("%D", "8/1/2017")]
         [InlineData("%e", " 1")]
         [InlineData("%F", "2017-08-01")]
@@ -137,6 +144,8 @@ namespace Fluid.Tests
         [InlineData("%l", " 5")]
         [InlineData("%L", "123")]
         [InlineData("%m", "08")]
+        [InlineData("%_m", " 8")]
+        [InlineData("%-m", "8")]
         [InlineData("%M", "04")]
         [InlineData("%p", "PM")]
         [InlineData("%P", "pm")]
@@ -148,20 +157,24 @@ namespace Fluid.Tests
         [InlineData("%u", "2")]
         [InlineData("%U", "31")]
         [InlineData("%v", "Tuesday, August 1, 2017")]
+        [InlineData("%^v", "TUESDAY, AUGUST 1, 2017")]
         [InlineData("%V", "31")]
         [InlineData("%W", "32")]
         [InlineData("%y", "17")]
         [InlineData("%Y", "2017")]
-        [InlineData("%z", "+08:00")]
+        [InlineData("%z", "+0800")]
+        [InlineData("%Z", "+08:00")]
+        [InlineData("%:z", "+08:00")]
         [InlineData("%%", "%")]
         [InlineData("It is %r", "It is 5:04:36 PM")]
+        [InlineData("Chained %z%:z%a%a%^a", "Chained +0800+08:00TueTueTUE")]
         public void Date(string format, string expected)
         {
-            var input = new DateTimeValue(new DateTimeOffset(new DateTime(2017, 8, 1, 17, 4, 36, 123), TimeSpan.FromHours(8)));
+            var input = new DateTimeValue(new DateTimeOffset(
+                new DateTime(2017, 8, 1, 17, 4, 36, 123), TimeSpan.FromHours(8)));
 
             var arguments = new FilterArguments(new StringValue(format));
-            var context = new TemplateContext();
-            context.CultureInfo = new CultureInfo("en-US");
+            var context = new TemplateContext {CultureInfo = new CultureInfo("en-US")};
 
             var result = MiscFilters.Date(input, arguments, context);
 

--- a/Fluid/Filters/MiscFilters.cs
+++ b/Fluid/Filters/MiscFilters.cs
@@ -141,7 +141,12 @@ namespace Fluid.Filters
                 sb.Builder.EnsureCapacity(format.Length * 2);
                 var result = sb.Builder;
                 var percent = false;
-    
+
+                var removeLeadingZerosFlag = false;
+                var useSpaceForPaddingFlag = false;
+                var upperCaseFlag = false;
+                var useColonsForZeeDirectiveFlag = false;
+
                 for (var i = 0; i < format.Length; i++)
                 {
                     var c = format[i];
@@ -160,13 +165,72 @@ namespace Fluid.Filters
                     {
                         switch (c)
                         {
-                            case 'a': result.Append(context.CultureInfo.DateTimeFormat.AbbreviatedDayNames[(int)value.DayOfWeek]); break;
-                            case 'A': result.Append(context.CultureInfo.DateTimeFormat.DayNames[(int)value.DayOfWeek]); break;
-                            case 'b': result.Append(context.CultureInfo.DateTimeFormat.AbbreviatedMonthNames[value.Month - 1]); break;
-                            case 'B': result.Append(context.CultureInfo.DateTimeFormat.MonthNames[value.Month - 1]); break;
-                            case 'c': result.Append(value.ToString("F", context.CultureInfo)); break;
+                            case '^': upperCaseFlag = true; continue;
+                            case '-': removeLeadingZerosFlag = true; continue;
+                            case '_': useSpaceForPaddingFlag = true; continue;
+                            case ':': useColonsForZeeDirectiveFlag = true; continue;
+                            case 'a':
+                            {
+                                result.Append(
+                                    upperCaseFlag
+                                        ? context.CultureInfo.DateTimeFormat.AbbreviatedDayNames[(int) value.DayOfWeek].ToUpper()
+                                        : context.CultureInfo.DateTimeFormat.AbbreviatedDayNames[(int) value.DayOfWeek]);
+
+                                break;
+                            }
+                            case 'A':
+                            {
+                                if (upperCaseFlag)
+                                {
+                                    result.Append(context.CultureInfo.DateTimeFormat.DayNames[(int) value.DayOfWeek].ToUpper());
+                                }
+                                else
+                                {
+                                    result.Append(context.CultureInfo.DateTimeFormat.DayNames[(int) value.DayOfWeek]);
+                                }
+
+                                break;
+                            }
+                            case 'b':
+                            {
+                                result.Append(upperCaseFlag
+                                    ? context.CultureInfo.DateTimeFormat.AbbreviatedMonthNames[value.Month - 1]
+                                        .ToUpper()
+                                    : context.CultureInfo.DateTimeFormat.AbbreviatedMonthNames[value.Month - 1]);
+                                break;
+                            }
+                            case 'B':
+                            {
+                                result.Append(upperCaseFlag
+                                    ? context.CultureInfo.DateTimeFormat.MonthNames[value.Month - 1].ToUpper()
+                                    : context.CultureInfo.DateTimeFormat.MonthNames[value.Month - 1]);
+                                break;
+                            }
+                            case 'c':
+                            {
+                                result.Append(upperCaseFlag
+                                    ? value.ToString("F", context.CultureInfo).ToUpper()
+                                    : value.ToString("F", context.CultureInfo));
+                                break;
+                            }
                             case 'C': result.Append(value.Year / 100); break;
-                            case 'd': result.Append(value.Day.ToString(context.CultureInfo).PadLeft(2, '0')); break;
+                            case 'd':
+                            {
+                                if (useSpaceForPaddingFlag)
+                                {
+                                    result.Append(value.Day.ToString(context.CultureInfo).PadLeft(2, ' '));
+
+                                }
+                                else if (removeLeadingZerosFlag)
+                                {
+                                    result.Append(value.Day.ToString(context.CultureInfo));
+                                }
+                                else
+                                {
+                                    result.Append(value.Day.ToString(context.CultureInfo).PadLeft(2, '0'));
+                                }
+                                break;
+                                }
                             case 'D': result.Append(value.ToString("d", context.CultureInfo)); break;
                             case 'e': result.Append(value.Day.ToString(context.CultureInfo).PadLeft(2, ' ')); break;
                             case 'F': result.Append(value.ToString("yyyy-MM-dd", context.CultureInfo)); break;
@@ -176,7 +240,22 @@ namespace Fluid.Filters
                             case 'k': result.Append(value.Hour); break;
                             case 'l': result.Append((value.Hour % 12).ToString(context.CultureInfo).PadLeft(2, ' ')); break;
                             case 'L': result.Append(value.Millisecond.ToString(context.CultureInfo).PadLeft(3, '0')); break;
-                            case 'm': result.Append(value.Month.ToString(context.CultureInfo).PadLeft(2, '0')); break;
+                            case 'm':
+                            {
+                                if (useSpaceForPaddingFlag)
+                                {
+                                    result.Append(value.Month.ToString(context.CultureInfo).PadLeft(2, ' '));
+
+                                } else if (removeLeadingZerosFlag)
+                                {
+                                    result.Append(value.Month.ToString(context.CultureInfo));
+                                }
+                                else
+                                {
+                                    result.Append(value.Month.ToString(context.CultureInfo).PadLeft(2, '0'));
+                                }
+                                break;
+                                }
                             case 'M': result.Append(value.Minute.ToString(context.CultureInfo).PadLeft(2, '0')); break;
                             case 'p': result.Append(value.ToString("tt", context.CultureInfo).ToUpper()); break;
                             case 'P': result.Append(value.ToString("tt", context.CultureInfo).ToLower()); break;
@@ -187,18 +266,38 @@ namespace Fluid.Filters
                             case 'S': result.Append(value.Second.ToString(context.CultureInfo).PadLeft(2, '0')); break;
                             case 'u': result.Append((int)value.DayOfWeek); break;
                             case 'U': result.Append(context.CultureInfo.Calendar.GetWeekOfYear(value.DateTime, CalendarWeekRule.FirstDay, DayOfWeek.Sunday).ToString().PadLeft(2, '0')); break;
-                            case 'v': result.Append(value.ToString("D", context.CultureInfo)); break;
+                            case 'v':
+                            {
+                                result.Append(upperCaseFlag
+                                    ? value.ToString("D", context.CultureInfo).ToUpper()
+                                    : value.ToString("D", context.CultureInfo));
+
+                                break;
+                            }
                             case 'V': result.Append((value.DayOfYear / 7 + 1).ToString(context.CultureInfo).PadLeft(2, '0')); break;
                             case 'W': result.Append(context.CultureInfo.Calendar.GetWeekOfYear(value.DateTime, CalendarWeekRule.FirstDay, DayOfWeek.Monday).ToString().PadLeft(2, '0')); break;
                             case 'y': result.Append(value.ToString("yy", context.CultureInfo)); break;
                             case 'Y': result.Append(value.Year); break;
-                            case 'z': result.Append(value.ToString("zzz", context.CultureInfo)); break;
-                            case 'Z': goto default; // unsupported
+                            case 'z':
+                            {
+                                result.Append(useColonsForZeeDirectiveFlag
+                                    ? value.ToString("zzz", context.CultureInfo)
+                                    : value.ToString("zzz", context.CultureInfo).Replace(":", ""));
+                                break;
+                            }
+                            case 'Z':
+                                result.Append(value.ToString("zzz", context.CultureInfo));
+                                break;
+
                             case '%': result.Append('%'); break;
                             default: result.Append('%').Append(c); break;
                         }
 
                         percent = false;
+                        removeLeadingZerosFlag = false;
+                        useSpaceForPaddingFlag = false;
+                        upperCaseFlag = false;
+                        useColonsForZeeDirectiveFlag = false;
                     }
                 }
 

--- a/Fluid/Filters/MiscFilters.cs
+++ b/Fluid/Filters/MiscFilters.cs
@@ -171,66 +171,52 @@ namespace Fluid.Filters
                             case ':': useColonsForZeeDirectiveFlag = true; continue;
                             case 'a':
                             {
-                                result.Append(
-                                    upperCaseFlag
-                                        ? context.CultureInfo.DateTimeFormat.AbbreviatedDayNames[(int) value.DayOfWeek].ToUpper()
-                                        : context.CultureInfo.DateTimeFormat.AbbreviatedDayNames[(int) value.DayOfWeek]);
-
+                                var abbreviatedDayName = context.CultureInfo.DateTimeFormat.AbbreviatedDayNames[(int) value.DayOfWeek];
+                                result.Append(upperCaseFlag ? abbreviatedDayName.ToUpper() : abbreviatedDayName);
                                 break;
                             }
                             case 'A':
                             {
-                                if (upperCaseFlag)
-                                {
-                                    result.Append(context.CultureInfo.DateTimeFormat.DayNames[(int) value.DayOfWeek].ToUpper());
-                                }
-                                else
-                                {
-                                    result.Append(context.CultureInfo.DateTimeFormat.DayNames[(int) value.DayOfWeek]);
-                                }
-
+                                var dayName = context.CultureInfo.DateTimeFormat.DayNames[(int) value.DayOfWeek];
+                                result.Append(upperCaseFlag ? dayName.ToUpper() : dayName);
                                 break;
                             }
                             case 'b':
                             {
-                                result.Append(upperCaseFlag
-                                    ? context.CultureInfo.DateTimeFormat.AbbreviatedMonthNames[value.Month - 1]
-                                        .ToUpper()
-                                    : context.CultureInfo.DateTimeFormat.AbbreviatedMonthNames[value.Month - 1]);
+                                var abbreviatedMonthName = context.CultureInfo.DateTimeFormat.AbbreviatedMonthNames[value.Month - 1];
+                                result.Append(upperCaseFlag ? abbreviatedMonthName.ToUpper() : abbreviatedMonthName);
                                 break;
                             }
                             case 'B':
                             {
-                                result.Append(upperCaseFlag
-                                    ? context.CultureInfo.DateTimeFormat.MonthNames[value.Month - 1].ToUpper()
-                                    : context.CultureInfo.DateTimeFormat.MonthNames[value.Month - 1]);
+                                var monthName = context.CultureInfo.DateTimeFormat.MonthNames[value.Month - 1];
+                                result.Append(upperCaseFlag ? monthName.ToUpper() : monthName);
                                 break;
                             }
                             case 'c':
-                            {
-                                result.Append(upperCaseFlag
-                                    ? value.ToString("F", context.CultureInfo).ToUpper()
-                                    : value.ToString("F", context.CultureInfo));
+                            {   
+                                var f = value.ToString("F", context.CultureInfo);
+                                result.Append(upperCaseFlag ? f.ToUpper() : f);
                                 break;
                             }
                             case 'C': result.Append(value.Year / 100); break;
                             case 'd':
                             {
+                                var day = value.Day.ToString(context.CultureInfo);
                                 if (useSpaceForPaddingFlag)
                                 {
-                                    result.Append(value.Day.ToString(context.CultureInfo).PadLeft(2, ' '));
-
+                                    result.Append(day.PadLeft(2, ' '));
                                 }
                                 else if (removeLeadingZerosFlag)
                                 {
-                                    result.Append(value.Day.ToString(context.CultureInfo));
+                                    result.Append(day);
                                 }
                                 else
                                 {
-                                    result.Append(value.Day.ToString(context.CultureInfo).PadLeft(2, '0'));
+                                    result.Append(day.PadLeft(2, '0'));
                                 }
                                 break;
-                                }
+                            }
                             case 'D': result.Append(value.ToString("d", context.CultureInfo)); break;
                             case 'e': result.Append(value.Day.ToString(context.CultureInfo).PadLeft(2, ' ')); break;
                             case 'F': result.Append(value.ToString("yyyy-MM-dd", context.CultureInfo)); break;
@@ -242,20 +228,21 @@ namespace Fluid.Filters
                             case 'L': result.Append(value.Millisecond.ToString(context.CultureInfo).PadLeft(3, '0')); break;
                             case 'm':
                             {
+                                var month = value.Month.ToString(context.CultureInfo);
                                 if (useSpaceForPaddingFlag)
                                 {
-                                    result.Append(value.Month.ToString(context.CultureInfo).PadLeft(2, ' '));
-
-                                } else if (removeLeadingZerosFlag)
+                                    result.Append(month.PadLeft(2, ' '));
+                                } 
+                                else if (removeLeadingZerosFlag)
                                 {
-                                    result.Append(value.Month.ToString(context.CultureInfo));
+                                    result.Append(month);
                                 }
                                 else
                                 {
-                                    result.Append(value.Month.ToString(context.CultureInfo).PadLeft(2, '0'));
+                                    result.Append(month.PadLeft(2, '0'));
                                 }
                                 break;
-                                }
+                            }
                             case 'M': result.Append(value.Minute.ToString(context.CultureInfo).PadLeft(2, '0')); break;
                             case 'p': result.Append(value.ToString("tt", context.CultureInfo).ToUpper()); break;
                             case 'P': result.Append(value.ToString("tt", context.CultureInfo).ToLower()); break;
@@ -268,10 +255,8 @@ namespace Fluid.Filters
                             case 'U': result.Append(context.CultureInfo.Calendar.GetWeekOfYear(value.DateTime, CalendarWeekRule.FirstDay, DayOfWeek.Sunday).ToString().PadLeft(2, '0')); break;
                             case 'v':
                             {
-                                result.Append(upperCaseFlag
-                                    ? value.ToString("D", context.CultureInfo).ToUpper()
-                                    : value.ToString("D", context.CultureInfo));
-
+                                var d = value.ToString("D", context.CultureInfo);
+                                result.Append(upperCaseFlag ? d.ToUpper() : d);
                                 break;
                             }
                             case 'V': result.Append((value.DayOfYear / 7 + 1).ToString(context.CultureInfo).PadLeft(2, '0')); break;
@@ -280,15 +265,13 @@ namespace Fluid.Filters
                             case 'Y': result.Append(value.Year); break;
                             case 'z':
                             {
-                                result.Append(useColonsForZeeDirectiveFlag
-                                    ? value.ToString("zzz", context.CultureInfo)
-                                    : value.ToString("zzz", context.CultureInfo).Replace(":", ""));
+                                var zzz = value.ToString("zzz", context.CultureInfo);
+                                result.Append(useColonsForZeeDirectiveFlag ? zzz : zzz.Replace(":", ""));
                                 break;
                             }
                             case 'Z':
                                 result.Append(value.ToString("zzz", context.CultureInfo));
                                 break;
-
                             case '%': result.Append('%'); break;
                             default: result.Append('%').Append(c); break;
                         }


### PR DESCRIPTION
BREAKING CHANGE %z previous included a colon in output, the docs for %z output '+0900'  , %:z will output '+09:00' (and also capital %Z)  which is the same output as %z did previously. This is to align with the docs for strftime (https://apidock.com/ruby/DateTime/strftime)

```
-  don't pad a numerical output.
_  use spaces for padding.
^  upcase the result string.
:  use colons for %z.
```
Not done (due to unable to find good examples of usage of '#', and that 0 padding appears to be a default?)
```
# change case.
0  use zeros for padding.
```