### PR TITLE
Reduce state machine creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,5 +286,7 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
-Fluid.Benchmarks/BenchmarkDotNet.Artifacts
 *.orig
+results
+
+BenchmarkDotNet.Artifacts

--- a/Fluid.Benchmarks/Fluid.Benchmarks.csproj
+++ b/Fluid.Benchmarks/Fluid.Benchmarks.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.4" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
     <PackageReference Include="DotLiquid" Version="2.0.298" />
     <PackageReference Include="Liquid.NET" Version="0.10.0" />
     <PackageReference Include="Scriban" Version="2.0.0" />

--- a/Fluid.MvcViewEngine/Fluid.MvcViewEngine.csproj
+++ b/Fluid.MvcViewEngine/Fluid.MvcViewEngine.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,6 +11,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Fluid\ExceptionHelper.cs">
+      <Link>ExceptionHelper.cs</Link>
+    </Compile>
   </ItemGroup>
   
 </Project>

--- a/Fluid.MvcViewEngine/FluidMvcViewOptionsSetup.cs
+++ b/Fluid.MvcViewEngine/FluidMvcViewOptionsSetup.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
 namespace Fluid.MvcViewEngine
@@ -14,7 +13,8 @@ namespace Fluid.MvcViewEngine
         /// <param name="fluidViewEngine">The <see cref="IFluidViewEngine"/>.</param>
         public FluidMvcViewOptionsSetup(IFluidViewEngine fluidViewEngine)
         {
-            _fluidViewEngine = fluidViewEngine ?? throw new ArgumentNullException(nameof(fluidViewEngine));
+            _fluidViewEngine = fluidViewEngine
+                               ?? ExceptionHelper.ThrowArgumentNullException<IFluidViewEngine>(nameof(fluidViewEngine));
         }
 
         /// <summary>
@@ -25,7 +25,8 @@ namespace Fluid.MvcViewEngine
         {
             if (options == null)
             {
-                throw new ArgumentNullException(nameof(options));
+                ExceptionHelper.ThrowArgumentNullException(nameof(options));
+                return;
             }
 
             options.ViewEngines.Add(_fluidViewEngine);

--- a/Fluid.MvcViewEngine/FluidRendering.cs
+++ b/Fluid.MvcViewEngine/FluidRendering.cs
@@ -43,7 +43,7 @@ namespace Fluid.MvcViewEngine
         private readonly IHostingEnvironment _hostingEnvironment;
         private FluidViewEngineOptions _options;
 
-        public async Task<string> RenderAsync(string path, object model, ViewDataDictionary viewData, ModelStateDictionary modelState)
+        public async ValueTask<string> RenderAsync(string path, object model, ViewDataDictionary viewData, ModelStateDictionary modelState)
         {
             // Check for a custom file provider
             var fileProvider = _options.FileProvider ?? _hostingEnvironment.ContentRootFileProvider;
@@ -78,7 +78,7 @@ namespace Fluid.MvcViewEngine
             return body;
         }
 
-        public IEnumerable<string> FindViewStarts(string viewPath, IFileProvider fileProvider)
+        public List<string> FindViewStarts(string viewPath, IFileProvider fileProvider)
         {
             var viewStarts = new List<string>();
             int index = viewPath.Length - 1;
@@ -127,7 +127,7 @@ namespace Fluid.MvcViewEngine
                         statements.Add(new CallbackStatement((writer, encoder, context) =>
                         {
                             context.AmbientValues[ViewPath] = viewStartPath;
-                            return Task.FromResult(Completion.Normal);
+                            return new ValueTask<Completion>(Completion.Normal);
                         }));
 
                         var viewStartTemplate = ParseLiquidFile(viewStartPath, fileProvider, false);

--- a/Fluid.MvcViewEngine/FluidViewEngine.cs
+++ b/Fluid.MvcViewEngine/FluidViewEngine.cs
@@ -120,12 +120,12 @@ namespace Fluid.MvcViewEngine
         {
             if (context == null)
             {
-                throw new ArgumentNullException(nameof(context));
+                ExceptionHelper.ThrowArgumentNullException(nameof(context));
             }
 
             if (key == null)
             {
-                throw new ArgumentNullException(nameof(key));
+                ExceptionHelper.ThrowArgumentNullException(nameof(key));
             }
 
             if (!context.RouteData.Values.TryGetValue(key, out object routeValue))

--- a/Fluid.MvcViewEngine/IFluidRendering.cs
+++ b/Fluid.MvcViewEngine/IFluidRendering.cs
@@ -6,6 +6,6 @@ namespace Fluid.MvcViewEngine
 {
     public interface IFluidRendering
     {
-        Task<string> RenderAsync(string path, object model, ViewDataDictionary viewData, ModelStateDictionary modelState);
+        ValueTask<string> RenderAsync(string path, object model, ViewDataDictionary viewData, ModelStateDictionary modelState);
     }
 }

--- a/Fluid.MvcViewEngine/MvcViewFeaturesMvcBuilderExtensions.cs
+++ b/Fluid.MvcViewEngine/MvcViewFeaturesMvcBuilderExtensions.cs
@@ -11,7 +11,7 @@ namespace Fluid.MvcViewEngine
         {
             if (builder == null)
             {
-                throw new ArgumentNullException(nameof(builder));
+                ExceptionHelper.ThrowArgumentNullException(nameof(builder));
             }
 
             builder.Services.AddOptions();

--- a/Fluid.Tests/Fluid.Tests.csproj
+++ b/Fluid.Tests/Fluid.Tests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
   </ItemGroup>

--- a/Fluid/Ast/CallbackStatement.cs
+++ b/Fluid/Ast/CallbackStatement.cs
@@ -10,18 +10,18 @@ namespace Fluid.Ast
     /// </summary>
     public class CallbackStatement : Statement
     {
-        public CallbackStatement(Func<TextWriter, TextEncoder, TemplateContext, Task<Completion>> action)
+        public CallbackStatement(Func<TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> action)
         {
             Action = action;
         }
 
-        public Func<TextWriter, TextEncoder, TemplateContext, Task<Completion>> Action { get; }
+        public Func<TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> Action { get; }
 
         public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
             context.IncrementSteps();
 
-            return new ValueTask<Completion>(Action?.Invoke(writer, encoder, context));
+            return Action?.Invoke(writer, encoder, context) ?? new ValueTask<Completion>(Completion.Normal);
         }
     }
 }

--- a/Fluid/Ast/DecrementStatement.cs
+++ b/Fluid/Ast/DecrementStatement.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Fluid.Values;

--- a/Fluid/Ast/OutputStatement.cs
+++ b/Fluid/Ast/OutputStatement.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using Fluid.Values;
 
 namespace Fluid.Ast
 {
@@ -16,15 +17,29 @@ namespace Fluid.Ast
 
         public IList<FilterExpression> Filters { get ; }
 
-        public override async ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
+        public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
+            static async ValueTask<Completion> Awaited(
+                ValueTask<FluidValue> t,
+                TextWriter w,
+                TextEncoder enc,
+                TemplateContext ctx)
+            {
+                var value = await t;
+                value.WriteTo(w, enc, ctx.CultureInfo);
+                return Completion.Normal;
+            }
+
             context.IncrementSteps();
 
-            var value = await Expression.EvaluateAsync(context);
+            var task = Expression.EvaluateAsync(context);
+            if (task.IsCompletedSuccessfully)
+            {
+                task.Result.WriteTo(writer, encoder, context.CultureInfo);
+                return new ValueTask<Completion>(Completion.Normal);
+            }
 
-            value.WriteTo(writer, encoder, context.CultureInfo);
-
-            return Completion.Normal;
+            return Awaited(task, writer, encoder, context);
         }
     }
 }

--- a/Fluid/ExceptionHelper.cs
+++ b/Fluid/ExceptionHelper.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Fluid
+{
+    internal static class ExceptionHelper
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowArgumentNullException(string paramName)
+        {
+            ThrowArgumentNullException<object>(paramName);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static T ThrowArgumentNullException<T>(string paramName)
+        {
+            throw new ArgumentNullException(paramName);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static T ThrowParseException<T>(string message)
+        {
+            throw new ParseException(message);
+        }
+    }
+}

--- a/Fluid/FiltersCollection.cs
+++ b/Fluid/FiltersCollection.cs
@@ -6,7 +6,18 @@ namespace Fluid
 {
     public class FilterCollection
     {
-        private Dictionary<string, AsyncFilterDelegate> _delegates = new Dictionary<string, AsyncFilterDelegate>();
+        private readonly Dictionary<string, AsyncFilterDelegate> _delegates;
+
+        public FilterCollection(int capacity = 0)
+        {
+            _delegates = new Dictionary<string, AsyncFilterDelegate>(capacity);
+        }
+
+        public int Count => _delegates.Count;
+
+#if NETSTANDARD2_1
+        public void EnsureCapacity(int capacity) => _delegates.EnsureCapacity(capacity);
+#endif
 
         public void AddFilter(string name, FilterDelegate d)
         {

--- a/Fluid/Fluid.csproj
+++ b/Fluid/Fluid.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;netstandard2.1;net46</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Fluid/IFluidTemplate.cs
+++ b/Fluid/IFluidTemplate.cs
@@ -9,6 +9,6 @@ namespace Fluid
     public interface IFluidTemplate
     {
         List<Statement> Statements { get; set; }
-        Task RenderAsync(TextWriter writer, TextEncoder encoder, TemplateContext context);
+        ValueTask RenderAsync(TextWriter writer, TextEncoder encoder, TemplateContext context);
     }
 }

--- a/Fluid/Scope.cs
+++ b/Fluid/Scope.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Fluid.Values;
 
 namespace Fluid
 {
     public class Scope
     {
-        private Dictionary<string, FluidValue> _properties = new Dictionary<string, FluidValue>();
+        private readonly Dictionary<string, FluidValue> _properties = new Dictionary<string, FluidValue>();
         private readonly Scope _parent;
 
         public Scope()
@@ -24,41 +24,36 @@ namespace Fluid
         /// if it doesn't exist.
         /// </summary>
         /// <param name="name">The name of the value to return.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public FluidValue GetValue(string name)
         {
             if (name == null)
             {
-                throw new ArgumentNullException(nameof(name));
+                return ExceptionHelper.ThrowArgumentNullException<FluidValue>(nameof(name));
             }
 
             if (_properties.TryGetValue(name, out var result))
             {
                 return result;
             }
-            else
-            {
-                if (_parent != null)
-                {
-                    return _parent.GetValue(name);
-                }
-            }
 
-            return NilValue.Instance;
+            return _parent != null
+                ? _parent.GetValue(name)
+                : NilValue.Instance;
         }
 
         public void Delete(string name)
         {
-            if (_properties.ContainsKey(name))
-            {
-                _properties.Remove(name);
-            }
+            _properties.Remove(name);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetValue(string name, FluidValue value)
         {
             _properties[name] = value;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetValue(string name, object value)
         {
             _properties[name] = FluidValue.Create(value);

--- a/Fluid/StringSegmentExtensions.cs
+++ b/Fluid/StringSegmentExtensions.cs
@@ -1,17 +1,19 @@
-﻿using Microsoft.Extensions.Primitives;
+﻿using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.Primitives
 {
     public static class StringSegmentExtensions
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static char Index(this StringSegment segment, int index)
         {
+            var indexToUse = segment.Offset + index;
             if (index < 0)
             {
-                return segment.Buffer[segment.Offset + segment.Length + index];
+                indexToUse += segment.Length;
             }
 
-            return segment.Buffer[segment.Offset + index];
+            return segment.Buffer[indexToUse];
         }
     }
 }

--- a/Fluid/Values/ArrayValue.cs
+++ b/Fluid/Values/ArrayValue.cs
@@ -114,12 +114,12 @@ namespace Fluid.Values
         {
             if (writer == null)
             {
-                throw new ArgumentNullException(nameof(writer));
+                ExceptionHelper.ThrowArgumentNullException(nameof(writer));
             }
 
             if (encoder == null)
             {
-                throw new ArgumentNullException(nameof(encoder));
+                ExceptionHelper.ThrowArgumentNullException(nameof(encoder));
             }
 
             encoder.Encode(writer, ToStringValue());

--- a/Fluid/Values/BooleanValue.cs
+++ b/Fluid/Values/BooleanValue.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Globalization;
+﻿using System.Globalization;
 using System.IO;
 using System.Text.Encodings.Web;
 
@@ -51,12 +50,13 @@ namespace Fluid.Values
         {
             if (writer == null)
             {
-                throw new ArgumentNullException(nameof(writer));
+                ExceptionHelper.ThrowArgumentNullException(nameof(writer));
             }
 
             if (encoder == null)
             {
-                throw new ArgumentNullException(nameof(encoder));
+                ExceptionHelper.ThrowArgumentNullException(nameof(encoder));
+                return;
             }
 
             encoder.Encode(writer, ToStringValue());

--- a/Fluid/Values/DateTimeValue.cs
+++ b/Fluid/Values/DateTimeValue.cs
@@ -55,7 +55,7 @@ namespace Fluid.Values
 
             if (cultureInfo == null)
             {
-                throw new ArgumentNullException(nameof(cultureInfo));
+                ExceptionHelper.ThrowArgumentNullException(nameof(cultureInfo));
             }
 
             writer.Write(_value.ToString("u", cultureInfo));

--- a/Fluid/Values/FactoryValue.cs
+++ b/Fluid/Values/FactoryValue.cs
@@ -91,17 +91,17 @@ namespace Fluid.Values
         {
             if (writer == null)
             {
-                throw new ArgumentNullException(nameof(writer));
+                ExceptionHelper.ThrowArgumentNullException(nameof(writer));
             }
 
             if (encoder == null)
             {
-                throw new ArgumentNullException(nameof(encoder));
+                ExceptionHelper.ThrowArgumentNullException(nameof(encoder));
             }
 
             if (cultureInfo == null)
             {
-                throw new ArgumentNullException(nameof(cultureInfo));
+                ExceptionHelper.ThrowArgumentNullException(nameof(cultureInfo));
             }
 
             _factory.Value.WriteTo(writer, encoder, cultureInfo);

--- a/Fluid/Values/NumberValue.cs
+++ b/Fluid/Values/NumberValue.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Globalization;
+﻿using System.Globalization;
 using System.IO;
 using System.Text.Encodings.Web;
 
@@ -59,17 +58,17 @@ namespace Fluid.Values
         {
             if (writer == null)
             {
-                throw new ArgumentNullException(nameof(writer));
+                ExceptionHelper.ThrowArgumentNullException(nameof(writer));
             }
 
             if (encoder == null)
             {
-                throw new ArgumentNullException(nameof(encoder));
+                ExceptionHelper.ThrowArgumentNullException(nameof(encoder));
             }
 
             if (cultureInfo == null)
             {
-                throw new ArgumentNullException(nameof(cultureInfo));
+                ExceptionHelper.ThrowArgumentNullException(nameof(cultureInfo));
             }
 
             encoder.Encode(writer, _value.ToString(cultureInfo));

--- a/Fluid/Values/StringValue.cs
+++ b/Fluid/Values/StringValue.cs
@@ -84,12 +84,12 @@ namespace Fluid.Values
         {
             if (writer == null)
             {
-                throw new ArgumentNullException(nameof(writer));
+                ExceptionHelper.ThrowArgumentNullException(nameof(writer));
             }
 
             if (encoder == null)
             {
-                throw new ArgumentNullException(nameof(encoder));
+                ExceptionHelper.ThrowArgumentNullException(nameof(encoder));
             }
 
             if (String.IsNullOrEmpty(_value))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ build_script:
   - dotnet build -c Release
   - dotnet pack -c Release
 test_script:
-  - dotnet test .\Fluid.Tests\Fluid.Tests.csproj
+  - dotnet test -c Release .\Fluid.Tests\Fluid.Tests.csproj
 artifacts:
   - path: 'Fluid\**\*.nupkg'
   - path: 'Fluid.MvcViewEngine\**\*.nupkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 # Do not build feature branch with open Pull Requests
 skip_branch_with_pr: true
 branches:
@@ -12,6 +12,8 @@ install:
   - ps: $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = true
   - ps: $env:NUGET_XMLDOC_MODE = "skip"
   - ps: $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
+  - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1" -OutFile "dotnet-install.ps1" 
+  - ps: .\dotnet-install.ps1 --Version 3.0.100-rc1-014190
 build_script:
   - dotnet --version
   - dotnet restore


### PR DESCRIPTION
Making code a bit uglier, but now detecting fast path where async targets are already resolved without need for `await`, this removes the state machine from call site. When looking at OC's traces it's a deeeep call chain because of state machinery, this PR paves way for tweaking OC behavior.

Profiled against the benchmark test case, probably could later check binary expressions etc, don't know how often they are used. This basically removes all state machines in benchmark test case's liquid template except for `ForStatement`.

* use idiomatic ExceptionHelper
* prepare some properties and helpers for better size prediction
* add netstandard 2.1 target
* upgrade support libs

## Fluid.Benchmarks.FluidBenchmarks

| **Diff**|Method|Mean|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------:|-------:|-------:|-------:|-------:|
| Old |Parse|35.85 us|7.0190|-|-|28.81 KB|
| **New** |	| **37.19 us (+4%)** | **7.0190 (0%)** | **-** | **-** | **28.81 KB (0%)** |
| Old |Render|1,158.34 us|58.5938|29.2969|29.2969|224.52 KB|
| **New** |	| **946.49 us (-18%)** | **58.5938 (0%)** | **57.6172 (+97%)** | **29.2969 (0%)** | **224.52 KB (0%)** |
| Old |ParseAndRender|1,282.51 us|58.5938|29.2969|29.2969|278.01 KB|
| **New** |	| **1,069.47 us (-17%)** | **58.5938 (0%)** | **29.2969 (0%)** | **29.2969 (0%)** | **278.01 KB (0%)** |


