### PR TITLE
Avoid state machines

### DIFF
--- a/Fluid.Benchmarks/TagBenchmarks.cs
+++ b/Fluid.Benchmarks/TagBenchmarks.cs
@@ -13,6 +13,7 @@ namespace Fluid.Benchmarks
         private readonly TestCase _ifWithOrs;
         private readonly TestCase _elseIf;
         private readonly TestCase _assign;
+        private readonly TestCase _else;
 
         public TagBenchmarks()
         {
@@ -20,6 +21,7 @@ namespace Fluid.Benchmarks
             _ifWithAnds = new TestCase("{% if true and false and false == false %}HIDDEN{% endif %}");
             _ifWithOrs = new TestCase("{% if true == false or false or false %}HIDDEN{% endif %}");
             _elseIf = new TestCase("{% if false %}{% elsif true == false or false or false %}HIDDEN{% endif %}");
+            _else = new TestCase("{% if false %}{% else %}SHOWN{% endif %}");
             _assign = new TestCase("{% assign something = 'foo' %} {% assign another = 1234 %} {% assign last = something %}");
 
             _context = new TemplateContext();
@@ -83,6 +85,18 @@ namespace Fluid.Benchmarks
         public string Assign_Render()
         {
             return _assign.Render(_context);
+        }
+
+        [Benchmark]
+        public object Else_Parse()
+        {
+            return _else.Parse();
+        }
+
+        [Benchmark]
+        public string Else_Render()
+        {
+            return _else.Render(_context);
         }
 
         private sealed class TestCase

--- a/Fluid.Benchmarks/TagBenchmarks.cs
+++ b/Fluid.Benchmarks/TagBenchmarks.cs
@@ -1,0 +1,92 @@
+﻿using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+
+namespace Fluid.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class TagBenchmarks
+    {
+        private static readonly FluidParser _parser = new();
+        private readonly TemplateContext _context;
+        private readonly TestCase _rawTag;
+        private readonly TestCase _ifWithAnds;
+        private readonly TestCase _ifWithOrs;
+        private readonly TestCase _elseIf;
+
+        public TagBenchmarks()
+        {
+            _rawTag = new TestCase("before {% raw %} {{ TEST 3 }} {% endraw %} after");
+            _ifWithAnds = new TestCase("{% if true and false and false == false %}HIDDEN{% endif %}");
+            _ifWithOrs = new TestCase("{% if true == false or false or false %}HIDDEN{% endif %}");
+            _elseIf = new TestCase("{% if false %}{% elsif true == false or false or false %}HIDDEN{% endif %}");
+
+            _context = new TemplateContext();
+        }
+
+        [Benchmark]
+        public object RawTag_Parse()
+        {
+            return _rawTag.Parse();
+        }
+
+        [Benchmark]
+        public string RawTag_Render()
+        {
+            return _rawTag.Render(_context);
+        }
+
+        [Benchmark]
+        public object IfStatement_Ands_Parse()
+        {
+            return _ifWithAnds.Parse();
+        }
+
+        [Benchmark]
+        public string IfStatement_Ands_Render()
+        {
+            return _ifWithAnds.Render(_context);
+        }
+
+        [Benchmark]
+        public object IfStatement_Ors_Parse()
+        {
+            return _ifWithOrs.Parse();
+        }
+
+        [Benchmark]
+        public string IfStatement_Ors_Render()
+        {
+            return _ifWithOrs.Render(_context);
+        }
+
+        [Benchmark]
+        public object ElseIfStatement_Parse()
+        {
+            return _elseIf.Parse();
+        }
+
+        [Benchmark]
+        public string ElseIfStatement_Render()
+        {
+            return _elseIf.Render(_context);
+        }
+
+        private sealed class TestCase
+        {
+            private readonly string _source;
+            private readonly IFluidTemplate _template;
+
+            public TestCase(string source)
+            {
+                _source = source;
+                _template = _parser.Parse(source);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public string Render(TemplateContext context) => _template.Render(context);
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public IFluidTemplate Parse() => _parser.Parse(_source);
+        }
+    }
+}

--- a/Fluid.Benchmarks/TagBenchmarks.cs
+++ b/Fluid.Benchmarks/TagBenchmarks.cs
@@ -4,6 +4,7 @@ using BenchmarkDotNet.Attributes;
 namespace Fluid.Benchmarks
 {
     [MemoryDiagnoser]
+    [ShortRunJob]
     public class TagBenchmarks
     {
         private static readonly FluidParser _parser = new();

--- a/Fluid.Benchmarks/TagBenchmarks.cs
+++ b/Fluid.Benchmarks/TagBenchmarks.cs
@@ -4,7 +4,6 @@ using BenchmarkDotNet.Attributes;
 namespace Fluid.Benchmarks
 {
     [MemoryDiagnoser]
-    [ShortRunJob]
     public class TagBenchmarks
     {
         private static readonly FluidParser _parser = new();

--- a/Fluid.Benchmarks/TagBenchmarks.cs
+++ b/Fluid.Benchmarks/TagBenchmarks.cs
@@ -14,6 +14,7 @@ namespace Fluid.Benchmarks
         private readonly TestCase _elseIf;
         private readonly TestCase _assign;
         private readonly TestCase _else;
+        private readonly TestCase _textSpan;
 
         public TagBenchmarks()
         {
@@ -23,6 +24,7 @@ namespace Fluid.Benchmarks
             _elseIf = new TestCase("{% if false %}{% elsif true == false or false or false %}HIDDEN{% endif %}");
             _else = new TestCase("{% if false %}{% else %}SHOWN{% endif %}");
             _assign = new TestCase("{% assign something = 'foo' %} {% assign another = 1234 %} {% assign last = something %}");
+            _textSpan = new TestCase("foo");
 
             _context = new TemplateContext();
         }
@@ -97,6 +99,18 @@ namespace Fluid.Benchmarks
         public string Else_Render()
         {
             return _else.Render(_context);
+        }
+
+        [Benchmark]
+        public object TextSpan_Parse()
+        {
+            return _textSpan.Parse();
+        }
+
+        [Benchmark]
+        public string TextSpan_Render()
+        {
+            return _textSpan.Render(_context);
         }
 
         private sealed class TestCase

--- a/Fluid.Benchmarks/TagBenchmarks.cs
+++ b/Fluid.Benchmarks/TagBenchmarks.cs
@@ -12,6 +12,7 @@ namespace Fluid.Benchmarks
         private readonly TestCase _ifWithAnds;
         private readonly TestCase _ifWithOrs;
         private readonly TestCase _elseIf;
+        private readonly TestCase _assign;
 
         public TagBenchmarks()
         {
@@ -19,6 +20,7 @@ namespace Fluid.Benchmarks
             _ifWithAnds = new TestCase("{% if true and false and false == false %}HIDDEN{% endif %}");
             _ifWithOrs = new TestCase("{% if true == false or false or false %}HIDDEN{% endif %}");
             _elseIf = new TestCase("{% if false %}{% elsif true == false or false or false %}HIDDEN{% endif %}");
+            _assign = new TestCase("{% assign something = 'foo' %} {% assign another = 1234 %} {% assign last = something %}");
 
             _context = new TemplateContext();
         }
@@ -69,6 +71,18 @@ namespace Fluid.Benchmarks
         public string ElseIfStatement_Render()
         {
             return _elseIf.Render(_context);
+        }
+
+        [Benchmark]
+        public object Assign_Parse()
+        {
+            return _assign.Parse();
+        }
+
+        [Benchmark]
+        public string Assign_Render()
+        {
+            return _assign.Render(_context);
         }
 
         private sealed class TestCase

--- a/Fluid/Ast/BinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpression.cs
@@ -2,7 +2,7 @@
 {
     public abstract class BinaryExpression : Expression
     {
-        public BinaryExpression(Expression left, Expression right)
+        protected BinaryExpression(Expression left, Expression right)
         {
             Left = left;
             Right = right;

--- a/Fluid/Ast/BinaryExpressions/AndBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/AndBinaryExpression.cs
@@ -9,12 +9,25 @@ namespace Fluid.Ast.BinaryExpressions
         {
         }
 
-        public override async ValueTask<FluidValue> EvaluateAsync(TemplateContext context)
+        public override ValueTask<FluidValue> EvaluateAsync(TemplateContext context)
         {
-            var leftValue = await Left.EvaluateAsync(context);
-            var rightValue = await Right.EvaluateAsync(context);
+            static async ValueTask<FluidValue> Awaited(ValueTask<FluidValue> leftTask, ValueTask<FluidValue> rightTask)
+            {
+                var leftValue = await leftTask;
+                var rightValue = await rightTask;
 
-            return BooleanValue.Create(leftValue.ToBooleanValue() && rightValue.ToBooleanValue());
+                return BooleanValue.Create(leftValue.ToBooleanValue() && rightValue.ToBooleanValue());
+            }
+
+            var leftTask = Left.EvaluateAsync(context);
+            var rightTask = Right.EvaluateAsync(context);
+
+            if (leftTask.IsCompletedSuccessfully && rightTask.IsCompletedSuccessfully)
+            {
+                return BooleanValue.Create(leftTask.Result.ToBooleanValue() && rightTask.Result.ToBooleanValue());
+            }
+
+            return Awaited(leftTask, rightTask);
         }
     }
 }

--- a/Fluid/Ast/ElseIfStatement.cs
+++ b/Fluid/Ast/ElseIfStatement.cs
@@ -17,14 +17,14 @@ namespace Fluid.Ast
         public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
             // Process statements until next block or end of statements
-            for (var index = 0; index < _statements.Count; index++)
+            for (var i = 0; i < _statements.Count; i++)
             {
                 context.IncrementSteps();
 
-                var task = _statements[index].WriteToAsync(writer, encoder, context);
+                var task = _statements[i].WriteToAsync(writer, encoder, context);
                 if (!task.IsCompletedSuccessfully)
                 {
-                    return Awaited(task, index + 1, writer, encoder, context);
+                    return Awaited(task, i + 1, writer, encoder, context);
                 }
 
                 var completion = task.Result;

--- a/Fluid/Ast/IfStatement.cs
+++ b/Fluid/Ast/IfStatement.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using Fluid.Values;
 
 namespace Fluid.Ast
 {
@@ -26,13 +27,87 @@ namespace Fluid.Ast
 
         public IReadOnlyList<ElseIfStatement> ElseIfs => _elseIfStatements;
 
-        public override async ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
+        public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
-            var result = (await Condition.EvaluateAsync(context)).ToBooleanValue();
+            var conditionTask = Condition.EvaluateAsync(context);
+            if (conditionTask.IsCompletedSuccessfully)
+            {
+                var result = conditionTask.Result.ToBooleanValue();
+
+                if (result)
+                {
+                    for (var i = 0; i < _statements.Count; i++)
+                    {
+                        var statement = _statements[i];
+                        var task = statement.WriteToAsync(writer, encoder, context);
+                        if (!task.IsCompletedSuccessfully)
+                        {
+                            return Awaited(conditionTask, writer, encoder, context, i + 1);
+                        }
+
+                        var completion = task.Result;
+
+                        if (completion != Completion.Normal)
+                        {
+                            // Stop processing the block statements
+                            // We return the completion to flow it to the outer loop
+                            return new ValueTask<Completion>(completion);
+                        }
+                    }
+
+                    return new ValueTask<Completion>(Completion.Normal);
+                }
+                else
+                {
+                    for (var i = 0; i < _elseIfStatements.Count; i++)
+                    {
+                        var elseIf = _elseIfStatements[i];
+                        var elseIfConditionTask = elseIf.Condition.EvaluateAsync(context);
+                        if (!elseIfConditionTask.IsCompletedSuccessfully)
+                        {
+                            var writeTask = elseIf.WriteToAsync(writer, encoder, context);
+                            return AwaitedElseBranch(elseIfConditionTask, writeTask, writer, encoder, context, i + 1);
+                        }
+
+                        if (elseIfConditionTask.Result.ToBooleanValue())
+                        {
+                            var writeTask = elseIf.WriteToAsync(writer, encoder, context);
+                            if (!writeTask.IsCompletedSuccessfully)
+                            {
+                                return AwaitedElseBranch(elseIfConditionTask, writeTask, writer, encoder, context, i + 1);
+                            }
+
+                            return new ValueTask<Completion>(writeTask.Result);
+                        }
+                    }
+
+                    if (Else != null)
+                    {
+                        return Else.WriteToAsync(writer, encoder, context);
+                    }
+                }
+
+                return new ValueTask<Completion>(Completion.Normal);
+            }
+            else
+            {
+                return Awaited(conditionTask, writer, encoder, context, statementStartIndex: 0);
+            }
+        }
+
+
+        private async ValueTask<Completion> Awaited(
+            ValueTask<FluidValue> conditionTask,
+            TextWriter writer,
+            TextEncoder encoder,
+            TemplateContext context,
+            int statementStartIndex)
+        {
+            var result = (await conditionTask).ToBooleanValue();
 
             if (result)
             {
-                for (var i = 0; i < _statements.Count; i++)
+                for (var i = statementStartIndex; i < _statements.Count; i++)
                 {
                     var statement = _statements[i];
                     var completion = await statement.WriteToAsync(writer, encoder, context);
@@ -49,19 +124,38 @@ namespace Fluid.Ast
             }
             else
             {
-                for (var i = 0; i < _elseIfStatements.Count; i++)
-                {
-                    var elseIf = _elseIfStatements[i];
-                    if ((await elseIf.Condition.EvaluateAsync(context)).ToBooleanValue())
-                    {
-                        return await elseIf.WriteToAsync(writer, encoder, context);
-                    }
-                }
+                await AwaitedElseBranch(new ValueTask<FluidValue>(BooleanValue.False), null, writer, encoder, context, startIndex: 0);
+            }
 
-                if (Else != null)
+            return Completion.Normal;
+        }
+
+        private async ValueTask<Completion> AwaitedElseBranch(
+            ValueTask<FluidValue> conditionTask,
+            ValueTask<Completion> elseIfTask,
+            TextWriter writer,
+            TextEncoder encoder,
+            TemplateContext context,
+            int startIndex)
+        {
+            bool condition = (await conditionTask).ToBooleanValue();
+            if (condition)
+            {
+                await elseIfTask;
+            }
+
+            for (var i = startIndex; i < _elseIfStatements.Count; i++)
+            {
+                var elseIf = _elseIfStatements[i];
+                if ((await elseIf.Condition.EvaluateAsync(context)).ToBooleanValue())
                 {
-                    await Else.WriteToAsync(writer, encoder, context);
+                    return await elseIf.WriteToAsync(writer, encoder, context);
                 }
+            }
+
+            if (Else != null)
+            {
+                return await Else.WriteToAsync(writer, encoder, context);
             }
 
             return Completion.Normal;

--- a/Fluid/Ast/IfStatement.cs
+++ b/Fluid/Ast/IfStatement.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;

--- a/Fluid/Ast/IfStatement.cs
+++ b/Fluid/Ast/IfStatement.cs
@@ -124,7 +124,7 @@ namespace Fluid.Ast
             }
             else
             {
-                await AwaitedElseBranch(new ValueTask<FluidValue>(BooleanValue.False), null, writer, encoder, context, startIndex: 0);
+                await AwaitedElseBranch(new ValueTask<FluidValue>(BooleanValue.False), new ValueTask<Completion>(), writer, encoder, context, startIndex: 0);
             }
 
             return Completion.Normal;

--- a/Fluid/Ast/IncrementStatement.cs
+++ b/Fluid/Ast/IncrementStatement.cs
@@ -26,8 +26,8 @@ namespace Fluid.Ast
             var prefixedIdentifier = Prefix + Identifier;
 
             var value = context.GetValue(prefixedIdentifier);
-            
-            if (value.IsNil()) 
+
+            if (value.IsNil())
             {
                 value = NumberValue.Zero;
             }

--- a/Fluid/Ast/RawStatement.cs
+++ b/Fluid/Ast/RawStatement.cs
@@ -24,11 +24,11 @@ namespace Fluid.Ast
                 await task;
                 return Completion.Normal;
             }
-            
+
             context.IncrementSteps();
 
             var task = writer.WriteAsync(_text.ToString());
-            return task.IsCompletedSuccessfully() 
+            return task.IsCompletedSuccessfully()
                 ? new ValueTask<Completion>(Completion.Normal)
                 : Awaited(task);
         }

--- a/Fluid/Ast/TextSpanStatement.cs
+++ b/Fluid/Ast/TextSpanStatement.cs
@@ -2,13 +2,14 @@
 using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using Fluid.Utils;
 
 namespace Fluid.Ast
 {
-    public class TextSpanStatement : Statement
+    public sealed class TextSpanStatement : Statement
     {
-        private bool _isStripped = false;
-        private bool _isEmpty = false;
+        private bool _isStripped;
+        private bool _isEmpty;
         private readonly object _synLock = new();
         private TextSpan _text;
         private string _buffer;
@@ -33,18 +34,18 @@ namespace Fluid.Ast
 
         public ref readonly TextSpan Text => ref _text;
 
-        public override async ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
+        public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
             if (!_isStripped)
             {
                 StripLeft |=
-                    (PreviousIsTag && context.Options.Trimming.HasFlag(TrimmingFlags.TagRight)) ||
-                    (PreviousIsOutput && context.Options.Trimming.HasFlag(TrimmingFlags.OutputRight))
+                    (PreviousIsTag && (context.Options.Trimming & TrimmingFlags.TagRight) != 0) ||
+                    (PreviousIsOutput && (context.Options.Trimming & TrimmingFlags.OutputRight) != 0)
                     ;
 
                 StripRight |=
-                    (NextIsTag && context.Options.Trimming.HasFlag(TrimmingFlags.TagLeft)) ||
-                    (NextIsOutput && context.Options.Trimming.HasFlag(TrimmingFlags.OutputLeft))
+                    (NextIsTag && (context.Options.Trimming & TrimmingFlags.TagLeft) != 0) ||
+                    (NextIsOutput && (context.Options.Trimming & TrimmingFlags.OutputLeft) != 0)
                     ;
 
                 var span = _text.Buffer;
@@ -144,7 +145,7 @@ namespace Fluid.Ast
 
             if (_isEmpty)
             {
-                return Completion.Normal;
+                return new ValueTask<Completion>(Completion.Normal);
             }
 
             context.IncrementSteps();
@@ -152,15 +153,20 @@ namespace Fluid.Ast
             // The Text fragments are not encoded, but kept as-is
 
             // Since WriteAsync needs an actual buffer, we created and reused _buffer
-            await writer.WriteAsync(_buffer);
 
-            //#if NETSTANDARD2_0
-            //            await writer.WriteAsync(_text.ToString());
-            //#else
-            //            await writer.WriteAsync(_text.Span.ToArray());
-            //#endif
+            static async ValueTask<Completion> Awaited(Task task)
+            {
+                await task;
+                return Completion.Normal;
+            }
 
-            return Completion.Normal;
+            var task = writer.WriteAsync(_buffer);
+            if (!task.IsCompletedSuccessfully())
+            {
+                return Awaited(task);
+            }
+
+            return new ValueTask<Completion>(Completion.Normal);
         }
     }
 }

--- a/Fluid/Ast/TextSpanStatement.cs
+++ b/Fluid/Ast/TextSpanStatement.cs
@@ -38,14 +38,15 @@ namespace Fluid.Ast
         {
             if (!_isStripped)
             {
+                var trimming = context.Options.Trimming;
                 StripLeft |=
-                    (PreviousIsTag && (context.Options.Trimming & TrimmingFlags.TagRight) != 0) ||
-                    (PreviousIsOutput && (context.Options.Trimming & TrimmingFlags.OutputRight) != 0)
+                    (PreviousIsTag && (trimming & TrimmingFlags.TagRight) != 0) ||
+                    (PreviousIsOutput && (trimming & TrimmingFlags.OutputRight) != 0)
                     ;
 
                 StripRight |=
-                    (NextIsTag && (context.Options.Trimming & TrimmingFlags.TagLeft) != 0) ||
-                    (NextIsOutput && (context.Options.Trimming & TrimmingFlags.OutputLeft) != 0)
+                    (NextIsTag && (trimming & TrimmingFlags.TagLeft) != 0) ||
+                    (NextIsOutput && (trimming & TrimmingFlags.OutputLeft) != 0)
                     ;
 
                 var span = _text.Buffer;

--- a/Fluid/ExceptionHelper.cs
+++ b/Fluid/ExceptionHelper.cs
@@ -29,9 +29,15 @@ namespace Fluid
             throw new ParseException(message);
         }
 
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowMaximumStatementsException()
+        {
+            throw new InvalidOperationException("The maximum number of statements has been reached. Your script took too long to run.");
+        }
+
 #if NETSTANDARD2_0
         private class DoesNotReturnAttribute : Attribute {}
 #endif
-
     }
 }

--- a/Fluid/TemplateContext.cs
+++ b/Fluid/TemplateContext.cs
@@ -74,9 +74,10 @@ namespace Fluid
 
         internal void IncrementSteps()
         {
-            if (Options.MaxSteps != 0 && _steps++ > Options.MaxSteps)
+            var maxSteps = Options.MaxSteps;
+            if (maxSteps > 0 && _steps++ > maxSteps)
             {
-                throw new InvalidOperationException("The maximum number of statements has been reached. Your script took too long to run.");
+                ExceptionHelper.ThrowMaximumStatementsException();
             }
         }
 

--- a/Fluid/TemplateOptions.cs
+++ b/Fluid/TemplateOptions.cs
@@ -23,7 +23,7 @@ namespace Fluid
         /// <summary>
         /// Gets or sets the maximum number of steps a script can execute. Leave to 0 for unlimited.
         /// </summary>
-        public int MaxSteps { get; set; } = 0;
+        public int MaxSteps { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="CultureInfo"/> instance used to render locale values like dates and numbers.

--- a/Fluid/TrimmingFlags.cs
+++ b/Fluid/TrimmingFlags.cs
@@ -8,26 +8,26 @@ namespace Fluid
         /// <summary>
         /// Default. Tags and outputs are not trimmed unless the '-' is set on the delimiter.
         /// </summary>
-        None,
-        
+        None = 0,
+
         /// <summary>
         /// Strip blank characters (including , \t, and \r) from the left of tags ({% %}) until \n (exclusive when greedy option os off).
         /// </summary>
-        TagLeft,
+        TagLeft = 1,
 
         /// <summary>
         /// Strip blank characters (including , \t, and \r) from the right of tags ({% %}) until \n (inclusive when greedy option os off).
         /// </summary>
-        TagRight,
+        TagRight = 2,
 
         /// <summary>
         /// Strip blank characters (including , \t, and \r) from the left of values ({{ }}) until \n (exclusive when greedy option os off).
         /// </summary>
-        OutputLeft,
+        OutputLeft = 4,
 
         /// <summary>
         /// Strip blank characters (including , \t, and \r) from the right of values ({{ }}) until \n (inclusive when greedy option os off).
         /// </summary>
-        OutputRight
+        OutputRight = 8
     }
 }

--- a/Fluid/Utils/TaskExtensions.cs
+++ b/Fluid/Utils/TaskExtensions.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+
+namespace Fluid.Utils
+{
+    internal static class TaskExtensions
+    {
+        public static bool IsCompletedSuccessfully(this Task t)
+        {
+#if !NETSTANDARD2_0
+            return t.IsCompletedSuccessfully;
+#else
+            return t.Status == TaskStatus.RanToCompletion && !t.IsFaulted && !t.IsCanceled;
+#endif
+        }
+    }
+}


### PR DESCRIPTION
Targeted the most obvious choices (often used or simple to change). If was the beast here and I'm sure the coded didn't get too clear by the change. Maybe judge that by the results - it's ugly but so often invoked...

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-6820HQ CPU 2.70GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.202
  [Host]     : .NET Core 5.0.5 (CoreCLR 5.0.521.16609, CoreFX 5.0.521.16609), X64 RyuJIT
  DefaultJob : .NET Core 5.0.5 (CoreCLR 5.0.521.16609, CoreFX 5.0.521.16609), X64 RyuJIT


```

## Fluid.Benchmarks.TagBenchmarks

| **Diff**|Method|Mean|Error|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------:|-------|-------:|-------:|-------:|-------:|
| Old |RawTag_Parse|1,403.9 ns|12.71 ns|0.1125|0.0000|0.0000|472 B|
| **New** |	| **1,363.40 ns (-3%)** | **8.817 ns** | **0.1125 (0%)** | **0.0000** | **0.0000** | **472 B (0%)** |
| Old |RawTag_Render|202.1 ns|0.25 ns|0.0458|0.0000|0.0000|192 B|
| **New** |	| **142.58 ns (-29%)** | **0.419 ns** | **0.0458 (0%)** | **0.0000** | **0.0000** | **192 B (0%)** |
| Old |IfStatement_Ands_Parse|2,933.6 ns|14.34 ns|0.2556|0.0000|0.0000|1080 B|
| **New** |	| **2,937.76 ns (0%)** | **10.568 ns** | **0.2556 (0%)** | **0.0000** | **0.0000** | **1080 B (0%)** |
| Old |IfStatement_Ands_Render|276.9 ns|0.37 ns|0.0134|0.0000|0.0000|56 B|
| **New** |	| **159.17 ns (-43%)** | **0.387 ns** | **0.0134 (0%)** | **0.0000** | **0.0000** | **56 B (0%)** |
| Old |IfStatement_Ors_Parse|2,778.1 ns|18.82 ns|0.2480|0.0000|0.0000|1048 B|
| **New** |	| **2,831.34 ns (+2%)** | **12.927 ns** | **0.2480 (0%)** | **0.0000** | **0.0000** | **1048 B (0%)** |
| Old |IfStatement_Ors_Render|284.9 ns|0.79 ns|0.0134|0.0000|0.0000|56 B|
| **New** |	| **163.08 ns (-43%)** | **0.494 ns** | **0.0134 (0%)** | **0.0000** | **0.0000** | **56 B (0%)** |
| Old |ElseIfStatement_Parse|3,656.2 ns|34.29 ns|0.3128|0.0000|0.0000|1320 B|
| **New** |	| **3,719.81 ns (+2%)** | **20.734 ns** | **0.3128 (0%)** | **0.0000** | **0.0000** | **1320 B (0%)** |
| Old |ElseIfStatement_Render|320.0 ns|1.36 ns|0.0134|0.0000|0.0000|56 B|
| **New** |	| **165.62 ns (-48%)** | **0.825 ns** | **0.0134 (0%)** | **0.0000** | **0.0000** | **56 B (0%)** |
| Old |Assign_Parse|3,322.4 ns|11.51 ns|0.3204|0.0000|0.0000|1352 B|
| **New** |	| **3,292.75 ns (-1%)** | **12.106 ns** | **0.3204 (0%)** | **0.0000** | **0.0000** | **1352 B (0%)** |
| Old |Assign_Render|367.3 ns|0.78 ns|0.0205|0.0000|0.0000|88 B|
| **New** |	| **271.46 ns (-26%)** | **2.938 ns** | **0.0210 (+2%)** | **0.0000** | **0.0000** | **88 B (0%)** |
| Old |Else_Parse|2,098.0 ns|17.45 ns|0.1945|0.0000|0.0000|816 B|
| **New** |	| **2,131.72 ns (+2%)** | **19.065 ns** | **0.1945 (0%)** | **0.0000** | **0.0000** | **816 B (0%)** |
| Old |Else_Render|185.0 ns|0.18 ns|0.0210|0.0000|0.0000|88 B|
| **New** |	| **105.97 ns (-43%)** | **0.224 ns** | **0.0210 (0%)** | **0.0000** | **0.0000** | **88 B (0%)** |
| Old |TextSpan_Parse|307.8 ns|0.97 ns|0.0782|0.0000|0.0000|328 B|
| **New** |	| **326.10 ns (+6%)** | **3.839 ns** | **0.0782 (0%)** | **0.0000** | **0.0000** | **328 B (0%)** |
| Old |TextSpan_Render|103.2 ns|0.34 ns|0.0210|0.0000|0.0000|88 B|
| **New** |	| **85.66 ns (-17%)** | **0.420 ns** | **0.0210 (0%)** | **0.0000** | **0.0000** | **88 B (0%)** |

## Fluid.Benchmarks.FluidBenchmarks

| **Diff**|Method|Mean|Error|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------:|-------|-------:|-------:|-------:|-------:|
| Old |Parse|8.874 μs|0.1658 μs|0.6561|0.0000|0.0000|2.71 KB|
| **New** |	| **8.627 μs (-3%)** | **0.1179 μs** | **0.6561 (0%)** | **0.0000** | **0.0000** | **2.71 KB (0%)** |
| Old |ParseBig|49.396 μs|0.9814 μs|2.9297|0.0610|0.0000|12.13 KB|
| **New** |	| **50.067 μs (+1%)** | **0.3050 μs** | **2.9297 (0%)** | **0.0000 (-100%)** | **0.0000** | **12.13 KB (0%)** |
| Old |Render|638.494 μs|2.5238 μs|22.4609|4.8828|0.0000|95.75 KB|
| **New** |	| **599.048 μs (-6%)** | **2.1111 μs** | **22.4609 (0%)** | **4.8828 (0%)** | **0.0000** | **95.75 KB (0%)** |
| Old |ParseAndRender|643.862 μs|2.1457 μs|23.4375|4.8828|0.0000|98.93 KB|
| **New** |	| **611.502 μs (-5%)** | **3.2349 μs** | **23.4375 (0%)** | **4.8828 (0%)** | **0.0000** | **98.93 KB (0%)** |
