### PR TITLE
added Braze custom time_zone filter

### DIFF
--- a/Fluid.Tests/Fluid.Tests.csproj
+++ b/Fluid.Tests/Fluid.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Fluid.Tests/MiscFiltersTests.cs
+++ b/Fluid.Tests/MiscFiltersTests.cs
@@ -188,6 +188,37 @@ namespace Fluid.Tests
             Assert.Equal(expected, result.ToStringValue().Trim());
         }
 
+        [Theory]
+        [InlineData("2020-05-18T02:13:09+00:00", "America/New_York", "2020-05-17T22:13:09-04:00")]
+        [InlineData("2020-05-18T02:13:09+00:00", "Europe/London", "2020-05-18T03:13:09+01:00")]
+        public void ChangeTimeZone(string initialDateTime, string timeZone, string expected)
+        {
+            var input = new DateTimeValue(DateTimeOffset.Parse(initialDateTime));
+
+            var arguments = new FilterArguments(new StringValue(timeZone));
+            var context = new TemplateContext {CultureInfo = CultureInfo.InvariantCulture};
+
+            var result = MiscFilters.ChangeTimeZone(input, arguments, context);
+
+            Assert.Equal(expected, ((DateTimeOffset) result.ToObjectValue()).ToString("yyyy-MM-ddTHH:mm:ssK"));
+        }
+
+        [Theory]
+        [InlineData("2020-05-18T02:13:09+00:00", "America/New_York", "%l:%M%P", "10:13pm")]
+        [InlineData("2020-05-18T02:13:09+00:00", "Europe/London", "%l:%M%P", "3:13am")]
+        public void ChangeTimeZoneAndApply12hFormat(string initialDateTime,string timeZone, string format, string expected)
+        {
+            var input = new DateTimeValue(DateTimeOffset.Parse(initialDateTime));
+            var timeZoneArgument = new FilterArguments(new StringValue(timeZone));
+            var formatArgument = new FilterArguments(new StringValue(format));
+            var context = new TemplateContext {CultureInfo = CultureInfo.InvariantCulture};
+
+            var result = MiscFilters.ChangeTimeZone(input, timeZoneArgument, context);
+            result = MiscFilters.Date(result, formatArgument, context);
+            
+            Assert.Equal(expected, result.ToStringValue().Trim());
+        }
+
         [Fact]
         public void DateResolvesNow()
         {

--- a/Fluid/Fluid.csproj
+++ b/Fluid/Fluid.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
@@ -12,6 +12,7 @@
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="TimeZoneConverter" Version="3.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net461'">


### PR DESCRIPTION
Please refer for the details to the [Braze Filter](https://www.braze.com/docs/user_guide/personalization_and_dynamic_content/liquid/filters/#string-filters)

time_zone is specific to Braze, however it is quite useful and as you may see used by one of the largest marketing platforms.

tests were added to confirm changes