### PR TITLE
Json filter should skip static properties.

### DIFF
--- a/Fluid.Tests/MiscFiltersTests.cs
+++ b/Fluid.Tests/MiscFiltersTests.cs
@@ -607,6 +607,18 @@ namespace Fluid.Tests
             Assert.Equal("{\"Name\":\"MultipleNode1\",\"Node1\":{\"Name\":\"Object1\",\"NodeRef\":{\"Name\":\"Child1\",\"NodeRef\":\"circular reference detected.\"}},\"Node2\":{\"Name\":\"Object1\",\"NodeRef\":{\"Name\":\"Child1\",\"NodeRef\":\"circular reference detected.\"}}}", result.ToStringValue());
         }
 
+        [Fact]
+        public async Task JsonShouldIgnoreStaticMembers()
+        {
+            var model = new JsonWithStaticMember { Id = 100 };
+            var input = FluidValue.Create(model, TemplateOptions.Default);
+            var options = new TemplateOptions();
+            options.MemberAccessStrategy.Register<JsonWithStaticMember>();
+
+            var result = await MiscFilters.Json(input, new FilterArguments(), new TemplateContext(options));
+            Assert.Equal("{\"Id\":100}", result.ToStringValue());
+        }
+
         [Theory]
         [InlineData("", "", "", "0")]
         [InlineData(123456, "", "", "123456")]
@@ -753,6 +765,12 @@ namespace Fluid.Tests
             public string Visible { get; set; } = "Visible";
             public string Null { get; set; }
             public string Hidden { get; set; } = "Hidden";
+        }
+
+        private class JsonWithStaticMember
+        {
+            public static Int32 StaticMember { get; set; } = 1;
+            public Int32 Id { get; set; }
         }
     }
 }

--- a/Fluid.Tests/MiscFiltersTests.cs
+++ b/Fluid.Tests/MiscFiltersTests.cs
@@ -769,8 +769,8 @@ namespace Fluid.Tests
 
         private class JsonWithStaticMember
         {
-            public static Int32 StaticMember { get; set; } = 1;
-            public Int32 Id { get; set; }
+            public static int StaticMember { get; set; } = 1;
+            public int Id { get; set; }
         }
     }
 }

--- a/Fluid/Filters/MiscFilters.cs
+++ b/Fluid/Filters/MiscFilters.cs
@@ -9,6 +9,7 @@ using TimeZoneConverter;
 using System.Threading.Tasks;
 using System.Text;
 using System.IO;
+using System.Reflection;
 
 namespace Fluid.Filters
 {
@@ -652,7 +653,7 @@ namespace Fluid.Filters
                     {
                         writer.WriteStartObject();
                         var type = obj.GetType();
-                        var properties = type.GetProperties();
+                        var properties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public);
                         var strategy = ctx.Options.MemberAccessStrategy;
 
                         var conv = strategy.MemberNameStrategy;


### PR DESCRIPTION
The nonparametric GetProperties() method returns the static properties together. If a custom MemberAccessStrategy is applied to an object, unexpected member names will be passed in. Therefore, JSON filters should skip these static properties.