### PR TITLE
Reduce state machines in binary expressions

### DIFF
--- a/Fluid.Benchmarks/TagBenchmarks.cs
+++ b/Fluid.Benchmarks/TagBenchmarks.cs
@@ -15,6 +15,7 @@ namespace Fluid.Benchmarks
         private readonly TestCase _assign;
         private readonly TestCase _else;
         private readonly TestCase _textSpan;
+        private readonly TestCase _binaryExpressions;
 
         public TagBenchmarks()
         {
@@ -25,10 +26,12 @@ namespace Fluid.Benchmarks
             _else = new TestCase("{% if false %}{% else %}SHOWN{% endif %}");
             _assign = new TestCase("{% assign something = 'foo' %} {% assign another = 1234 %} {% assign last = something %}");
             _textSpan = new TestCase("foo");
+            _binaryExpressions = new TestCase("{% if 1 == 'elvis' or 0 == 1 or 1 == 2 or 2 < 1 or 4 > 4 or 1 != 1 or 1 >= 2 or 4 <= 2 or 'abc' contains 'd' or 'abc' startswith 'd' or 'abc' endswith 'd' %}TEXT{% endif %}");
 
             _context = new TemplateContext();
         }
 
+        /*
         [Benchmark]
         public object RawTag_Parse()
         {
@@ -111,6 +114,18 @@ namespace Fluid.Benchmarks
         public string TextSpan_Render()
         {
             return _textSpan.Render(_context);
+        }
+*/
+        [Benchmark]
+        public object BinaryExpressions_Parse()
+        {
+            return _binaryExpressions.Parse();
+        }
+
+        [Benchmark]
+        public string BinaryExpressions_Render()
+        {
+            return _binaryExpressions.Render(_context);
         }
 
         private sealed class TestCase

--- a/Fluid.Benchmarks/TagBenchmarks.cs
+++ b/Fluid.Benchmarks/TagBenchmarks.cs
@@ -31,7 +31,6 @@ namespace Fluid.Benchmarks
             _context = new TemplateContext();
         }
 
-        /*
         [Benchmark]
         public object RawTag_Parse()
         {
@@ -115,7 +114,7 @@ namespace Fluid.Benchmarks
         {
             return _textSpan.Render(_context);
         }
-*/
+
         [Benchmark]
         public object BinaryExpressions_Parse()
         {

--- a/Fluid/Ast/BinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpression.cs
@@ -1,4 +1,9 @@
-﻿namespace Fluid.Ast
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Fluid.Values;
+
+namespace Fluid.Ast
 {
     public abstract class BinaryExpression : Expression
     {
@@ -11,5 +16,38 @@
         public Expression Left { get; }
 
         public Expression Right { get; }
+
+        /// <summary>
+        /// Evaluates two operands and tries to avoid state machines.
+        /// </summary>
+        public override ValueTask<FluidValue> EvaluateAsync(TemplateContext context)
+        {
+            var leftTask = Left.EvaluateAsync(context);
+            var rightTask = Right.EvaluateAsync(context);
+
+            if (leftTask.IsCompletedSuccessfully && rightTask.IsCompletedSuccessfully)
+            {
+                return Evaluate(leftTask.Result, rightTask.Result);
+            }
+
+            return Awaited(leftTask, rightTask);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private async ValueTask<FluidValue> Awaited(
+            ValueTask<FluidValue> leftTask,
+            ValueTask<FluidValue> rightTask)
+        {
+            var leftValue = await leftTask;
+            var rightValue = await rightTask;
+
+            return Evaluate(leftValue, rightValue);
+        }
+
+        // sub-classes using the default implementation need to override this
+        internal virtual FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Fluid/Ast/BinaryExpressions/AddBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/AddBinaryExpression.cs
@@ -1,19 +1,15 @@
-﻿using System.Threading.Tasks;
-using Fluid.Values;
+﻿using Fluid.Values;
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public class AddBinaryExpression : BinaryExpression
+    public sealed class AddBinaryExpression : BinaryExpression
     {
         public AddBinaryExpression(Expression left, Expression right) : base(left, right)
         {
         }
 
-        public override async ValueTask<FluidValue> EvaluateAsync(TemplateContext context)
+        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
-            var leftValue = await Left.EvaluateAsync(context);
-            var rightValue = await Right.EvaluateAsync(context);
-            
             if (leftValue is StringValue)
             {
                 return new StringValue(leftValue.ToStringValue() + rightValue.ToStringValue());

--- a/Fluid/Ast/BinaryExpressions/AndBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/AndBinaryExpression.cs
@@ -1,33 +1,16 @@
-﻿using System.Threading.Tasks;
-using Fluid.Values;
+﻿using Fluid.Values;
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public class AndBinaryExpression : BinaryExpression
+    public sealed class AndBinaryExpression : BinaryExpression
     {
         public AndBinaryExpression(Expression left, Expression right) : base(left, right)
         {
         }
 
-        public override ValueTask<FluidValue> EvaluateAsync(TemplateContext context)
+        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
-            static async ValueTask<FluidValue> Awaited(ValueTask<FluidValue> leftTask, ValueTask<FluidValue> rightTask)
-            {
-                var leftValue = await leftTask;
-                var rightValue = await rightTask;
-
-                return BooleanValue.Create(leftValue.ToBooleanValue() && rightValue.ToBooleanValue());
-            }
-
-            var leftTask = Left.EvaluateAsync(context);
-            var rightTask = Right.EvaluateAsync(context);
-
-            if (leftTask.IsCompletedSuccessfully && rightTask.IsCompletedSuccessfully)
-            {
-                return BooleanValue.Create(leftTask.Result.ToBooleanValue() && rightTask.Result.ToBooleanValue());
-            }
-
-            return Awaited(leftTask, rightTask);
+            return BooleanValue.Create(leftValue.ToBooleanValue() && rightValue.ToBooleanValue());
         }
     }
 }

--- a/Fluid/Ast/BinaryExpressions/ContainsBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/ContainsBinaryExpression.cs
@@ -1,22 +1,18 @@
-﻿using System.Threading.Tasks;
-using Fluid.Values;
+﻿using Fluid.Values;
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public class ContainsBinaryExpression : BinaryExpression
+    public sealed class ContainsBinaryExpression : BinaryExpression
     {
         public ContainsBinaryExpression(Expression left, Expression right) : base(left, right)
         {
         }
 
-        public override async ValueTask<FluidValue> EvaluateAsync(TemplateContext context)
+        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
-            var leftValue = await Left.EvaluateAsync(context);
-            var rightValue = await Right.EvaluateAsync(context);
-
             return leftValue.Contains(rightValue)
-                    ? BooleanValue.True
-                    : BooleanValue.False;
+                ? BooleanValue.True
+                : BooleanValue.False;
         }
     }
 }

--- a/Fluid/Ast/BinaryExpressions/DivideBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/DivideBinaryExpression.cs
@@ -1,19 +1,15 @@
-﻿using System.Threading.Tasks;
-using Fluid.Values;
+﻿using Fluid.Values;
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public class DivideBinaryExpression : BinaryExpression
+    public sealed class DivideBinaryExpression : BinaryExpression
     {
         public DivideBinaryExpression(Expression left, Expression right) : base(left, right)
         {
         }
 
-        public override async ValueTask<FluidValue> EvaluateAsync(TemplateContext context)
+        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
-            var leftValue = await Left.EvaluateAsync(context);
-            var rightValue = await Right.EvaluateAsync(context);
-
             if (leftValue is NumberValue && rightValue is NumberValue)
             {
                 var rightNumber = rightValue.ToNumberValue();

--- a/Fluid/Ast/BinaryExpressions/EndsWithBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/EndsWithBinaryExpression.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public class EndsWithBinaryExpression : BinaryExpression
+    public sealed class EndsWithBinaryExpression : BinaryExpression
     {
         public EndsWithBinaryExpression(Expression left, Expression right) : base(left, right)
         {

--- a/Fluid/Ast/BinaryExpressions/EqualBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/EqualBinaryExpression.cs
@@ -1,25 +1,18 @@
-﻿using System.Threading.Tasks;
-using Fluid.Values;
+﻿using Fluid.Values;
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public class EqualBinaryExpression : BinaryExpression
+    public sealed class EqualBinaryExpression : BinaryExpression
     {
         public EqualBinaryExpression(Expression left, Expression right) : base(left, right)
         {
         }
 
-        public override async ValueTask<FluidValue> EvaluateAsync(TemplateContext context)
+        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
-            var leftValue = await Left.EvaluateAsync(context);
-            var rightValue = await Right.EvaluateAsync(context);
-
-            if (leftValue.Equals(rightValue))
-            {
-                return BooleanValue.True;
-            }
-
-            return BooleanValue.False;
+            return leftValue.Equals(rightValue)
+                ? BooleanValue.True
+                : BooleanValue.False;
         }
     }
 }

--- a/Fluid/Ast/BinaryExpressions/GreaterThanBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/GreaterThanBinaryExpression.cs
@@ -1,9 +1,8 @@
-﻿using System.Threading.Tasks;
-using Fluid.Values;
+﻿using Fluid.Values;
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public class GreaterThanBinaryExpression : BinaryExpression
+    public sealed class GreaterThanBinaryExpression : BinaryExpression
     {
         public GreaterThanBinaryExpression(Expression left, Expression right, bool strict) : base(left, right)
         {
@@ -12,24 +11,18 @@ namespace Fluid.Ast.BinaryExpressions
 
         public bool Strict { get; }
 
-        public override async ValueTask<FluidValue> EvaluateAsync(TemplateContext context)
+        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
-            var leftValue = await Left.EvaluateAsync(context);
-            var rightValue = await Right.EvaluateAsync(context);
-
             if (leftValue.IsNil() || rightValue.IsNil())
             {
                 if (Strict)
                 {
                     return BooleanValue.False;
                 }
-                else
-                {
-                    return leftValue.IsNil() && rightValue.IsNil()
-                        ? BooleanValue.True
-                        : BooleanValue.False
-                        ;
-                }
+
+                return leftValue.IsNil() && rightValue.IsNil()
+                    ? BooleanValue.True
+                    : BooleanValue.False;
             }
 
             if (leftValue is NumberValue)
@@ -38,16 +31,12 @@ namespace Fluid.Ast.BinaryExpressions
                 {
                     return leftValue.ToNumberValue() > rightValue.ToNumberValue()
                         ? BooleanValue.True
-                        : BooleanValue.False
-                        ;
+                        : BooleanValue.False;
                 }
-                else
-                {
-                    return leftValue.ToNumberValue() >= rightValue.ToNumberValue()
-                        ? BooleanValue.True
-                        : BooleanValue.False
-                        ;
-                }
+
+                return leftValue.ToNumberValue() >= rightValue.ToNumberValue()
+                    ? BooleanValue.True
+                    : BooleanValue.False;
             }
 
             return NilValue.Instance;

--- a/Fluid/Ast/BinaryExpressions/LowerThanExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/LowerThanExpression.cs
@@ -1,9 +1,8 @@
-﻿using System.Threading.Tasks;
-using Fluid.Values;
+﻿using Fluid.Values;
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public class LowerThanExpression : BinaryExpression
+    public sealed class LowerThanExpression : BinaryExpression
     {
         public LowerThanExpression(Expression left, Expression right, bool strict) : base(left, right)
         {
@@ -12,24 +11,18 @@ namespace Fluid.Ast.BinaryExpressions
 
         public bool Strict { get; }
 
-        public override async ValueTask<FluidValue> EvaluateAsync(TemplateContext context)
+        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
-            var leftValue = await Left.EvaluateAsync(context);
-            var rightValue = await Right.EvaluateAsync(context);
-
             if (leftValue.IsNil() || rightValue.IsNil())
             {
                 if (Strict)
                 {
                     return BooleanValue.False;
                 }
-                else
-                {
-                    return leftValue.IsNil() && rightValue.IsNil()
-                        ? BooleanValue.True
-                        : BooleanValue.False
-                        ;
-                }
+
+                return leftValue.IsNil() && rightValue.IsNil()
+                    ? BooleanValue.True
+                    : BooleanValue.False;
             }
 
             if (leftValue is NumberValue)
@@ -38,16 +31,12 @@ namespace Fluid.Ast.BinaryExpressions
                 {
                     return leftValue.ToNumberValue() < rightValue.ToNumberValue()
                         ? BooleanValue.True
-                        : BooleanValue.False
-                        ;
+                        : BooleanValue.False;
                 }
-                else
-                {
-                    return leftValue.ToNumberValue() <= rightValue.ToNumberValue()
-                        ? BooleanValue.True
-                        : BooleanValue.False
-                        ;
-                }
+
+                return leftValue.ToNumberValue() <= rightValue.ToNumberValue()
+                    ? BooleanValue.True
+                    : BooleanValue.False;
             }
 
             return NilValue.Instance;

--- a/Fluid/Ast/BinaryExpressions/ModuloBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/ModuloBinaryExpression.cs
@@ -1,25 +1,18 @@
-﻿using System.Threading.Tasks;
-using Fluid.Values;
+﻿using Fluid.Values;
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public class ModuloBinaryExpression : BinaryExpression
+    public sealed class ModuloBinaryExpression : BinaryExpression
     {
         public ModuloBinaryExpression(Expression left, Expression right) : base(left, right)
         {
         }
 
-        public override async ValueTask<FluidValue> EvaluateAsync(TemplateContext context)
+        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
-            var leftValue = await Left.EvaluateAsync(context);
-            var rightValue = await Right.EvaluateAsync(context);
-
-            if (leftValue is NumberValue && rightValue is NumberValue)
-            {
-                return NumberValue.Create(leftValue.ToNumberValue() % rightValue.ToNumberValue());
-            }
-
-            return NilValue.Instance;
+            return leftValue is NumberValue && rightValue is NumberValue
+                ? NumberValue.Create(leftValue.ToNumberValue() % rightValue.ToNumberValue())
+                : NilValue.Instance;
         }
     }
 }

--- a/Fluid/Ast/BinaryExpressions/MultiplyBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/MultiplyBinaryExpression.cs
@@ -1,25 +1,18 @@
-﻿using System.Threading.Tasks;
-using Fluid.Values;
+﻿using Fluid.Values;
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public class MultiplyBinaryExpression : BinaryExpression
+    public sealed class MultiplyBinaryExpression : BinaryExpression
     {
         public MultiplyBinaryExpression(Expression left, Expression right) : base(left, right)
         {
         }
 
-        public override async ValueTask<FluidValue> EvaluateAsync(TemplateContext context)
+        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
-            var leftValue = await Left.EvaluateAsync(context);
-            var rightValue = await Right.EvaluateAsync(context);
-
-            if (leftValue is NumberValue && rightValue is NumberValue)
-            {
-                return NumberValue.Create(leftValue.ToNumberValue() * rightValue.ToNumberValue());
-            }
-
-            return NilValue.Instance;
+            return leftValue is NumberValue && rightValue is NumberValue
+                ? NumberValue.Create(leftValue.ToNumberValue() * rightValue.ToNumberValue())
+                : NilValue.Instance;
         }
     }
 }

--- a/Fluid/Ast/BinaryExpressions/NotEqualBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/NotEqualBinaryExpression.cs
@@ -1,25 +1,18 @@
-﻿using System.Threading.Tasks;
-using Fluid.Values;
+﻿using Fluid.Values;
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public class NotEqualBinaryExpression : BinaryExpression
+    public sealed class NotEqualBinaryExpression : BinaryExpression
     {
         public NotEqualBinaryExpression(Expression left, Expression right) : base(left, right)
         {
         }
 
-        public override async ValueTask<FluidValue> EvaluateAsync(TemplateContext context)
+        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
-            var leftValue = await Left.EvaluateAsync(context);
-            var rightValue = await Right.EvaluateAsync(context);
-
-            if (leftValue.Equals(rightValue))
-            {
-                return BooleanValue.False;
-            }
-
-            return BooleanValue.True;
+            return leftValue.Equals(rightValue)
+                ? BooleanValue.False 
+                : BooleanValue.True;
         }
     }
 }

--- a/Fluid/Ast/BinaryExpressions/OrBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/OrBinaryExpression.cs
@@ -1,33 +1,16 @@
-﻿using System.Threading.Tasks;
-using Fluid.Values;
+﻿using Fluid.Values;
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public class OrBinaryExpression : BinaryExpression
+    public sealed class OrBinaryExpression : BinaryExpression
     {
         public OrBinaryExpression(Expression left, Expression right) : base(left, right)
         {
         }
 
-        public override ValueTask<FluidValue> EvaluateAsync(TemplateContext context)
+        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
-            static async ValueTask<FluidValue> Awaited(ValueTask<FluidValue> leftTask, ValueTask<FluidValue> rightTask)
-            {
-                var leftValue = await leftTask;
-                var rightValue = await rightTask;
-
-                return BooleanValue.Create(leftValue.ToBooleanValue() || rightValue.ToBooleanValue());
-            }
-
-            var leftTask = Left.EvaluateAsync(context);
-            var rightTask = Right.EvaluateAsync(context);
-
-            if (leftTask.IsCompletedSuccessfully && rightTask.IsCompletedSuccessfully)
-            {
-                return BooleanValue.Create(leftTask.Result.ToBooleanValue() || rightTask.Result.ToBooleanValue());
-            }
-
-            return Awaited(leftTask, rightTask);
+            return BooleanValue.Create(leftValue.ToBooleanValue() || rightValue.ToBooleanValue());
         }
     }
 }

--- a/Fluid/Ast/BinaryExpressions/SubstractBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/SubstractBinaryExpression.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using Fluid.Values;
+﻿using Fluid.Values;
 
 namespace Fluid.Ast.BinaryExpressions
 {
@@ -9,17 +8,11 @@ namespace Fluid.Ast.BinaryExpressions
         {
         }
 
-        public override async ValueTask<FluidValue> EvaluateAsync(TemplateContext context)
+        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
-            var leftValue = await Left.EvaluateAsync(context);
-            var rightValue = await Right.EvaluateAsync(context);
-
-            if (leftValue is NumberValue && rightValue is NumberValue)
-            {
-                return NumberValue.Create(leftValue.ToNumberValue() - rightValue.ToNumberValue());
-            }
-
-            return NilValue.Instance;
+            return leftValue is NumberValue && rightValue is NumberValue
+                ? NumberValue.Create(leftValue.ToNumberValue() - rightValue.ToNumberValue())
+                : NilValue.Instance;
         }
     }
 }

--- a/Fluid/Values/FluidValue.cs
+++ b/Fluid/Values/FluidValue.cs
@@ -106,25 +106,24 @@ namespace Fluid.Values
                 return fluidValue;
             }
 
-            if (options.ValueConverters.Count > 0)
+            var converters = options.ValueConverters;
+            for (var i = 0; i < converters.Count; i++)
             {
-                foreach (var valueConverter in options.ValueConverters)
+                var valueConverter = converters[i];
+                var result = valueConverter(value);
+
+                if (result != null)
                 {
-                    var result = valueConverter(value);
-
-                    if (result != null)
+                    // If a converter returned a FluidValue instance use it directly
+                    if (result is FluidValue resultFluidValue)
                     {
-                        // If a converter returned a FluidValue instance use it directly
-                        if (result is FluidValue resultFluidValue)
-                        {
-                            return resultFluidValue;
-                        }
-
-                        // Otherwise stop custom conversions
-
-                        value = result;
-                        break;
+                        return resultFluidValue;
                     }
+
+                    // Otherwise stop custom conversions
+
+                    value = result;
+                    break;
                 }
             }
 


### PR DESCRIPTION
Spotted some things when profiling Orchard Agency, so let's work the magic.

* Use generic pattern in BinaryExpression to reduce state machines
* improve FluidValue conversion
* remove state machine in FluidParserExtensions

## Fluid.Benchmarks.TagBenchmarks

| **Diff**|Method|Mean|Error|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------:|-------|-------:|-------:|-------:|-------:|
| Old |BinaryExpressions_Parse|10.022 μs|0.0235 μs|0.8392|0.0000|0.0000|3560 B|
| **New** |	| **9,969.8 ns (-3%)** | **32.87 ns** | **0.8392 (0%)** | **0.0000** | **0.0000** | **3560 B (0%)** |
| Old |BinaryExpressions_Render|1.352 μs|0.0032 μs|0.0134|0.0000|0.0000|56 B|
| **New** |	| **971.0 ns (-30%)** | **3.56 ns** | **0.0134 (0%)** | **0.0000** | **0.0000** | **56 B (0%)** |


