### PR TITLE
Fix lock contention in FluidValue.Create

### DIFF
--- a/Fluid.Benchmarks/FluidValueBenchmarks.cs
+++ b/Fluid.Benchmarks/FluidValueBenchmarks.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Fluid.Values;
+
+namespace Fluid.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class FluidValueBenchmarks
+    {
+        // many interfaces, none of which is dictionary
+        private static readonly List<string> nonDictionaryType = new();
+
+        private static readonly TemplateOptions options = new();
+
+        [Benchmark]
+        public FluidValue CreateFromList()
+        {
+            return FluidValue.Create(nonDictionaryType, options);
+        }
+    }
+}

--- a/Fluid/Ast/LiquidStatement.cs
+++ b/Fluid/Ast/LiquidStatement.cs
@@ -15,8 +15,9 @@ namespace Fluid.Ast
         {
             context.IncrementSteps();
 
-            foreach (var statement in Statements)
+            for (var i = 0; i < _statements.Count; i++)
             {
+                var statement = _statements[i];
                 await statement.WriteToAsync(writer, encoder, context);
             }
 

--- a/Fluid/Values/FluidValue.cs
+++ b/Fluid/Values/FluidValue.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.Encodings.Web;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Fluid.Values
@@ -14,9 +15,7 @@ namespace Fluid.Values
     {
         public abstract void WriteTo(TextWriter writer, TextEncoder encoder, CultureInfo cultureInfo);
 
-        public static Dictionary<Type, Type> _genericDictionaryTypeCache = new();
-        public static object _synLock = new();
-
+        private static Dictionary<Type, Type> _genericDictionaryTypeCache = new();
 
         [Conditional("DEBUG")]
         protected static void AssertWriteToParameters(TextWriter writer, TextEncoder encoder, CultureInfo cultureInfo)
@@ -182,30 +181,24 @@ namespace Fluid.Values
                     }
 
                     // Check if it's a more specific IDictionary<string, V>, e.g. JObject
-
-                    if (!_genericDictionaryTypeCache.TryGetValue(typeOfValue, out var genericType))
+                    var cache = _genericDictionaryTypeCache;
+                    if (!cache.TryGetValue(typeOfValue, out var genericType))
                     {
-                        lock (_synLock)
+                        foreach (var i in typeOfValue.GetInterfaces())
                         {
-                            if (!_genericDictionaryTypeCache.TryGetValue(typeOfValue, out genericType))
+                            if (i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>) && i.GetGenericArguments()[0] == typeof(string))
                             {
-                                foreach (var i in typeOfValue.GetInterfaces())
-                                {
-                                    if (i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>) && i.GetGenericArguments()[0] == typeof(string))
-                                    {
-                                        genericType = typeof(ObjectDictionaryFluidIndexable<>).MakeGenericType(i.GetGenericArguments()[1]);
-
-                                        // Swap the previous cache with a new copy to prevent locking on reads
-
-                                        var dictionary = new Dictionary<Type, Type>(_genericDictionaryTypeCache);
-                                        dictionary[typeOfValue] = genericType;
-                                        _genericDictionaryTypeCache = dictionary;
-
-                                        break;
-                                    }
-                                }
+                                genericType = typeof(ObjectDictionaryFluidIndexable<>).MakeGenericType(i.GetGenericArguments()[1]);
+                                break;
                             }
                         }
+
+                        // Swap the previous cache with a new copy to prevent locking on reads
+                        // make sure we also store null value so we don't try again
+                        Interlocked.CompareExchange(ref _genericDictionaryTypeCache, new Dictionary<Type, Type>(cache)
+                        {
+                            [typeOfValue] = genericType
+                        }, cache);
                     }
 
                     if (genericType != null)
@@ -222,11 +215,12 @@ namespace Fluid.Values
                             return new ArrayValue(enumerable);
 
                         case IList list:
-                            var values = new List<FluidValue>(list.Count);
-                            foreach (var item in list)
+                            var values = new FluidValue[list.Count];
+                            for (var i = 0; i < values.Length; i++)
                             {
-                                values.Add(Create(item, options));
+                                values[i] = Create(list[i], options);
                             }
+
                             return new ArrayValue(values);
 
                         case IEnumerable enumerable:

--- a/Fluid/Values/FluidValue.cs
+++ b/Fluid/Values/FluidValue.cs
@@ -182,6 +182,7 @@ namespace Fluid.Values
 
                     // Check if it's a more specific IDictionary<string, V>, e.g. JObject
                     var cache = _genericDictionaryTypeCache;
+
                     if (!cache.TryGetValue(typeOfValue, out var genericType))
                     {
                         foreach (var i in typeOfValue.GetInterfaces())
@@ -193,8 +194,9 @@ namespace Fluid.Values
                             }
                         }
 
-                        // Swap the previous cache with a new copy to prevent locking on reads
-                        // make sure we also store null value so we don't try again
+                        // Swap the previous cache with a new copy if no other thread has updated the reference.
+                        // This ensures the dictionary can only grow and not replace another one of the same size.
+                        // Store a null value for non-matching types so we don't try again
                         Interlocked.CompareExchange(ref _genericDictionaryTypeCache, new Dictionary<Type, Type>(cache)
                         {
                             [typeOfValue] = genericType


### PR DESCRIPTION
While doing performance checkup in Orchard (load test profiling agency theme) I noticed that there was quite big lock contention problem in Fluid, it originates from https://github.com/sebastienros/fluid/pull/387 where the logic never assigns anything on cache miss thus making the locking and looping happen every time for types like `ContentItem` (non-dictionary type). 

![image](https://user-images.githubusercontent.com/171892/147853913-485aefc7-f45a-4734-a144-376a61a4e351.png)

Fixed issue by using `Interlocked.CompareExchange`  (no locks needed) and also storing null as result for given type.  The dictionary was public, don't know why (Orchard doesn't seem to need it), made it private.

## Main

|         Method |     Mean |   Error |  StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------- |---------:|--------:|--------:|-------:|------:|------:|----------:|
| CreateFromList | 287.9 ns | 1.22 ns | 1.08 ns | 0.0110 |     - |     - |     184 B |

## This PR

|         Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------- |---------:|---------:|---------:|-------:|------:|------:|----------:|
| CreateFromList | 46.98 ns | 0.979 ns | 1.048 ns | 0.0029 |     - |     - |      48 B |