### PR TITLE
Make Awaited local methods static

### DIFF
--- a/Fluid/Ast/IdentifierSegment.cs
+++ b/Fluid/Ast/IdentifierSegment.cs
@@ -23,13 +23,13 @@ namespace Fluid.Ast
 
         public override ValueTask<FluidValue> ResolveAsync(Scope value, TemplateContext context)
         {
-            async ValueTask<FluidValue> Awaited(
+            static async ValueTask<FluidValue> Awaited(
                 IAsyncMemberAccessor asyncAccessor,
                 TemplateContext ctx,
                 string identifier)
             {
                 var o = await asyncAccessor.GetAsync(ctx.Model, identifier, ctx);
-                return FluidValue.Create(o, context.Options);
+                return FluidValue.Create(o, ctx.Options);
             }
 
             var result = value.GetValue(Identifier);

--- a/Fluid/Values/ObjectValue.cs
+++ b/Fluid/Values/ObjectValue.cs
@@ -41,13 +41,13 @@ namespace Fluid.Values
 
         public override ValueTask<FluidValue> GetValueAsync(string name, TemplateContext context)
         {
-            async ValueTask<FluidValue> Awaited(
+            static async ValueTask<FluidValue> Awaited(
                 IAsyncMemberAccessor asyncAccessor,
                 object value,
                 string n,
                 TemplateContext ctx)
             {
-                return Create(await asyncAccessor.GetAsync(value, n, ctx), context.Options);
+                return Create(await asyncAccessor.GetAsync(value, n, ctx), ctx.Options);
             }
 
             if (name.IndexOf(".", StringComparison.OrdinalIgnoreCase) != -1)


### PR DESCRIPTION
Spotted this while profiling NJsonSchema. Couple places where closure was created because context was unintentionally captured.

Before

```
|         Method |      Mean |    Error |   StdDev |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|--------------- |----------:|---------:|---------:|--------:|-------:|------:|----------:|
|          Parse |  10.05 μs | 0.018 μs | 0.016 μs |  0.6256 |      - |     - |   2.59 KB |
|       ParseBig |  55.71 μs | 0.099 μs | 0.092 μs |  2.8076 | 0.0610 |     - |  11.63 KB |
|         Render | 786.13 μs | 2.105 μs | 1.969 μs | 39.0625 |      - |     - | 166.09 KB |
| ParseAndRender | 838.86 μs | 2.093 μs | 1.958 μs | 41.0156 | 9.7656 |     - |  168.8 KB |
```

After

```
|         Method |       Mean |     Error |    StdDev |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|--------------- |-----------:|----------:|----------:|--------:|-------:|------:|----------:|
|          Parse |   9.678 μs | 0.0099 μs | 0.0093 μs |  0.6256 |      - |     - |   2.59 KB |
|       ParseBig |  54.847 μs | 0.1493 μs | 0.1396 μs |  2.8076 | 0.0610 |     - |  11.63 KB |
|         Render | 780.191 μs | 1.5681 μs | 1.3901 μs | 22.4609 | 4.8828 |     - |  95.75 KB |
| ParseAndRender | 764.409 μs | 1.3924 μs | 1.3024 μs | 23.4375 | 5.8594 |     - |  98.45 KB | 
```