### PR TITLE
Prevent stack overflow in MiscFilters.WriteJson

### DIFF
--- a/Fluid.Tests/MiscFiltersTests.cs
+++ b/Fluid.Tests/MiscFiltersTests.cs
@@ -530,7 +530,7 @@ namespace Fluid.Tests
 
             var result = await MiscFilters.Json(input, new FilterArguments(), new TemplateContext(to));
 
-            Assert.Equal("{\"Name\":\"Object1\",\"NodeRef\":{\"Name\":\"Child1\",\"NodeRef\":{\"Name\":\"Object1\",\"NodeRef\":{\"Name\":\"Child1\",\"NodeRef\":\"Cycle detected...stopping\"}}}}", result.ToStringValue());
+            Assert.Equal("{\"Name\":\"Object1\",\"NodeRef\":{\"Name\":\"Child1\",\"NodeRef\":\"circular reference detected.\"}}", result.ToStringValue());
         }
 
         [Theory]

--- a/Fluid/Filters/MiscFilters.cs
+++ b/Fluid/Filters/MiscFilters.cs
@@ -628,7 +628,8 @@ namespace Fluid.Filters
 
                             writer.WritePropertyName(name);
                             stack.Add(obj);
-                            await WriteJson(writer, fluidValue, ctx, new HashSet<object>(stack));
+                            await WriteJson(writer, fluidValue, ctx, stack);
+                            stack.Remove(obj);
                         }
 
                         writer.WriteEndObject();

--- a/Fluid/Filters/MiscFilters.cs
+++ b/Fluid/Filters/MiscFilters.cs
@@ -614,13 +614,10 @@ namespace Fluid.Filters
                                 value = access.Get(obj, name, ctx);
                             }
 
-                            if (value is object)
+                            stack ??= new HashSet<object>();
+                            if (stack.Contains(value))
                             {
-                                stack ??= new HashSet<object>();
-                                if (stack.Contains(value))
-                                {
-                                    value = "circular reference detected.";
-                                }
+                                value = "circular reference detected.";
                             }
 
                             var fluidValue = FluidValue.Create(value, ctx.Options);


### PR DESCRIPTION
Adds in a check for a cycle when writing json for an object.  Currently, a stack overflow exception is thrown.

The fix should allow multiple properties in the object graph to have the same references, it simply stops following a specific branch of the graph when a property value results in an object reference that has been traversed more than once already within the same graph path.

Fixes #351