### PR TITLE
Support single line liquid tags

### DIFF
--- a/Fluid.Tests/ParserTests.cs
+++ b/Fluid.Tests/ParserTests.cs
@@ -964,5 +964,15 @@ class  {
             var rendered = template.Render();
             Assert.Contains("WELCOME TO THE LIQUID TAG", rendered);
         }
+
+        [Fact]
+        public void ShouldParseLiquidTagInline()
+        {
+            var source = @"{% liquid if cool echo 'cool' else echo 'not cool' endif %}";
+
+            Assert.True(_parser.TryParse(source, out var template, out var errors), errors);
+            var rendered = template.Render();
+            Assert.Contains("not cool", rendered);
+        }
     }
 }

--- a/Fluid/Ast/BinaryExpressions/EndsWithBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/EndsWithBinaryExpression.cs
@@ -1,5 +1,4 @@
 ﻿using Fluid.Values;
-using System.Threading.Tasks;
 
 namespace Fluid.Ast.BinaryExpressions
 {
@@ -9,21 +8,19 @@ namespace Fluid.Ast.BinaryExpressions
         {
         }
 
-        public override async ValueTask<FluidValue> EvaluateAsync(TemplateContext context)
+        internal override FluidValue Evaluate(FluidValue left, FluidValue right)
         {
-            var leftValue = await Left.EvaluateAsync(context);
-            var rightValue = await Right.EvaluateAsync(context);
-
-            if (leftValue is ArrayValue)
+            if (left is ArrayValue arrayValue)
             {
-                var first = await leftValue.GetValueAsync("last", context);
-                return first.Equals(rightValue)
+                var values = arrayValue.Values;
+                var last = values.Length > 0 ? values[values.Length - 1] : NilValue.Instance;
+                return last.Equals(right)
                         ? BooleanValue.True
                         : BooleanValue.False;
             }
             else
             {
-                return leftValue.ToStringValue().EndsWith(rightValue.ToStringValue())
+                return left.ToStringValue().EndsWith(right.ToStringValue())
                         ? BooleanValue.True
                         : BooleanValue.False;
             }

--- a/Fluid/Ast/MemberExpression.cs
+++ b/Fluid/Ast/MemberExpression.cs
@@ -27,7 +27,7 @@ namespace Fluid.Ast
 
             // Search the initial segment in the local scope first
 
-            FluidValue value = context.LocalScope.GetValue(initial.Identifier);
+            var value = context.LocalScope.GetValue(initial.Identifier);
 
             // If it was not successful, try again with a member of the model
 

--- a/Fluid/Ast/RangeExpression.cs
+++ b/Fluid/Ast/RangeExpression.cs
@@ -1,9 +1,6 @@
-﻿using Fluid.Values;
-using System.Threading.Tasks;
-
-namespace Fluid.Ast
+﻿namespace Fluid.Ast
 {
-    public class RangeExpression : Expression
+    public class RangeExpression
     {
         public RangeExpression(Expression from, Expression to)
         {
@@ -14,10 +11,5 @@ namespace Fluid.Ast
         public Expression From { get; }
 
         public Expression To { get; }
-
-        public override ValueTask<FluidValue> EvaluateAsync(TemplateContext context)
-        {
-            throw new System.NotImplementedException();
-        }
     }
 }

--- a/Fluid/FluidParserExtensions.cs
+++ b/Fluid/FluidParserExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using Fluid.Ast;
 using Fluid.Parser;
-using Parlot.Fluent;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Fluid/Parser/TagParsers.cs
+++ b/Fluid/Parser/TagParsers.cs
@@ -113,6 +113,7 @@ namespace Fluid.Parser
 
                         while (Character.IsWhiteSpace(cursor.Current))
                         {
+                            newLineIsPresent = true;
                             cursor.Advance();
                         }
 


### PR DESCRIPTION
[DO NOT MERGE]

This is just to track the feature which I find useful, to be able to used inlined liquid tags instead of requiring a new line before each tag.

Right now Liquid 5.1.0 doesn't support this feature.

```
{% liquid if name == 'tobi' 
    echo 'hello tobi'
    endif %}
```

Could then be written 

```
{% liquid if name == 'tobi' echo 'hello tobi' endif %}
```