### PR TITLE
Skip write-only property

### DIFF
--- a/Fluid.Tests/MemberAccessStrategyTests.cs
+++ b/Fluid.Tests/MemberAccessStrategyTests.cs
@@ -191,6 +191,15 @@ namespace Fluid.Tests
             var template = _parser.Parse("{{Firstname}}{{Lastname}}");
             Assert.Equal("John", template.Render(new TemplateContext(john, options, false)));
         }
+        [Fact]
+        public void ShouldSkipWriteOnlyProperty()
+        {
+            var strategy = new DefaultMemberAccessStrategy();
+
+            strategy.Register<Class1>();
+
+            Assert.Null(strategy.GetAccessor(typeof(Class1), nameof(Class1.WriteOnlyProperty)));
+        }
     }
 
     public class Class1
@@ -205,5 +214,6 @@ namespace Fluid.Tests
         public string Property1 { get; set; }
         public int Property2 { get; set; }
         public Task<string> Property3 { get; set; }
+        public string WriteOnlyProperty { private get; set; }
     }
 }

--- a/Fluid/MemberAccessStrategyExtensions.cs
+++ b/Fluid/MemberAccessStrategyExtensions.cs
@@ -22,7 +22,7 @@ namespace Fluid
 
                 foreach (var propertyInfo in key.Type.GetTypeInfo().GetProperties(BindingFlags.Public | BindingFlags.Instance))
                 {
-                    if (propertyInfo.GetIndexParameters().Length > 0)
+                    if (propertyInfo.GetIndexParameters().Length > 0 || !propertyInfo.CanRead)
                     {
                         // Indexed property...
                         continue;

--- a/Fluid/MemberAccessStrategyExtensions.cs
+++ b/Fluid/MemberAccessStrategyExtensions.cs
@@ -22,9 +22,15 @@ namespace Fluid
 
                 foreach (var propertyInfo in key.Type.GetTypeInfo().GetProperties(BindingFlags.Public | BindingFlags.Instance))
                 {
-                    if (propertyInfo.GetIndexParameters().Length > 0 || !propertyInfo.CanRead)
+                    if (propertyInfo.GetIndexParameters().Length > 0)
                     {
                         // Indexed property...
+                        continue;
+                    }
+
+                    if (propertyInfo.GetGetMethod() == null)
+                    {
+                        //Write-only property...
                         continue;
                     }
 


### PR DESCRIPTION
NullReferenceException is thrown when the Model has a write-only property.
```
public class Test
{
    public Int32 Id { protected get;set;}
}
```