### PR TITLE
Fixing nil, blank, empty comparisons

### DIFF
--- a/Fluid.Tests/BinaryExpressionTests.cs
+++ b/Fluid.Tests/BinaryExpressionTests.cs
@@ -204,5 +204,13 @@ namespace Fluid.Tests
             return CheckAsync(source, expected);
         }
 
+        [Theory]
+        [InlineData("1 == 1 or 1 == 2 and 1 == 2", "true")]
+        [InlineData("1 == 1 and 1 == 2 and 1 == 2 or 1 == 1", "false")]
+        public Task OperatorsHavePriority(string source, string expected)
+        {
+            return CheckAsync(source, expected);
+        }
+
     }
 }

--- a/Fluid.Tests/ParserTests.cs
+++ b/Fluid.Tests/ParserTests.cs
@@ -513,5 +513,49 @@ def", "at (")]
 
             Assert.Equal("true", rendered);
         }
+
+        [Theory]
+
+        [InlineData("'' == p", "false")]
+        [InlineData("p == nil", "true")]
+        [InlineData("p == blank", "true")]
+        [InlineData("p == empty", "true")] // spec not clear, assuming empty is equal to nil and blank and ''
+        [InlineData("empty == blank", "true")]
+        [InlineData("nil == blank", "true")]
+        [InlineData("blank == ''", "true")]
+        [InlineData("nil == ''", "false")]
+        [InlineData("empty == ''", "true")]
+        [InlineData("e == ''", "true")]
+        [InlineData("e == blank", "true")]
+        [InlineData("empty == nil", "true")]
+
+        [InlineData("p == ''", "false")]
+        [InlineData("nil == p", "true")]
+        [InlineData("blank == p ", "true")]
+        [InlineData("empty == p", "true")] // spec not clear, assuming empty is equal to nil and blank and ''
+        [InlineData("blank == empty", "true")]
+        [InlineData("blank == nil", "true")]
+        [InlineData("'' == blank", "true")]
+        [InlineData("'' == nil", "false")]
+        [InlineData("'' == empty", "true")]
+        [InlineData("'' == e", "true")]
+        [InlineData("blank == e", "true")]
+        [InlineData("nil == empty", "true")]
+        public void EmptyShouldEqualToNil(string source, string expected)
+        {
+            var result = _parser.TryParse("{%if " + source + " %}true{%else%}false{%endif%}", out var template, out var errors);
+
+            Assert.True(result);
+            Assert.NotNull(template);
+            Assert.Null(errors);
+
+            var context = new TemplateContext();
+            context.SetValue("e", "");
+
+            var rendered = template.Render(context);
+
+            Assert.Equal(expected, rendered);
+            
+        }
     }
 }

--- a/Fluid.Tests/StringFiltersTests.cs
+++ b/Fluid.Tests/StringFiltersTests.cs
@@ -251,7 +251,7 @@ world
         {
             var input = new StringValue("abc");
 
-            var arguments = new FilterArguments().Add(StringValue.Empty);
+            var arguments = new FilterArguments().Add(StringValue.Blank);
             var context = new TemplateContext();
 
             var result = StringFilters.Split(input, arguments, context);

--- a/Fluid.Tests/StringFiltersTests.cs
+++ b/Fluid.Tests/StringFiltersTests.cs
@@ -251,7 +251,7 @@ world
         {
             var input = new StringValue("abc");
 
-            var arguments = new FilterArguments().Add(StringValue.Blank);
+            var arguments = new FilterArguments().Add(StringValue.Empty);
             var context = new TemplateContext();
 
             var result = StringFilters.Split(input, arguments, context);

--- a/Fluid/Filters/MiscFilters.cs
+++ b/Fluid/Filters/MiscFilters.cs
@@ -136,7 +136,7 @@ namespace Fluid.Filters
             var html = input.ToStringValue();
             if (String.IsNullOrEmpty(html))
             {
-                return StringValue.Empty;
+                return StringValue.Blank;
             }
 
             try
@@ -217,14 +217,11 @@ namespace Fluid.Filters
 
             var format = arguments.At(0).ToStringValue();
 
-            using (var sb = StringBuilderPool.GetInstance())
-            {
-                var result = sb.Builder;
+            var result = new StringBuilder(64);
 
-                ForStrf(value, format, result);
+            ForStrf(value, format, result);
 
-                return new StringValue(result.ToString());
-            }
+            return new StringValue(result.ToString());
 
             void ForStrf(DateTimeOffset value, string format, StringBuilder result)
             {

--- a/Fluid/Filters/MiscFilters.cs
+++ b/Fluid/Filters/MiscFilters.cs
@@ -136,7 +136,7 @@ namespace Fluid.Filters
             var html = input.ToStringValue();
             if (String.IsNullOrEmpty(html))
             {
-                return StringValue.Blank;
+                return StringValue.Empty;
             }
 
             try

--- a/Fluid/Filters/StringFilters.cs
+++ b/Fluid/Filters/StringFilters.cs
@@ -175,7 +175,7 @@ namespace Fluid.Filters
             {
                 if (requestedLength <= 0)
                 {
-                    return StringValue.Blank;
+                    return BlankValue.Instance;
                 }
 
                 var sourceString = input.ToStringValue();
@@ -184,7 +184,7 @@ namespace Fluid.Filters
 
                 if (requestedStartIndex < 0 && Math.Abs(requestedStartIndex) > sourceStringLength)
                 {
-                    return StringValue.Blank;
+                    return BlankValue.Instance;
                 }
 
                 var startIndex = requestedStartIndex < 0 ? Math.Max(sourceStringLength + requestedStartIndex, 0) : Math.Min(requestedStartIndex, sourceStringLength);
@@ -250,14 +250,14 @@ namespace Fluid.Filters
         {
             if (input.IsNil())
             {
-                return StringValue.Blank;
+                return StringValue.Empty;
             }
 
             var inputStr = input.ToStringValue();
 
             if (inputStr == null)
             {
-                return StringValue.Blank;
+                return StringValue.Empty;
             }
 
             var ellipsisStr = arguments.At(1).Or(Ellipsis).ToStringValue();

--- a/Fluid/Filters/StringFilters.cs
+++ b/Fluid/Filters/StringFilters.cs
@@ -175,7 +175,7 @@ namespace Fluid.Filters
             {
                 if (requestedLength <= 0)
                 {
-                    return StringValue.Empty;
+                    return StringValue.Blank;
                 }
 
                 var sourceString = input.ToStringValue();
@@ -184,7 +184,7 @@ namespace Fluid.Filters
 
                 if (requestedStartIndex < 0 && Math.Abs(requestedStartIndex) > sourceStringLength)
                 {
-                    return StringValue.Empty;
+                    return StringValue.Blank;
                 }
 
                 var startIndex = requestedStartIndex < 0 ? Math.Max(sourceStringLength + requestedStartIndex, 0) : Math.Min(requestedStartIndex, sourceStringLength);
@@ -250,14 +250,14 @@ namespace Fluid.Filters
         {
             if (input.IsNil())
             {
-                return StringValue.Empty;
+                return StringValue.Blank;
             }
 
             var inputStr = input.ToStringValue();
 
             if (inputStr == null)
             {
-                return StringValue.Empty;
+                return StringValue.Blank;
             }
 
             var ellipsisStr = arguments.At(1).Or(Ellipsis).ToStringValue();

--- a/Fluid/TemplateContext.cs
+++ b/Fluid/TemplateContext.cs
@@ -37,7 +37,7 @@ namespace Fluid
             LocalScope = new Scope(options.Scope);
 
             LocalScope.SetValue("empty", NilValue.Empty);
-            LocalScope.SetValue("blank", StringValue.Empty);
+            LocalScope.SetValue("blank", StringValue.Blank);
             CultureInfo = options.CultureInfo;
             TimeZone = options.TimeZone;
             Now = options.Now;

--- a/Fluid/TemplateContext.cs
+++ b/Fluid/TemplateContext.cs
@@ -36,8 +36,8 @@ namespace Fluid
 
             LocalScope = new Scope(options.Scope);
 
-            LocalScope.SetValue("empty", NilValue.Empty);
-            LocalScope.SetValue("blank", StringValue.Blank);
+            LocalScope.SetValue("empty", EmptyValue.Instance);
+            LocalScope.SetValue("blank", BlankValue.Instance);
             CultureInfo = options.CultureInfo;
             TimeZone = options.TimeZone;
             Now = options.Now;

--- a/Fluid/Utils/StringBuilderPool.cs
+++ b/Fluid/Utils/StringBuilderPool.cs
@@ -15,7 +15,7 @@ namespace Fluid.Utils
     /// </summary>
     internal sealed class StringBuilderPool : IDisposable
     {
-        private const int DefaultPoolCapacity = 16 * 1024;
+        private const int DefaultPoolCapacity = 40 * 1024;
         private readonly int _defaultCapacity;
 
         // global pool
@@ -37,7 +37,7 @@ namespace Fluid.Utils
         /// <summary>
         /// If someone need to create a private pool
         /// </summary>
-        internal static ObjectPool<StringBuilderPool> CreatePool(int size = 16, int capacity = DefaultPoolCapacity)
+        internal static ObjectPool<StringBuilderPool> CreatePool(int size = 100, int capacity = DefaultPoolCapacity)
         {
             ObjectPool<StringBuilderPool> pool = null;
             pool = new ObjectPool<StringBuilderPool>(() => new StringBuilderPool(pool, capacity), size);

--- a/Fluid/Values/ArrayValue.cs
+++ b/Fluid/Values/ArrayValue.cs
@@ -104,7 +104,7 @@ namespace Fluid.Values
 
         public override decimal ToNumberValue()
         {
-            return 0;
+            return _value.Length;
         }
 
         public FluidValue[] Values => _value;

--- a/Fluid/Values/BlankValue.cs
+++ b/Fluid/Values/BlankValue.cs
@@ -4,33 +4,30 @@ using System.Text.Encodings.Web;
 
 namespace Fluid.Values
 {
-    public sealed class NilValue : FluidValue
+    public sealed class BlankValue : FluidValue
     {
-        public static readonly NilValue Instance = new NilValue(); // a variable that is not defined, or the nil keyword
-        public static readonly NilValue Empty = new NilValue(); // the empty keyword
+        public static readonly BlankValue Instance = new BlankValue();
 
-        private NilValue()
+        private BlankValue()
         {
         }
 
-        public override FluidValues Type => FluidValues.Nil;
+        public override FluidValues Type => FluidValues.Empty;
 
         public override bool Equals(FluidValue other)
         {
-            if (other == EmptyValue.Instance) return false;
+            if (other == this) return true;
+            if (other == BooleanValue.False) return true;
+            if (other == EmptyValue.Instance) return true;
+            if (other.ToObjectValue() == null) return true;
+            if (other.Type == FluidValues.String && string.IsNullOrWhiteSpace(other.ToStringValue())) return true;
 
-            if (other == NilValue.Instance
-                || other == BlankValue.Instance)
-            {
-                return true;
-            }
-
-            return other.ToObjectValue() == null;
+            return false;
         }
 
         public override bool ToBooleanValue()
         {
-            return false;
+            return true;
         }
 
         public override decimal ToNumberValue()
@@ -40,7 +37,7 @@ namespace Fluid.Values
 
         public override object ToObjectValue()
         {
-            return null;
+            return "";
         }
 
         public override string ToStringValue()

--- a/Fluid/Values/EmptyValue.cs
+++ b/Fluid/Values/EmptyValue.cs
@@ -4,33 +4,30 @@ using System.Text.Encodings.Web;
 
 namespace Fluid.Values
 {
-    public sealed class NilValue : FluidValue
+    public sealed class EmptyValue : FluidValue
     {
-        public static readonly NilValue Instance = new NilValue(); // a variable that is not defined, or the nil keyword
-        public static readonly NilValue Empty = new NilValue(); // the empty keyword
+        public static readonly EmptyValue Instance = new EmptyValue();
 
-        private NilValue()
+        private EmptyValue()
         {
         }
 
-        public override FluidValues Type => FluidValues.Nil;
+        public override FluidValues Type => FluidValues.Empty;
 
         public override bool Equals(FluidValue other)
         {
-            if (other == EmptyValue.Instance) return false;
+            if (other.Type == FluidValues.String && other.ToStringValue() == "") return true;
+            if (other.Type == FluidValues.Array && other.ToNumberValue() == 0) return true;
+            if (other == BlankValue.Instance) return true;
+            if (other == EmptyValue.Instance) return true;
+            if (other == NilValue.Instance) return false;
 
-            if (other == NilValue.Instance
-                || other == BlankValue.Instance)
-            {
-                return true;
-            }
-
-            return other.ToObjectValue() == null;
+            return false;
         }
 
         public override bool ToBooleanValue()
         {
-            return false;
+            return true;
         }
 
         public override decimal ToNumberValue()
@@ -40,7 +37,7 @@ namespace Fluid.Values
 
         public override object ToObjectValue()
         {
-            return null;
+            return "";
         }
 
         public override string ToStringValue()

--- a/Fluid/Values/FluidValues.cs
+++ b/Fluid/Values/FluidValues.cs
@@ -3,6 +3,8 @@
     public enum FluidValues
     {
         Nil,
+        Empty,
+        Blank,
         Array,
         Boolean,
         Dictionary,

--- a/Fluid/Values/NilValue.cs
+++ b/Fluid/Values/NilValue.cs
@@ -6,8 +6,8 @@ namespace Fluid.Values
 {
     public sealed class NilValue : FluidValue
     {
-        public static readonly NilValue Instance = new NilValue();
-        public static readonly NilValue Empty = new NilValue();
+        public static readonly NilValue Instance = new NilValue(); // a variable that is not defined, or the nil keyword
+        public static readonly NilValue Empty = new NilValue(); // the empty keyword
 
         private NilValue()
         {
@@ -17,7 +17,23 @@ namespace Fluid.Values
 
         public override bool Equals(FluidValue other)
         {
-            return other == Instance;
+            if (this == Empty)
+            {
+                return other == Empty
+                    || other == Instance
+                    || other == StringValue.Blank
+                    || other.Type == FluidValues.String && other.ToStringValue() == ""
+                    ;
+            }
+            else if (this == Instance)
+            {
+                return other == Instance
+                    || other == Empty
+                    || other == StringValue.Blank
+                    ;
+            }
+
+            return false;
         }
 
         public override bool ToBooleanValue()

--- a/Fluid/Values/StringValue.cs
+++ b/Fluid/Values/StringValue.cs
@@ -10,7 +10,7 @@ namespace Fluid.Values
 {
     public sealed class StringValue : FluidValue, IEquatable<StringValue>
     {
-        public static readonly StringValue Blank = new StringValue("");
+        public static readonly StringValue Empty = new StringValue("");
 
         private static readonly StringValue[] CharToString = new StringValue[256];
 
@@ -57,6 +57,11 @@ namespace Fluid.Values
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static StringValue Create(string s)
         {
+            if (s == "")
+            {
+                return Empty;
+            }
+
             return s.Length == 1
                 ? Create(s[0])
                 : new StringValue(s);
@@ -65,6 +70,11 @@ namespace Fluid.Values
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static StringValue Create(in TextSpan span)
         {
+            if (span.Length == 0)
+            {
+                return Empty;
+            }
+
             return span.Length == 1
                 ? Create(span.Buffer[span.Offset])
                 : new StringValue(span.ToString());
@@ -72,19 +82,11 @@ namespace Fluid.Values
 
         public override bool Equals(FluidValue other)
         {
-            if (this == Blank)
-            {
-                return other == Blank
-                    || other.Type == FluidValues.String && other.ToStringValue() == ""
-                    || other.Type == FluidValues.Nil
-                    ;
-            }
-            else if(other.IsNil()) // empty, nil
-            {
-                return other == NilValue.Empty && _value == "";
-            }
+            if (other.Type == FluidValues.String) return _value == other.ToStringValue();
+            if (other == BlankValue.Instance) return String.IsNullOrWhiteSpace(ToStringValue());
+            if (other == EmptyValue.Instance) return ToStringValue().Length == 0;
 
-            return _value == other.ToStringValue();
+            return false;
         }
 
         protected override FluidValue GetIndex(FluidValue index, TemplateContext context)

--- a/Fluid/Values/StringValue.cs
+++ b/Fluid/Values/StringValue.cs
@@ -10,7 +10,7 @@ namespace Fluid.Values
 {
     public sealed class StringValue : FluidValue, IEquatable<StringValue>
     {
-        public static readonly StringValue Empty = new StringValue("");
+        public static readonly StringValue Blank = new StringValue("");
 
         private static readonly StringValue[] CharToString = new StringValue[256];
 
@@ -72,9 +72,16 @@ namespace Fluid.Values
 
         public override bool Equals(FluidValue other)
         {
-            if (other.IsNil())
+            if (this == Blank)
             {
-                return _value.Length == 0;
+                return other == Blank
+                    || other.Type == FluidValues.String && other.ToStringValue() == ""
+                    || other.Type == FluidValues.Nil
+                    ;
+            }
+            else if(other.IsNil()) // empty, nil
+            {
+                return other == NilValue.Empty && _value == "";
             }
 
             return _value == other.ToStringValue();


### PR DESCRIPTION
`empty` is now assumed equivalent to `'' and nil` meaning a variable that is either undefined (nil) or has an empty string will be equal to `empty`