### PR TITLE
slice filter is safe when indexes are outside bounds

### DIFF
--- a/Fluid.Tests/StringFiltersTests.cs
+++ b/Fluid.Tests/StringFiltersTests.cs
@@ -45,7 +45,7 @@ namespace Fluid.Tests
 
             Assert.Equal("hello world", result.ToStringValue());
         }
-        
+
         [Fact]
         public void LStrip()
         {
@@ -58,7 +58,7 @@ namespace Fluid.Tests
 
             Assert.Equal("Hello World   ", result.ToStringValue());
         }
-        
+
         [Fact]
         public void RStrip()
         {
@@ -71,7 +71,7 @@ namespace Fluid.Tests
 
             Assert.Equal("   Hello World", result.ToStringValue());
         }
-        
+
         [Fact]
         public void Strip()
         {
@@ -125,7 +125,7 @@ world
 
             Assert.Equal("Hello World", result.ToStringValue());
         }
-                
+
         [Fact]
         public void RemoveFirst()
         {
@@ -138,7 +138,7 @@ world
 
             Assert.Equal("acabc", result.ToStringValue());
         }
-                
+
         [Fact]
         public void Remove()
         {
@@ -198,6 +198,28 @@ world
         [InlineData("hello", new object[] { -3 }, "l")]
         [InlineData("abcdefg", new object[] { -3, 2 }, "ef")]
         public void Slice(object input, object[] arguments, string expected)
+        {
+            var filterInput = FluidValue.Create(input);
+            var filterArguments = new FilterArguments(arguments);
+            var context = new TemplateContext();
+
+            var result = StringFilters.Slice(filterInput, filterArguments, context);
+
+            Assert.Equal(expected, result.ToStringValue());
+        }
+
+        [Theory]
+        [InlineData("hello", new object[] { 0, 100 }, "hello")]
+        [InlineData("hello", new object[] { 2, 100 }, "llo")]
+        [InlineData("hello", new object[] { 100, 100 }, "")]
+        [InlineData("hello", new object[] { -3, 100 }, "llo")]
+        [InlineData("hello", new object[] { -5, 200 }, "hello")]
+        [InlineData("hello", new object[] { -100, 100 }, "")]
+        [InlineData("hello", new object[] { -100, 200 }, "")]
+        [InlineData("hello", new object[] { -5, 100 }, "hello")]
+        [InlineData("hello", new object[] { 0, -100 }, "")]
+        [InlineData("hello", new object[] { -100, -100 }, "")]
+        public void SliceOutsideBounds(object input, object[] arguments, string expected)
         {
             var filterInput = FluidValue.Create(input);
             var filterArguments = new FilterArguments(arguments);

--- a/Fluid/Filters/StringFilters.cs
+++ b/Fluid/Filters/StringFilters.cs
@@ -126,14 +126,27 @@ namespace Fluid.Filters
 
         public static FluidValue Slice(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            var source = input.ToStringValue();
-            var start = Convert.ToInt32(arguments.At(0).ToNumberValue());
-            var length = Convert.ToInt32(arguments.At(1).Or(NumberValue.Create(1)).ToNumberValue());
+            var sourceString = input.ToStringValue();
+            var requestedStartIndex = Convert.ToInt32(arguments.At(0).ToNumberValue());
+            var requestedLenght = Convert.ToInt32(arguments.At(1).Or(NumberValue.Create(1)).ToNumberValue());
 
-            var len = source.Length;
-            var from = start < 0 ? Math.Max(len + start, 0) : Math.Min(start, len);
+            var sourceStringLength = sourceString.Length;
 
-            return new StringValue(source.Substring(from, length));
+            if (requestedLenght <= 0)
+            {
+                return new StringValue("");
+            }
+
+            if (requestedStartIndex < 0 && Math.Abs(requestedStartIndex) > sourceStringLength)
+            {
+                return new StringValue("");
+            }
+
+            var startIndex = requestedStartIndex < 0 ? Math.Max(sourceStringLength + requestedStartIndex, 0) : Math.Min(requestedStartIndex, sourceStringLength);
+            var length = requestedLenght > sourceStringLength ? sourceStringLength : requestedLenght;
+            length = startIndex > 0 && length + startIndex > sourceStringLength ? length - startIndex : length;
+
+            return new StringValue(sourceString.Substring(startIndex, length));
         }
 
         public static FluidValue Split(FluidValue input, FilterArguments arguments, TemplateContext context)
@@ -152,7 +165,7 @@ namespace Fluid.Filters
                     strings[i] = stringInput[i].ToString();
                 }
             }
-            else 
+            else
             {
                 strings = stringInput.Split(new[] { separator }, StringSplitOptions.RemoveEmptyEntries);
             }
@@ -183,14 +196,14 @@ namespace Fluid.Filters
             {
                 result = result.Replace("\n", "");
             }
-            
+
             return new StringValue(result);
         }
 
         public static FluidValue Truncate(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
             var text = input.ToStringValue();
-            var size = Math.Max(0, (int) arguments.At(0).ToNumberValue());
+            var size = Math.Max(0, (int)arguments.At(0).ToNumberValue());
             var ellipsis = arguments.At(1).Or(Ellipsis).ToStringValue();
 
             if (text == null)
@@ -240,7 +253,7 @@ namespace Fluid.Filters
             {
                 source = "";
             }
-            
+
             source += ellipsis;
 
             return new StringValue(source);


### PR DESCRIPTION
Current implementation of slice filter throws an exception when any index is outside of string bounds. 

Proposed changes are fixing the issue by making the filter compliant with the Ruby implementation.