### PR TITLE
IncludeStatement_ReevaluatePathOnEachWriteToAsync

### DIFF
--- a/Fluid/Ast/IncludeStatement.cs
+++ b/Fluid/Ast/IncludeStatement.cs
@@ -31,14 +31,15 @@ namespace Fluid.Ast
         {
             context.IncrementSteps();
 
-            if (_template == null)
-            {
-                var relativePath = (await Path.EvaluateAsync(context)).ToStringValue();
-                if (!relativePath.EndsWith(ViewExtension, StringComparison.OrdinalIgnoreCase))
-                {
-                    relativePath += ViewExtension;
-                }
+            var relativePath = (await Path.EvaluateAsync(context)).ToStringValue();
 
+            if (!relativePath.EndsWith(ViewExtension, StringComparison.OrdinalIgnoreCase))
+            {
+                relativePath += ViewExtension;
+            }
+
+            if (_template == null || !string.Equals(_identifier, System.IO.Path.GetFileNameWithoutExtension(relativePath), StringComparison.OrdinalIgnoreCase))
+            {
                 var fileProvider = context.Options.FileProvider;
 
                 var fileInfo = fileProvider.GetFileInfo(relativePath);


### PR DESCRIPTION
Simple but probably inefficient fix for the include statement not re-evaluating the Path which could be based on a MemberExpression that changes during a For...In loop.  Added unit test to demonstrate the problem, but feel additional tests involving a mock IFileProvider where we can test the number of times the file is resolved is required to prove that if the Path doesn't change the template is re-used and not reloaded.  I'm using the _identifier to compare the current path against the loaded path, again this could be better as I'm duplicating the "how to make an _identifier" logic, but I didn't want to change too much at this stage.  We could also reduce the amount of work to determine the path in the repeat cases, maybe even testing whether the path is a Literal or not.  I could have also probably moved the IF to append the view extension inside the IF (template == null...) block.  I also thought it might be useful to have a small cache of loaded templates but this is probably specific to my use case.

My example liquid for this problem:

{% for part in Item.Parts %}
   {% include part.TemplateName, Item:part %}
{% endfor %}

In this example a value of the loop item provides the name of the template to load.  In the current version, all Item.Parts are rendered using the first template instead of the one they specify.

I actually created a nasty expression block that uses reflection to null the _template field on the IncludeStatement and wrapped that around the {% include %} to temporarily resolve it.

I think I'm probably abusing Liquid, but it's a really powerful use case for me where I'm dynamically create HTML from an object tree of "Parts"
 