### PR TITLE
Expose TryGetDateTimeInput to be usable by custom filters

### DIFF
--- a/Fluid/Filters/MiscFilters.cs
+++ b/Fluid/Filters/MiscFilters.cs
@@ -264,7 +264,7 @@ namespace Fluid.Filters
 
         public static ValueTask<FluidValue> ChangeTimeZone(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            if (!TryGetDateTimeInput(input, context, out var value))
+            if (!input.TryGetDateTimeInput(context, out var value))
             {
                 return NilValue.Instance;
             }
@@ -285,7 +285,7 @@ namespace Fluid.Filters
 
         public static ValueTask<FluidValue> Date(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            if (!TryGetDateTimeInput(input, context, out var value))
+            if (!input.TryGetDateTimeInput(context, out var value))
             {
                 return NilValue.Instance;
             }
@@ -520,7 +520,7 @@ namespace Fluid.Filters
 
         public static ValueTask<FluidValue> FormatDate(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            if (!TryGetDateTimeInput(input, context, out var value))
+            if (!input.TryGetDateTimeInput(context, out var value))
             {
                 return NilValue.Instance;
             }
@@ -542,7 +542,7 @@ namespace Fluid.Filters
             return new StringValue(value.ToString(format, culture));
         }
 
-        private static bool TryGetDateTimeInput(FluidValue input, TemplateContext context, out DateTimeOffset result)
+        public static bool TryGetDateTimeInput(this FluidValue input, TemplateContext context, out DateTimeOffset result)
         {
             result = context.Now();
 

--- a/Fluid/Filters/MiscFilters.cs
+++ b/Fluid/Filters/MiscFilters.cs
@@ -9,60 +9,17 @@ using TimeZoneConverter;
 using System.Threading.Tasks;
 using System.Text;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 
 namespace Fluid.Filters
 {
     public static class MiscFilters
     {
-        private static readonly string[] DefaultFormats = {
-            "yyyy-MM-ddTHH:mm:ss.FFF",
-            "yyyy-MM-ddTHH:mm:ss",
-            "yyyy-MM-ddTHH:mm",
-            "yyyy-MM-dd",
-            "yyyy-MM",
-            "yyyy"
-        };
-
-        private static readonly string[] SecondaryFormats = {
-            // Formats used in DatePrototype toString methods
-            "ddd MMM dd yyyy HH:mm:ss 'GMT'K",
-            "ddd MMM dd yyyy",
-            "HH:mm:ss 'GMT'K",
-
-            // standard formats
-            "yyyy-M-dTH:m:s.FFFK",
-            "yyyy/M/dTH:m:s.FFFK",
-            "yyyy-M-dTH:m:sK",
-            "yyyy/M/dTH:m:sK",
-            "yyyy-M-dTH:mK",
-            "yyyy/M/dTH:mK",
-            "yyyy-M-d H:m:s.FFFK",
-            "yyyy/M/d H:m:s.FFFK",
-            "yyyy-M-d H:m:sK",
-            "yyyy/M/d H:m:sK",
-            "yyyy-M-d H:mK",
-            "yyyy/M/d H:mK",
-            "yyyy-M-dK",
-            "yyyy/M/dK",
-            "yyyy-MK",
-            "yyyy/MK",
-            "yyyyK",
-            "THH:mm:ss.FFFK",
-            "THH:mm:ssK",
-            "THH:mmK",
-            "THHK"
-        };
-
         private static readonly Regex HtmlCaseRegex =
             new Regex(
                 "(?<!^)((?<=[a-zA-Z0-9])[A-Z][a-z])|((?<=[a-z])[A-Z])",
                 RegexOptions.None,
                 TimeSpan.FromMilliseconds(500));
-
-        private const string Now = "now";
-        private const string Today = "today";
 
         public static FilterCollection WithMiscFilters(this FilterCollection filters)
         {
@@ -540,81 +497,6 @@ namespace Fluid.Filters
             }
 
             return new StringValue(value.ToString(format, culture));
-        }
-
-        public static bool TryGetDateTimeInput(this FluidValue input, TemplateContext context, out DateTimeOffset result)
-        {
-            result = context.Now();
-
-            if (input.Type == FluidValues.String)
-            {
-                var stringValue = input.ToStringValue();
-
-                if (stringValue == Now || stringValue == Today)
-                {
-                    return true;
-                }
-                else
-                {
-                    var success = true;
-
-                    if (!DateTime.TryParseExact(stringValue, DefaultFormats, context.CultureInfo, DateTimeStyles.None, out var dateTime))
-                    {
-                        if (!DateTime.TryParseExact(stringValue, SecondaryFormats, context.CultureInfo, DateTimeStyles.None, out dateTime))
-                        {
-                            if (!DateTime.TryParse(stringValue, context.CultureInfo, DateTimeStyles.None, out dateTime))
-                            {
-                                if (!DateTime.TryParse(stringValue, CultureInfo.InvariantCulture, DateTimeStyles.None, out dateTime))
-                                {
-                                    success = false;
-                                }
-                            }
-                        }
-                    }
-
-                    // If no timezone is specified, assume local using the configured timezone
-                    if (success)
-                    {
-                        if (dateTime.Kind == DateTimeKind.Unspecified)
-                        {
-                            result = new DateTimeOffset(dateTime, context.TimeZone.GetUtcOffset(dateTime));
-                        }
-                        else
-                        {
-                            result = new DateTimeOffset(dateTime);
-                        }
-                    }
-
-                    return success;
-                }
-            }
-            else if (input.Type == FluidValues.Number)
-            {
-                var dateTime = DateTimeOffset.FromUnixTimeSeconds((long)input.ToNumberValue());
-                result = dateTime.ToOffset(context.TimeZone.GetUtcOffset(dateTime));
-            }
-            else if (input.Type == FluidValues.DateTime)
-            {
-                result = (DateTimeOffset)input.ToObjectValue();
-            }
-            else
-            {
-                switch (input.ToObjectValue())
-                {
-                    case DateTime dateTime:
-                        result = dateTime;
-                        break;
-
-                    case DateTimeOffset dateTimeOffset:
-                        result = dateTimeOffset;
-                        break;
-
-                    default:
-                        return false;
-                }
-            }
-
-            return true;
         }
 
         private static async ValueTask WriteJson(Utf8JsonWriter writer, FluidValue input, TemplateContext ctx, HashSet<object> stack = null)

--- a/Fluid/Values/FluidValueExtensions.cs
+++ b/Fluid/Values/FluidValueExtensions.cs
@@ -1,7 +1,126 @@
-﻿namespace Fluid.Values
+﻿using System;
+using System.Globalization;
+
+namespace Fluid.Values
 {
     public static class FluidValueExtensions
     {
+        private const string Now = "now";
+        private const string Today = "today";
+
+        private static readonly string[] DefaultFormats = {
+            "yyyy-MM-ddTHH:mm:ss.FFF",
+            "yyyy-MM-ddTHH:mm:ss",
+            "yyyy-MM-ddTHH:mm",
+            "yyyy-MM-dd",
+            "yyyy-MM",
+            "yyyy"
+        };
+
+        private static readonly string[] SecondaryFormats = {
+            // Formats used in DatePrototype toString methods
+            "ddd MMM dd yyyy HH:mm:ss 'GMT'K",
+            "ddd MMM dd yyyy",
+            "HH:mm:ss 'GMT'K",
+
+            // standard formats
+            "yyyy-M-dTH:m:s.FFFK",
+            "yyyy/M/dTH:m:s.FFFK",
+            "yyyy-M-dTH:m:sK",
+            "yyyy/M/dTH:m:sK",
+            "yyyy-M-dTH:mK",
+            "yyyy/M/dTH:mK",
+            "yyyy-M-d H:m:s.FFFK",
+            "yyyy/M/d H:m:s.FFFK",
+            "yyyy-M-d H:m:sK",
+            "yyyy/M/d H:m:sK",
+            "yyyy-M-d H:mK",
+            "yyyy/M/d H:mK",
+            "yyyy-M-dK",
+            "yyyy/M/dK",
+            "yyyy-MK",
+            "yyyy/MK",
+            "yyyyK",
+            "THH:mm:ss.FFFK",
+            "THH:mm:ssK",
+            "THH:mmK",
+            "THHK"
+        };
+
+        public static bool TryGetDateTimeInput(this FluidValue input, TemplateContext context, out DateTimeOffset result)
+        {
+            result = context.Now();
+
+            if (input.Type == FluidValues.String)
+            {
+                var stringValue = input.ToStringValue();
+
+                if (stringValue == Now || stringValue == Today)
+                {
+                    return true;
+                }
+                else
+                {
+                    var success = true;
+
+                    if (!DateTime.TryParseExact(stringValue, DefaultFormats, context.CultureInfo, DateTimeStyles.None, out var dateTime))
+                    {
+                        if (!DateTime.TryParseExact(stringValue, SecondaryFormats, context.CultureInfo, DateTimeStyles.None, out dateTime))
+                        {
+                            if (!DateTime.TryParse(stringValue, context.CultureInfo, DateTimeStyles.None, out dateTime))
+                            {
+                                if (!DateTime.TryParse(stringValue, CultureInfo.InvariantCulture, DateTimeStyles.None, out dateTime))
+                                {
+                                    success = false;
+                                }
+                            }
+                        }
+                    }
+
+                    // If no timezone is specified, assume local using the configured timezone
+                    if (success)
+                    {
+                        if (dateTime.Kind == DateTimeKind.Unspecified)
+                        {
+                            result = new DateTimeOffset(dateTime, context.TimeZone.GetUtcOffset(dateTime));
+                        }
+                        else
+                        {
+                            result = new DateTimeOffset(dateTime);
+                        }
+                    }
+
+                    return success;
+                }
+            }
+            else if (input.Type == FluidValues.Number)
+            {
+                var dateTime = DateTimeOffset.FromUnixTimeSeconds((long)input.ToNumberValue());
+                result = dateTime.ToOffset(context.TimeZone.GetUtcOffset(dateTime));
+            }
+            else if (input.Type == FluidValues.DateTime)
+            {
+                result = (DateTimeOffset)input.ToObjectValue();
+            }
+            else
+            {
+                switch (input.ToObjectValue())
+                {
+                    case DateTime dateTime:
+                        result = dateTime;
+                        break;
+
+                    case DateTimeOffset dateTimeOffset:
+                        result = dateTimeOffset;
+                        break;
+
+                    default:
+                        return false;
+                }
+            }
+
+            return true;
+        }
 
         public static FluidValue Or(this FluidValue self, FluidValue other)
         {


### PR DESCRIPTION
I have a few custom filters in my solution for manipulating DateTime values and this would have been much easier if the TryGetDateTimeInput was made public or exposed.

I noticed there was another extension in this file and thought this would be a clean and simple approach that exposes this for custom filters in the Fluid.Filters namespace.