### PR TITLE
changed number type to decimal, updated tests

### DIFF
--- a/Fluid.Tests/NumberFiltersTests.cs
+++ b/Fluid.Tests/NumberFiltersTests.cs
@@ -13,7 +13,7 @@ namespace Fluid.Tests
         [InlineData(4.2, 4.2)]
         [InlineData(-4, 4)]
         [InlineData(-4.2, 4.2)]
-        public void Abs(double value, double expectedResult)
+        public void Abs(double value, decimal expectedResult)
         {
             var input = NumberValue.Create(value);
 
@@ -32,7 +32,7 @@ namespace Fluid.Tests
         {
             var input = NumberValue.Create(value1);
 
-            var arguments = new FilterArguments(NumberValue.Create(Convert.ToDouble(value2), value2 is int));
+            var arguments = new FilterArguments(NumberValue.Create(Convert.ToDecimal(value2), value2 is int));
             var context = new TemplateContext();
 
             var result = NumberFilters.AtLeast(input, arguments, context);
@@ -47,7 +47,7 @@ namespace Fluid.Tests
         {
             var input = NumberValue.Create(value1);
 
-            var arguments = new FilterArguments(NumberValue.Create(Convert.ToDouble(value2), value2 is int));
+            var arguments = new FilterArguments(NumberValue.Create(Convert.ToDecimal(value2), value2 is int));
             var context = new TemplateContext();
 
             var result = NumberFilters.AtMost(input, arguments, context);
@@ -73,11 +73,11 @@ namespace Fluid.Tests
         [InlineData(4, 5.0, 0.8)]
         [InlineData(5, 2, 2)]
         [InlineData(5, 2.0, 2.5)]
-        public void DividedByReturnsSameTypeAsDivisor(double value, object divisor, double expected)
+        public void DividedByReturnsSameTypeAsDivisor(decimal value, object divisor, decimal expected)
         {
             var input = NumberValue.Create(value);
 
-            var arguments = new FilterArguments(NumberValue.Create(Convert.ToDouble(divisor), divisor is int));
+            var arguments = new FilterArguments(NumberValue.Create(Convert.ToDecimal(divisor), divisor is int));
             var context = new TemplateContext();
 
             var result = NumberFilters.DividedBy(input, arguments, context);
@@ -109,6 +109,21 @@ namespace Fluid.Tests
             var result = NumberFilters.Minus(input, arguments, context);
 
             Assert.Equal(3, result.ToNumberValue());
+        }
+
+        [Theory]
+        [InlineData("23.4", "20", 3.4)]
+        [InlineData("0.8", ".4", 0.4)]
+        [InlineData("0.0003", "0.0001", 0.0002)]
+        public void MinusWithDecimalPointFromObject(string input, string argument, decimal expectedResult)
+        {
+            var inputA = NumberValue.Create(input);
+            var inputB = new FilterArguments(argument);
+            var context = new TemplateContext();
+
+            var result = NumberFilters.Minus(inputA, inputB, context);
+
+            Assert.Equal(expectedResult, result.ToNumberValue());
         }
 
         [Fact]
@@ -148,9 +163,24 @@ namespace Fluid.Tests
             Assert.Equal(9, result.ToNumberValue());
         }
 
+        [Theory]
+        [InlineData("23.4", "20", 43.4)]
+        [InlineData("0.8", ".4", 1.2)]
+        [InlineData("0.0003", "0.0001", 0.0004)]
+        public void PlusWithDecimalPointFromObject(string input, string argument, decimal expectedResult)
+        {
+            var inputA = NumberValue.Create(input);
+            var inputB = new FilterArguments(argument);
+            var context = new TemplateContext();
+
+            var result = NumberFilters.Plus(inputA, inputB, context);
+
+            Assert.Equal(expectedResult, result.ToNumberValue());
+        }
+
         [Fact]
         public void PlusConvertsObjectToNumber()
-        {   
+        {
             var input = new ObjectValue("6");
 
             var arguments = new FilterArguments(3);
@@ -171,7 +201,7 @@ namespace Fluid.Tests
 
             var result = NumberFilters.Round(input, arguments, context);
 
-            Assert.Equal(4.12, result.ToNumberValue());
+            Assert.Equal(4.12M, result.ToNumberValue());
         }
 
         [Fact]
@@ -186,6 +216,21 @@ namespace Fluid.Tests
 
             Assert.Equal(18, result.ToNumberValue());
             Assert.True(((NumberValue)result).IsIntegral);
+        }
+
+        [Theory]
+        [InlineData("23.4", "20", 468)]
+        [InlineData("0.8", ".4", 0.32)]
+        [InlineData("0.0003", "0.0001", 0.00000003)]
+        public void TimesWithDecimalPointFromObject(string input, string argument, decimal expectedResult)
+        {
+            var inputA = NumberValue.Create(input);
+            var inputB = new FilterArguments(argument);
+            var context = new TemplateContext();
+
+            var result = NumberFilters.Times(inputA, inputB, context);
+
+            Assert.Equal(expectedResult, result.ToNumberValue());
         }
 
         [Fact]

--- a/Fluid/Ast/ForStatement.cs
+++ b/Fluid/Ast/ForStatement.cs
@@ -219,7 +219,7 @@ namespace Fluid.Ast
                 return false;
             }
 
-            public override double ToNumberValue()
+            public override decimal ToNumberValue()
             {
                 return Length;
             }

--- a/Fluid/DefaultFluidParser.cs
+++ b/Fluid/DefaultFluidParser.cs
@@ -1030,7 +1030,7 @@ namespace Fluid
 
                 case "number":
                     var decimalSeparator = System.Globalization.CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
-                    return new LiteralExpression(NumberValue.Create(Convert.ToDouble(node.Token.Value), !node.Token.Text.Contains(decimalSeparator)));
+                    return new LiteralExpression(NumberValue.Create(Convert.ToDecimal(node.Token.Value), !node.Token.Text.Contains(decimalSeparator)));
 
                 case "boolean":
                     if (!bool.TryParse(node.ChildNodes[0].Token.Text, out var boolean))

--- a/Fluid/Filters/NumberFilters.cs
+++ b/Fluid/Filters/NumberFilters.cs
@@ -51,7 +51,7 @@ namespace Fluid.Filters
         public static FluidValue DividedBy(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
             var first = arguments.At(0);
-            double divisor = first.ToNumberValue();
+            decimal divisor = first.ToNumberValue();
 
             // The result is rounded down to the nearest integer(that is, the floor) if the divisor is an integer.
             // https://shopify.github.io/liquid/filters/divided_by/

--- a/Fluid/Values/ArrayValue.cs
+++ b/Fluid/Values/ArrayValue.cs
@@ -105,7 +105,7 @@ namespace Fluid.Values
             return true;
         }
 
-        public override double ToNumberValue()
+        public override decimal ToNumberValue()
         {
             return 0;
         }

--- a/Fluid/Values/BooleanValue.cs
+++ b/Fluid/Values/BooleanValue.cs
@@ -36,7 +36,7 @@ namespace Fluid.Values
             return _value;
         }
 
-        public override double ToNumberValue()
+        public override decimal ToNumberValue()
         {
             return _value ? 1 : 0;
         }

--- a/Fluid/Values/DateTimeValue.cs
+++ b/Fluid/Values/DateTimeValue.cs
@@ -36,7 +36,7 @@ namespace Fluid.Values
             return true;
         }
 
-        public override double ToNumberValue()
+        public override decimal ToNumberValue()
         {
             return _value.Ticks;
         }

--- a/Fluid/Values/DictionaryValue.cs
+++ b/Fluid/Values/DictionaryValue.cs
@@ -106,7 +106,7 @@ namespace Fluid.Values
             return true;
         }
 
-        public override double ToNumberValue()
+        public override decimal ToNumberValue()
         {
             return 0;
         }

--- a/Fluid/Values/FactoryValue.cs
+++ b/Fluid/Values/FactoryValue.cs
@@ -67,7 +67,7 @@ namespace Fluid.Values
             return _factory.Value.ToBooleanValue();
         }
 
-        public override double ToNumberValue()
+        public override decimal ToNumberValue()
         {
             return _factory.Value.ToNumberValue();
         }

--- a/Fluid/Values/FluidValue.cs
+++ b/Fluid/Values/FluidValue.cs
@@ -19,7 +19,7 @@ namespace Fluid.Values
 
         public abstract bool ToBooleanValue();
 
-        public abstract double ToNumberValue();
+        public abstract decimal ToNumberValue();
 
         public abstract string ToStringValue();
 
@@ -81,7 +81,7 @@ namespace Fluid.Values
                 case TypeCode.Decimal:
                 case TypeCode.Double:
                 case TypeCode.Single:
-                    return NumberValue.Create(Convert.ToDouble(value));
+                    return NumberValue.Create(Convert.ToDecimal(value));
                 case TypeCode.SByte:
                 case TypeCode.Byte:
                 case TypeCode.Int16:
@@ -90,7 +90,7 @@ namespace Fluid.Values
                 case TypeCode.UInt16:
                 case TypeCode.UInt32:
                 case TypeCode.UInt64:
-                    return NumberValue.Create(Convert.ToDouble(value), true);
+                    return NumberValue.Create(Convert.ToDecimal(value), true);
                 case TypeCode.Empty:
                     return NilValue.Instance;
                 case TypeCode.Object:

--- a/Fluid/Values/NilValue.cs
+++ b/Fluid/Values/NilValue.cs
@@ -26,7 +26,7 @@ namespace Fluid.Values
             return ReferenceEquals(this, Empty);
         }
 
-        public override double ToNumberValue()
+        public override decimal ToNumberValue()
         {
             return 0;
         }

--- a/Fluid/Values/NumberValue.cs
+++ b/Fluid/Values/NumberValue.cs
@@ -15,7 +15,7 @@ namespace Fluid.Values
         private static readonly NumberValue[] _intToValue = new NumberValue[NumbersMax];
         private static readonly NumberValue NegativeOneIntegral = new NumberValue(-1, true);
         private static readonly NumberValue NegativeOneDouble = new NumberValue(-1, false);
-        private readonly double _value;
+        private readonly decimal _value;
 
         static NumberValue()
         {
@@ -26,7 +26,7 @@ namespace Fluid.Values
             }
         }
 
-        private NumberValue(double value, bool isIntegral = false)
+        private NumberValue(decimal value, bool isIntegral = false)
         {
             _value = value;
             IsIntegral = isIntegral;
@@ -44,7 +44,7 @@ namespace Fluid.Values
             return true;
         }
 
-        public override double ToNumberValue()
+        public override decimal ToNumberValue()
         {
             return _value;
         }
@@ -97,7 +97,7 @@ namespace Fluid.Values
             return _value.GetHashCode();
         }
 
-        public static NumberValue Create(double value, bool integral = false)
+        public static NumberValue Create(decimal value, bool integral = false)
         {
             if (value >= 0 && value < NumbersMax && (int)value == value)
             {

--- a/Fluid/Values/ObjectValue.cs
+++ b/Fluid/Values/ObjectValue.cs
@@ -134,9 +134,9 @@ namespace Fluid.Values
             return _value != null;
         }
 
-        public override double ToNumberValue()
+        public override decimal ToNumberValue()
         {
-            return Convert.ToDouble(_value);
+            return Convert.ToDecimal(_value);
         }
 
         public override void WriteTo(TextWriter writer, TextEncoder encoder, CultureInfo cultureInfo)

--- a/Fluid/Values/StringValue.cs
+++ b/Fluid/Values/StringValue.cs
@@ -65,9 +65,9 @@ namespace Fluid.Values
             return true;
         }
 
-        public override double ToNumberValue()
+        public override decimal ToNumberValue()
         {
-            if (double.TryParse(_value, out var value))
+            if (decimal.TryParse(_value, out var value))
             {
                 return value;
             }


### PR DESCRIPTION
The basic operations with decimal values using double as a base type causing calculation errors.
e.g. 
- 10.4 - 10 == 0.40000000000000036  
- 23.4-20 == 3.3999999999999986

Suggested changes of the base type from **double** to **decimal** avoid such calculation errors.