### PR TITLE
Correctly register async member accessors

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -5,7 +5,7 @@
     <Authors>Sebastien Ros</Authors>
     <PackageProjectUrl>https://github.com/sebastienros/fluid</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/sebastienros/fluid/blob/master/LICENSE.txt</PackageLicenseUrl>
-    <TargetFrameworks>netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <VersionSuffix Condition="'$(VersionSuffix)'!='' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>

--- a/Fluid.MvcViewEngine/Fluid.MvcViewEngine.csproj
+++ b/Fluid.MvcViewEngine/Fluid.MvcViewEngine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
 
@@ -18,5 +18,5 @@
       <Link>ExceptionHelper.cs</Link>
     </Compile>
   </ItemGroup>
-  
+
 </Project>

--- a/Fluid.Tests/MemberAccessStrategyTests.cs
+++ b/Fluid.Tests/MemberAccessStrategyTests.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Fluid.Accessors;
 using Xunit;
 
 namespace Fluid.Tests
@@ -31,6 +32,36 @@ namespace Fluid.Tests
             Assert.NotNull(strategy.GetAccessor(typeof(Class1), nameof(Class1.Property2)));
 
             Assert.Null(strategy.GetAccessor(typeof(Class1), nameof(Class1.PrivateProperty)));
+        }
+
+        [Fact]
+        public void RegisterByTypeAddAsyncPublicFields()
+        {
+            // GIVEN a template context
+            var strategy = new MemberAccessStrategy();
+
+            // WHEN the model is registered using the fluid member access strategy extensions
+            strategy.Register<Class1>();
+
+            // THEN async field values on the model exist
+            var accessor = strategy.GetAccessor(typeof(Class1), nameof(Class1.Field3));
+            Assert.NotNull(accessor);
+            Assert.IsAssignableFrom<AsyncDelegateAccessor>(accessor);
+        }
+
+        [Fact]
+        public void RegisterByTypeAddAsyncPublicProperties()
+        {
+            // GIVEN a template context
+            var strategy = new MemberAccessStrategy();
+
+            // WHEN the model is registered using the fluid member access strategy extensions
+            strategy.Register<Class1>();
+
+            // THEN async field values on the model exist
+            var accessor = strategy.GetAccessor(typeof(Class1), nameof(Class1.Property3));
+            Assert.NotNull(accessor);
+            Assert.IsAssignableFrom<AsyncDelegateAccessor>(accessor);
         }
 
         [Fact]
@@ -111,7 +142,9 @@ namespace Fluid.Tests
         internal string PrivateProperty { get; set; }
         public string Field1;
         public int Field2;
+        public Task<string> Field3;
         public string Property1 { get; set; }
         public int Property2 { get; set; }
+        public Task<string> Property3 { get; set; }
     }
 }

--- a/Fluid.Tests/MemberAccessStrategyTests.cs
+++ b/Fluid.Tests/MemberAccessStrategyTests.cs
@@ -37,13 +37,10 @@ namespace Fluid.Tests
         [Fact]
         public void RegisterByTypeAddAsyncPublicFields()
         {
-            // GIVEN a template context
             var strategy = new MemberAccessStrategy();
 
-            // WHEN the model is registered using the fluid member access strategy extensions
             strategy.Register<Class1>();
 
-            // THEN async field values on the model exist
             var accessor = strategy.GetAccessor(typeof(Class1), nameof(Class1.Field3));
             Assert.NotNull(accessor);
             Assert.IsAssignableFrom<AsyncDelegateAccessor>(accessor);
@@ -52,13 +49,10 @@ namespace Fluid.Tests
         [Fact]
         public void RegisterByTypeAddAsyncPublicProperties()
         {
-            // GIVEN a template context
             var strategy = new MemberAccessStrategy();
 
-            // WHEN the model is registered using the fluid member access strategy extensions
             strategy.Register<Class1>();
 
-            // THEN async field values on the model exist
             var accessor = strategy.GetAccessor(typeof(Class1), nameof(Class1.Property3));
             Assert.NotNull(accessor);
             Assert.IsAssignableFrom<AsyncDelegateAccessor>(accessor);

--- a/Fluid/Fluid.csproj
+++ b/Fluid/Fluid.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;netstandard2.1;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net46</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Irony.Core" Version="1.0.7" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="1.1.1" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.0" />

--- a/Fluid/MemberAccessStrategyExtensions.cs
+++ b/Fluid/MemberAccessStrategyExtensions.cs
@@ -29,7 +29,7 @@ namespace Fluid
                     }
 
                     if (propertyInfo.PropertyType.IsGenericType && propertyInfo.PropertyType.GetGenericTypeDefinition() == typeof(Task<>))
-                        list[memberNameStrategy(propertyInfo)] = new AsyncDelegateAccessor( async (o, n) =>
+                        list[memberNameStrategy(propertyInfo)] = new AsyncDelegateAccessor(async (o, n) =>
                         {
                             var asyncValue = (Task) propertyInfo.GetValue(o);
                             await asyncValue.ConfigureAwait(false);
@@ -42,7 +42,7 @@ namespace Fluid
                 foreach (var fieldInfo in t.GetTypeInfo().GetFields(BindingFlags.Public | BindingFlags.Instance))
                 {
                     if (fieldInfo.FieldType.IsGenericType && fieldInfo.FieldType.GetGenericTypeDefinition() == typeof(Task<>))
-                        list[memberNameStrategy(fieldInfo)] = new AsyncDelegateAccessor( async (o, n) =>
+                        list[memberNameStrategy(fieldInfo)] = new AsyncDelegateAccessor(async (o, n) =>
                         {
                             var asyncValue = (Task) fieldInfo.GetValue(o);
                             await asyncValue.ConfigureAwait(false);

--- a/Fluid/Values/NilValue.cs
+++ b/Fluid/Values/NilValue.cs
@@ -45,7 +45,7 @@ namespace Fluid.Values
         {
             return true;
         }
-        
+
         public override void WriteTo(TextWriter writer, TextEncoder encoder, CultureInfo cultureInfo)
         {
         }
@@ -58,7 +58,7 @@ namespace Fluid.Values
 
         public override int GetHashCode()
         {
-            return GetType().GetHashCode(); ;
+            return GetType().GetHashCode();
         }
     }
 }


### PR DESCRIPTION
This PR addresses issue #135. When classes are registered, any property or field that is of type `Task<>` should be registered with an `AsyncDelegateAccessor` instead of a `DelegateAccessor` or `PropertyAccessor`. This could also be extended to `ValueTask<>` in future if desired.

This change uses reflection properties that are only available in netstandard2.0+, so support for netstandard1.6 was dropped. I'm sure there are other ways to achieve this support, but this seemed the most appropriate for future support while keeping the code simple.

It also relies on dynamic boxing of tasks to get the result without throwing cast exceptions, hence a dependency on `Microsoft.CSharp` was added.