### PR TITLE
Added else clause to for statement 

### DIFF
--- a/Fluid.Tests/ForStatementTests.cs
+++ b/Fluid.Tests/ForStatementTests.cs
@@ -227,6 +227,48 @@ namespace Fluid.Tests
             Assert.Equal("543", sw.ToString());
         }
 
+        [Fact]
+        public async Task ShouldExecuteElseOnEmptyArray()
+        {
+            var e = new ForStatement(
+                new List<Statement> { new TextStatement(new StringSegment("x")) },
+                "i",
+                new MemberExpression(
+                    new IdentifierSegment("items")
+                ),
+                null, null, false,
+                new ElseStatement(new List<Statement> { new TextStatement(new StringSegment("y")) })
+            );
+
+            var sw = new StringWriter();
+            var context = new TemplateContext();
+            context.SetValue("items", new int[0]);
+            await e.WriteToAsync(sw, HtmlEncoder.Default, context);
+
+            Assert.Equal("y", sw.ToString());
+        }
+
+        [Fact]
+        public async Task ShouldNotExecuteElseOnNonEmptyArray()
+        {
+            var e = new ForStatement(
+                new List<Statement> { new TextStatement(new StringSegment("x")) },
+                "i",
+                new MemberExpression(
+                    new IdentifierSegment("items")
+                ),
+                null, null, false,
+                new ElseStatement(new List<Statement> { new TextStatement(new StringSegment("y")) })
+            );
+
+            var sw = new StringWriter();
+            var context = new TemplateContext();
+            context.SetValue("items", new int[] { 1, 2, 3 });
+            await e.WriteToAsync(sw, HtmlEncoder.Default, context);
+
+            Assert.Equal("xxx", sw.ToString());
+        }
+
         Statement CreateMemberStatement(string p)
         {
             return new OutputStatement(new MemberExpression(p.Split('.').Select(x => new IdentifierSegment(x)).ToArray()));

--- a/Fluid.Tests/ForStatementTests.cs
+++ b/Fluid.Tests/ForStatementTests.cs
@@ -269,6 +269,7 @@ namespace Fluid.Tests
             Assert.Equal("xxx", sw.ToString());
         }
             
+        [Fact]
         public async Task ForEvaluatesMemberOptions()
         {
             var context = new TemplateContext()

--- a/Fluid.Tests/ForStatementTests.cs
+++ b/Fluid.Tests/ForStatementTests.cs
@@ -267,7 +267,8 @@ namespace Fluid.Tests
             await e.WriteToAsync(sw, HtmlEncoder.Default, context);
 
             Assert.Equal("xxx", sw.ToString());
-
+        }
+            
         public async Task ForEvaluatesMemberOptions()
         {
             var context = new TemplateContext()

--- a/Fluid.Tests/ParserTests.cs
+++ b/Fluid.Tests/ParserTests.cs
@@ -64,6 +64,18 @@ namespace Fluid.Tests
         }
 
         [Fact]
+        public void ShouldParseForElseTag()
+        {
+            var statements = Parse("{% for a in b %}x{% else %}y{% endfor %}");
+
+            Assert.IsType<ForStatement>(statements.ElementAt(0));
+            var forStatement = statements.ElementAt(0) as ForStatement;
+            Assert.True(forStatement.Statements.Count == 1);
+            Assert.NotNull(forStatement.Else);
+            Assert.True((forStatement.Else is ElseStatement s) && s.Statements.Count == 1);
+        }
+
+        [Fact]
         public void ShouldReadSingleCharInTag()
         {
             var statements = Parse(@"{% for a in b %};{% endfor %}");

--- a/Fluid/Ast/ForStatement.cs
+++ b/Fluid/Ast/ForStatement.cs
@@ -17,13 +17,16 @@ namespace Fluid.Ast
             MemberExpression member,
             LiteralExpression limit,
             LiteralExpression offset,
-            bool reversed) : base(statements)
+            bool reversed,
+            ElseStatement elseStatement = null
+            ) : base(statements)
         {
             Identifier = identifier;
             Member = member;
             Limit = limit;
             Offset = offset;
             Reversed = reversed;
+            Else = elseStatement;
         }
         public ForStatement(
             List<Statement> statements,
@@ -31,13 +34,16 @@ namespace Fluid.Ast
             RangeExpression range,
             LiteralExpression limit,
             LiteralExpression offset,
-            bool reversed) : base(statements)
+            bool reversed,
+            ElseStatement elseStatement = null
+            ) : base(statements)
         {
             Identifier = identifier;
             Range = range;
             Limit = limit;
             Offset = offset;
             Reversed = reversed;
+            Else = elseStatement;
         }
 
         public string Identifier { get; }
@@ -46,6 +52,7 @@ namespace Fluid.Ast
         public LiteralExpression Limit { get; }
         public LiteralExpression Offset { get; }
         public bool Reversed { get; }
+        public Statement Else { get; }
 
         private List<FluidValue> _rangeElements;
         private int _rangeStart, _rangeEnd;
@@ -86,6 +93,10 @@ namespace Fluid.Ast
 
             if (!elements.Any())
             {
+                if (Else != null)
+                {
+                    await Else.WriteToAsync(writer, encoder, context);
+                }
                 return Completion.Normal;
             }
 
@@ -112,6 +123,10 @@ namespace Fluid.Ast
 
             if (!list.Any())
             {
+                if (Else != null)
+                {
+                    await Else.WriteToAsync(writer, encoder, context);
+                }
                 return Completion.Normal;
             }
 

--- a/Fluid/DefaultFluidParser.cs
+++ b/Fluid/DefaultFluidParser.cs
@@ -806,6 +806,9 @@ namespace Fluid
             LiteralExpression offset = null;
             var reversed = false;
 
+            var elseStatements = context.GetBlockStatements<ElseStatement>("else");
+
+
             // Options?
             if (context.Tag.ChildNodes.Count > 2)
             {
@@ -837,7 +840,8 @@ namespace Fluid
                         BuildMemberExpression(source),
                         limit,
                         offset,
-                        reversed);
+                        reversed,
+                        elseStatements.FirstOrDefault());
                     break;
 
                 case "range":
@@ -847,7 +851,8 @@ namespace Fluid
                         BuildRangeExpression(source),
                         limit,
                         offset,
-                        reversed);
+                        reversed,
+                        elseStatements.FirstOrDefault());
                     break;
 
                 default:


### PR DESCRIPTION
Per https://shopify.github.io/liquid/tags/iteration/, the for statement can have an optional else clause that is executed in the case that the collection has no elements. This PR implements the else clause handling; it includes tests for both the parse and the for statement with else.