### PR TITLE
Fixed "limit" and "offset"; Added in Unit Tests

### DIFF
--- a/Fluid.Tests/ForStatementTests.cs
+++ b/Fluid.Tests/ForStatementTests.cs
@@ -253,6 +253,56 @@ namespace Fluid.Tests
             Assert.Equal("543", sw.ToString());
         }
 
+        [Fact]
+        public async Task ForEvaluatesMemberOptionsLimitOnly()
+        {
+            var context = new TemplateContext()
+                .SetValue("limit", 3)
+                ;
+
+            var e = new ForStatement(
+                new List<Statement> { CreateMemberStatement("i") },
+                "i",
+                new RangeExpression(
+                    new LiteralExpression(NumberValue.Create(1)),
+                    new LiteralExpression(NumberValue.Create(5))
+                ),
+                new MemberExpression(new IdentifierSegment("limit")),
+                null,
+                true
+            );
+
+            var sw = new StringWriter();
+            await e.WriteToAsync(sw, HtmlEncoder.Default, context);
+
+            Assert.Equal("321", sw.ToString());
+        }
+
+        [Fact]
+        public async Task ForEvaluatesMemberOptionsOffsetOnly()
+        {
+            var context = new TemplateContext()
+                .SetValue("offset", 3)
+                ;
+
+            var e = new ForStatement(
+                new List<Statement> { CreateMemberStatement("i") },
+                "i",
+                new RangeExpression(
+                    new LiteralExpression(NumberValue.Create(1)),
+                    new LiteralExpression(NumberValue.Create(5))
+                ),
+                null,
+                new MemberExpression(new IdentifierSegment("offset")),
+                true
+            );
+
+            var sw = new StringWriter();
+            await e.WriteToAsync(sw, HtmlEncoder.Default, context);
+
+            Assert.Equal("54", sw.ToString());
+        }
+
         Statement CreateMemberStatement(string p)
         {
             return new OutputStatement(new MemberExpression(p.Split('.').Select(x => new IdentifierSegment(x)).ToArray()));

--- a/Fluid.Tests/TemplateTests.cs
+++ b/Fluid.Tests/TemplateTests.cs
@@ -616,6 +616,33 @@ shape: '{{ shape }}'");
 
             await Assert.ThrowsAsync<InvalidOperationException>(() => template.RenderAsync(context).AsTask());
         }
+        
+        [Fact]
+        public Task ForLoopLimitAndOffset()
+        {
+            var source = @"{% assign array = '1,2,3,4,5' | split: ',' %}{% for item in array limit:3 offset:2 %}{{ item }}{% endfor %}";
+            var expected = "345";
+
+            return CheckAsync(source, expected);
+        }
+
+        [Fact]
+        public Task ForLoopLimitOnly()
+        {
+            var source = @"{% assign array = '1,2,3,4,5' | split: ',' %}{% for item in array limit:3 %}{{ item }}{% endfor %}";
+            var expected = "123";
+
+            return CheckAsync(source, expected);
+        }
+
+        [Fact]
+        public Task ForLoopOffsetOnly()
+        {
+            var source = @"{% assign array = '1,2,3,4,5' | split: ',' %}{% for item in array offset:3 %}{{ item }}{% endfor %}";
+            var expected = "45";
+
+            return CheckAsync(source, expected);
+        }
 
         [Fact]
         public async Task IgonreCasing()

--- a/Fluid/DefaultFluidParser.cs
+++ b/Fluid/DefaultFluidParser.cs
@@ -850,10 +850,10 @@ namespace Fluid
                     switch (option.Term.Name)
                     {
                         case "limit":
-                            limit = BuildExpression(option.ChildNodes[0]);
+                            limit = BuildExpression(option);
                             break;
                         case "offset":
-                            offset = BuildExpression(option.ChildNodes[0]);
+                            offset = BuildExpression(option);
                             break;
                         case "reversed":
                             reversed = true;


### PR DESCRIPTION
As discussed at https://github.com/OrchardCMS/OrchardCore/issues/5517 there was an issue with limit and offset no longer functioning. This corrects the issue and adds in unit tests.