### PR TITLE
Convert Dictionary<string, T> to FluidValue automatically

### DIFF
--- a/Fluid.Tests/TemplateContextTests.cs
+++ b/Fluid.Tests/TemplateContextTests.cs
@@ -98,6 +98,8 @@ namespace Fluid.Tests
         [Fact]
         public void SegmentAccessorCacheShouldVaryByType()
         {
+            // NB: Based on a previous implementation what would cache accessors too aggressively
+
             FluidParser parser = new();
             var options = new TemplateOptions { MemberAccessStrategy = UnsafeMemberAccessStrategy.Instance };
             var template = parser.Parse("{% if Model1 %}{{ Model1.Name }}{% endif %}");

--- a/Fluid/Ast/IndexerSegment.cs
+++ b/Fluid/Ast/IndexerSegment.cs
@@ -17,22 +17,5 @@ namespace Fluid.Ast
             var index = await Expression.EvaluateAsync(context);
             return await value.GetIndexAsync(index, context);
         }
-
-        public override ValueTask<FluidValue> ResolveAsync(Scope value, TemplateContext context)
-        {
-            static async ValueTask<FluidValue> Awaited(ValueTask<FluidValue> valueTask, Scope s)
-            {
-                var index = await valueTask;
-                return s.GetIndex(index);
-            }
-
-            var task = Expression.EvaluateAsync(context);
-            if (task.IsCompletedSuccessfully)
-            {
-                return new ValueTask<FluidValue>(value.GetIndex(task.Result));
-            }
-
-            return Awaited(task, value);
-        }
     }
 }

--- a/Fluid/Ast/MemberSegment.cs
+++ b/Fluid/Ast/MemberSegment.cs
@@ -9,10 +9,5 @@ namespace Fluid.Ast
         /// Resolves the member of a <see cref="FluidValue"/> instance.
         /// </summary>
         public abstract ValueTask<FluidValue> ResolveAsync(FluidValue value, TemplateContext context);
-
-        /// <summary>
-        /// Resolves the member of a <see cref="Scope"/> or the context Model.
-        /// </summary>
-        public abstract ValueTask<FluidValue> ResolveAsync(Scope value, TemplateContext context);
     }
 }

--- a/Fluid/TemplateContext.cs
+++ b/Fluid/TemplateContext.cs
@@ -31,8 +31,15 @@ namespace Fluid
                 ExceptionHelper.ThrowArgumentNullException(nameof(model));
             }
 
-            Model = model;
-            AllowModelMembers = allowModelMembers;
+            if (model is FluidValue fluidValue)
+            {
+                Model = fluidValue;
+            }
+            else
+            {
+                Model = FluidValue.Create(model, options);
+                AllowModelMembers = allowModelMembers;
+            }
         }
 
         /// <summary>
@@ -61,8 +68,15 @@ namespace Fluid
                 ExceptionHelper.ThrowArgumentNullException(nameof(model));
             }
 
-            Model = model;
-            AllowModelMembers = allowModelMembers;
+            if (model is FluidValue fluidValue)
+            {
+                Model = fluidValue;
+            }
+            else
+            {
+                Model = FluidValue.Create(model, TemplateOptions.Default);
+                AllowModelMembers = allowModelMembers;
+            }
         }
 
         /// <summary>
@@ -111,7 +125,7 @@ namespace Fluid
         /// Gets or sets a model object that is used to resolve properties in a template. This object is used if local and
         /// global scopes are unsuccessfull.
         /// </summary>
-        public object Model { get; set; }
+        public FluidValue Model { get; }
 
         /// <summary>
         /// Whether the direct properties of the Model can be accessed without being registered. Default is <code>true</code>.

--- a/Fluid/Values/DictionaryDictionaryFluidIndexable.cs
+++ b/Fluid/Values/DictionaryDictionaryFluidIndexable.cs
@@ -22,7 +22,11 @@ namespace Fluid.Values
             {
                 foreach (var key in _dictionary.Keys)
                 {
-                    yield return key.ToString();
+                    // Only handle string keys since this is what TryGetValue returns
+                    if (key is string)
+                    {
+                        yield return key.ToString();
+                    }
                 }
             }
         }

--- a/Fluid/Values/DictionaryValue.cs
+++ b/Fluid/Values/DictionaryValue.cs
@@ -61,36 +61,12 @@ namespace Fluid.Values
                 return new ValueTask<FluidValue>(NumberValue.Create(_value.Count));
             }
 
-            object value = null;
-
-            // NOTE: This code block doesn't seem to make any sense for a dictionary, just keeping it
-            // as a comment in case it breaks something at some point.
-
-            //var accessor = context.MemberAccessStrategy.GetAccessor(_value.GetType(), name);
-
-            //if (accessor != null)
-            //{
-            //    if (accessor is IAsyncMemberAccessor asyncAccessor)
-            //    {
-            //        value = await asyncAccessor.GetAsync(_value,  context);
-            //    }
-            //    else
-            //    {
-            //        value = accessor.Get(_value,  context);
-            //    }
-            //}
-
-            if (value == null)
+            if (!_value.TryGetValue(name, out var fluidValue))
             {
-                if (!_value.TryGetValue(name, out var fluidValue))
-                {
-                    return new ValueTask<FluidValue>(NilValue.Instance);
-                }
-
-                return new ValueTask<FluidValue>(fluidValue);
+                return new ValueTask<FluidValue>(NilValue.Instance);
             }
 
-            return new ValueTask<FluidValue>(FluidValue.Create(value, context.Options));
+            return new ValueTask<FluidValue>(fluidValue);
         }
 
         protected override FluidValue GetIndex(FluidValue index, TemplateContext context)

--- a/Fluid/Values/FluidValues.cs
+++ b/Fluid/Values/FluidValues.cs
@@ -2,15 +2,15 @@
 {
     public enum FluidValues
     {
-        Nil,
-        Empty,
-        Blank,
-        Array,
-        Boolean,
-        Dictionary,
-        Number,
-        Object,
-        String,
-        DateTime
+        Nil = 0,
+        Empty = 1,
+        Blank = 2,
+        Array = 3,
+        Boolean = 4,
+        Dictionary = 5,
+        Number = 6,
+        Object = 7,
+        String = 8,
+        DateTime = 9,
     }
 }

--- a/Fluid/Values/ObjectDictionaryFluidIndexable.cs
+++ b/Fluid/Values/ObjectDictionaryFluidIndexable.cs
@@ -2,12 +2,12 @@
 
 namespace Fluid.Values
 {
-    public sealed class ObjectDictionaryFluidIndexable : IFluidIndexable
+    public sealed class ObjectDictionaryFluidIndexable<T> : IFluidIndexable
     {
-        private readonly IDictionary<string, object> _dictionary;
+        private readonly IDictionary<string, T> _dictionary;
         private readonly TemplateOptions _options;
 
-        public ObjectDictionaryFluidIndexable(IDictionary<string, object> dictionary, TemplateOptions options)
+        public ObjectDictionaryFluidIndexable(IDictionary<string, T> dictionary, TemplateOptions options)
         {
             _dictionary = dictionary;
             _options = options;

--- a/README.md
+++ b/README.md
@@ -189,27 +189,16 @@ options.MemberAccessStrategy.Register<Person>("Firstname", "Lastname");
 
 This will provide a method to intercept when a member is accessed and either return a custom value or prevent it.
 
-This example demonstrates how to intercept calls to a `JObject` and return the corresponding property.
+NB: If the model implements `IDictionary` or any similar generic dictionary types the dictionary access has priority over the custom accessors.
+
+This example demonstrates how to intercept calls to a `Person` and always return the same property.
 
 ```csharp
+var model = new Person { Name = "Bill" };
+
 var options = new TemplateOptions();
-options.MemberAccessStrategy.Register<JObject, object>((obj, name) => obj[name]);
+options.MemberAccessStrategy.Register<Person, object>((obj, name) => obj.Name);
 ``` 
-
-Another common pattern is to pass a dictionary as the model to allow members to represent the keys of the dictionary:
-
-```csharp
-var options = new TemplateOptions();
-options.MemberAccessStrategy.Register<IDictionary, object>((obj, name) => obj[name]);
-
-var model = new Dictionary<string, object>();
-model.Add("Firstname", "Bill");
-model.Add("Lastname", "Gates");
-
-var template = _parser.Parse("{{Firstname}} {{Lastname}}");
-
-template.Render(new TemplateContext(model, options));
-```
 
 ### Inheritance
 
@@ -272,35 +261,6 @@ options.ValueConverters.Add((value) => value is IUser user ? user.Name : null);
 ```
 
 > Note: Type mapping are defined globally for the application.
-
-<br>
-
-## Using Json.NET object in models
-
-The classes that are used in Json.NET don't have direct named properties like classes, which makes them unusable out of the box
-in a Liquid template.
-
-To remedy that we can configure Fluid to map names to `JObject` properties, and convert `JValue` objects to the ones used by Fluid.
-
-```csharp
-var options = new TemplateOptions();
-
-// When a property of a JObject value is accessed, try to look into its properties
-options.MemberAccessStrategy.Register<JObject, object>((source, name) => source[name]);
-
-// Convert JToken to FluidValue
-options.ValueConverters.Add(x => x is JObject o ? new ObjectValue(o) : null);
-options.ValueConverters.Add(x => x is JValue v ? v.Value : null);
-
-var model = JObject.Parse("{\"Name\": \"Bill\"}");
-
-var parser = new FluidParser();
-
-parser.TryParse("His name is {{ Name }}", out var template);
-var context = new TemplateContext(model, options);
-
-Console.WriteLine(template.Render(context));
-```
 
 <br>
 


### PR DESCRIPTION
This change removed the need to define custom mappings for `JObject` and other dictionary based structures.
It's also fixing the difference in converting the `Model` property and objects that are returned when accessing its properties, which is that the `Model` would not be converted to a `FluidValue` unlike its properties. With this PR the model is also converted.