### PR TITLE
Internalize types and harmonize parameters and access

### DIFF
--- a/Fluid.Benchmarks/Fluid.Benchmarks.csproj
+++ b/Fluid.Benchmarks/Fluid.Benchmarks.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageReference Include="DotLiquid" Version=" 2.2.548" />
     <PackageReference Include="Liquid.NET" Version="0.10.0" />
     <PackageReference Include="Scriban" Version="5.0.0" />

--- a/Fluid.Tests/Directory.Build.props
+++ b/Fluid.Tests/Directory.Build.props
@@ -1,0 +1,5 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="../Common.props"/>
+
+</Project>

--- a/Fluid.Tests/MvcViewEngine/SampleTests.cs
+++ b/Fluid.Tests/MvcViewEngine/SampleTests.cs
@@ -1,5 +1,4 @@
-﻿#if !NETCOREAPP2_1
-using Fluid.Ast;
+﻿using Fluid.Ast;
 using Fluid.MvcViewEngine;
 using Fluid.ViewEngine;
 using Xunit;
@@ -11,7 +10,7 @@ namespace Fluid.Tests.MvcViewEngine
         [Fact]
         public void ShouldParseIndex()
         {
-            var index = 
+            var index =
 @"Hello World from Liquid 2
 
 <h1>{{ ViewData[""Title""] }}</h1>
@@ -44,4 +43,3 @@ This is the footer
         }
     }
 }
-#endif

--- a/Fluid/Accessors/AsyncDelegateAccessor.cs
+++ b/Fluid/Accessors/AsyncDelegateAccessor.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Accessors
 {
-    public class AsyncDelegateAccessor : AsyncDelegateAccessor<object, object>
+    internal sealed class AsyncDelegateAccessor : AsyncDelegateAccessor<object, object>
     {
         public AsyncDelegateAccessor(Func<object, string, Task<object>> getter) : base((obj, name, ctx) => getter(obj, name))
         {

--- a/Fluid/Accessors/MethodInfoAccessor.cs
+++ b/Fluid/Accessors/MethodInfoAccessor.cs
@@ -2,7 +2,7 @@
 
 namespace Fluid.Accessors
 {
-    public class MethodInfoAccessor : IMemberAccessor
+    internal sealed class MethodInfoAccessor : IMemberAccessor
     {
         private readonly MethodInfo _methodInfo;
 

--- a/Fluid/Accessors/PropertyInfoAccessor.cs
+++ b/Fluid/Accessors/PropertyInfoAccessor.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 namespace Fluid.Accessors
 {
-    public class PropertyInfoAccessor : IMemberAccessor
+    internal sealed class PropertyInfoAccessor : IMemberAccessor
     {
         private readonly IInvoker _invoker;
 

--- a/Fluid/Ast/AssignStatement.cs
+++ b/Fluid/Ast/AssignStatement.cs
@@ -5,7 +5,7 @@ using Fluid.Values;
 
 namespace Fluid.Ast
 {
-    public class AssignStatement : Statement
+    internal sealed class AssignStatement : Statement
     {
         public AssignStatement(string identifier, Expression value)
         {

--- a/Fluid/Ast/BinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpression.cs
@@ -13,9 +13,9 @@ namespace Fluid.Ast
             Right = right;
         }
 
-        public Expression Left { get; }
+        protected Expression Left { get; }
 
-        public Expression Right { get; }
+        protected Expression Right { get; }
 
         /// <summary>
         /// Evaluates two operands and tries to avoid state machines.
@@ -45,7 +45,7 @@ namespace Fluid.Ast
         }
 
         // sub-classes using the default implementation need to override this
-        internal virtual FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
+        protected virtual FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
             throw new NotImplementedException();
         }

--- a/Fluid/Ast/BinaryExpressions/AddBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/AddBinaryExpression.cs
@@ -2,13 +2,13 @@
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public sealed class AddBinaryExpression : BinaryExpression
+    internal sealed class AddBinaryExpression : BinaryExpression
     {
         public AddBinaryExpression(Expression left, Expression right) : base(left, right)
         {
         }
 
-        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
+        protected override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
             if (leftValue is StringValue)
             {

--- a/Fluid/Ast/BinaryExpressions/AndBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/AndBinaryExpression.cs
@@ -2,13 +2,13 @@
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public sealed class AndBinaryExpression : BinaryExpression
+    internal sealed class AndBinaryExpression : BinaryExpression
     {
         public AndBinaryExpression(Expression left, Expression right) : base(left, right)
         {
         }
 
-        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
+        protected override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
             return BooleanValue.Create(leftValue.ToBooleanValue() && rightValue.ToBooleanValue());
         }

--- a/Fluid/Ast/BinaryExpressions/ContainsBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/ContainsBinaryExpression.cs
@@ -2,13 +2,13 @@
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public sealed class ContainsBinaryExpression : BinaryExpression
+    internal sealed class ContainsBinaryExpression : BinaryExpression
     {
         public ContainsBinaryExpression(Expression left, Expression right) : base(left, right)
         {
         }
 
-        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
+        protected override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
             return leftValue.Contains(rightValue)
                 ? BooleanValue.True

--- a/Fluid/Ast/BinaryExpressions/DivideBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/DivideBinaryExpression.cs
@@ -2,13 +2,13 @@
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public sealed class DivideBinaryExpression : BinaryExpression
+    internal sealed class DivideBinaryExpression : BinaryExpression
     {
         public DivideBinaryExpression(Expression left, Expression right) : base(left, right)
         {
         }
 
-        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
+        protected override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
             if (leftValue is NumberValue && rightValue is NumberValue)
             {

--- a/Fluid/Ast/BinaryExpressions/EndsWithBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/EndsWithBinaryExpression.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public sealed class EndsWithBinaryExpression : BinaryExpression
+    internal sealed class EndsWithBinaryExpression : BinaryExpression
     {
         public EndsWithBinaryExpression(Expression left, Expression right) : base(left, right)
         {

--- a/Fluid/Ast/BinaryExpressions/EqualBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/EqualBinaryExpression.cs
@@ -2,13 +2,13 @@
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public sealed class EqualBinaryExpression : BinaryExpression
+    internal sealed class EqualBinaryExpression : BinaryExpression
     {
         public EqualBinaryExpression(Expression left, Expression right) : base(left, right)
         {
         }
 
-        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
+        protected override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
             return leftValue.Equals(rightValue)
                 ? BooleanValue.True

--- a/Fluid/Ast/BinaryExpressions/GreaterThanBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/GreaterThanBinaryExpression.cs
@@ -2,7 +2,7 @@
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public sealed class GreaterThanBinaryExpression : BinaryExpression
+    internal sealed class GreaterThanBinaryExpression : BinaryExpression
     {
         public GreaterThanBinaryExpression(Expression left, Expression right, bool strict) : base(left, right)
         {
@@ -11,7 +11,7 @@ namespace Fluid.Ast.BinaryExpressions
 
         public bool Strict { get; }
 
-        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
+        protected override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
             if (leftValue.IsNil() || rightValue.IsNil())
             {

--- a/Fluid/Ast/BinaryExpressions/LowerThanExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/LowerThanExpression.cs
@@ -2,7 +2,7 @@
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public sealed class LowerThanExpression : BinaryExpression
+    internal sealed class LowerThanExpression : BinaryExpression
     {
         public LowerThanExpression(Expression left, Expression right, bool strict) : base(left, right)
         {
@@ -11,7 +11,7 @@ namespace Fluid.Ast.BinaryExpressions
 
         public bool Strict { get; }
 
-        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
+        protected override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
             if (leftValue.IsNil() || rightValue.IsNil())
             {

--- a/Fluid/Ast/BinaryExpressions/ModuloBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/ModuloBinaryExpression.cs
@@ -2,13 +2,13 @@
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public sealed class ModuloBinaryExpression : BinaryExpression
+    internal sealed class ModuloBinaryExpression : BinaryExpression
     {
         public ModuloBinaryExpression(Expression left, Expression right) : base(left, right)
         {
         }
 
-        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
+        protected override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
             return leftValue is NumberValue && rightValue is NumberValue
                 ? NumberValue.Create(leftValue.ToNumberValue() % rightValue.ToNumberValue())

--- a/Fluid/Ast/BinaryExpressions/MultiplyBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/MultiplyBinaryExpression.cs
@@ -2,13 +2,13 @@
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public sealed class MultiplyBinaryExpression : BinaryExpression
+    internal sealed class MultiplyBinaryExpression : BinaryExpression
     {
         public MultiplyBinaryExpression(Expression left, Expression right) : base(left, right)
         {
         }
 
-        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
+        protected override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
             return leftValue is NumberValue && rightValue is NumberValue
                 ? NumberValue.Create(leftValue.ToNumberValue() * rightValue.ToNumberValue())

--- a/Fluid/Ast/BinaryExpressions/NotEqualBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/NotEqualBinaryExpression.cs
@@ -2,16 +2,16 @@
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public sealed class NotEqualBinaryExpression : BinaryExpression
+    internal sealed class NotEqualBinaryExpression : BinaryExpression
     {
         public NotEqualBinaryExpression(Expression left, Expression right) : base(left, right)
         {
         }
 
-        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
+        protected override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
             return leftValue.Equals(rightValue)
-                ? BooleanValue.False 
+                ? BooleanValue.False
                 : BooleanValue.True;
         }
     }

--- a/Fluid/Ast/BinaryExpressions/OrBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/OrBinaryExpression.cs
@@ -2,13 +2,13 @@
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public sealed class OrBinaryExpression : BinaryExpression
+    internal sealed class OrBinaryExpression : BinaryExpression
     {
         public OrBinaryExpression(Expression left, Expression right) : base(left, right)
         {
         }
 
-        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
+        protected override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
             return BooleanValue.Create(leftValue.ToBooleanValue() || rightValue.ToBooleanValue());
         }

--- a/Fluid/Ast/BinaryExpressions/StartsWithBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/StartsWithBinaryExpression.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public class StartsWithBinaryExpression : BinaryExpression
+    internal sealed class StartsWithBinaryExpression : BinaryExpression
     {
         public StartsWithBinaryExpression(Expression left, Expression right) : base(left, right)
         {

--- a/Fluid/Ast/BinaryExpressions/SubstractBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/SubstractBinaryExpression.cs
@@ -2,13 +2,13 @@
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public class SubstractBinaryExpression : BinaryExpression
+    internal sealed class SubstractBinaryExpression : BinaryExpression
     {
         public SubstractBinaryExpression(Expression left, Expression right) : base(left, right)
         {
         }
 
-        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
+        protected override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
         {
             return leftValue is NumberValue && rightValue is NumberValue
                 ? NumberValue.Create(leftValue.ToNumberValue() - rightValue.ToNumberValue())

--- a/Fluid/Ast/BreakStatement.cs
+++ b/Fluid/Ast/BreakStatement.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class BreakStatement : Statement
+    internal sealed class BreakStatement : Statement
     {
         public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {

--- a/Fluid/Ast/CallbackStatement.cs
+++ b/Fluid/Ast/CallbackStatement.cs
@@ -8,7 +8,7 @@ namespace Fluid.Ast
     /// <summary>
     /// An instance of this class is used to execute some custom code in a template.
     /// </summary>
-    public class CallbackStatement : Statement
+    public sealed class CallbackStatement : Statement
     {
         public CallbackStatement(Func<TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> action)
         {

--- a/Fluid/Ast/CaptureStatement.cs
+++ b/Fluid/Ast/CaptureStatement.cs
@@ -7,14 +7,14 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class CaptureStatement : TagStatement
+    internal sealed class CaptureStatement : TagStatement
     {
+        private readonly string _identifier;
+
         public CaptureStatement(string identifier, List<Statement> statements): base(statements)
         {
-            Identifier = identifier;
+            _identifier = identifier;
         }
-
-        public string Identifier { get; }
 
         public override async ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
@@ -39,11 +39,11 @@ namespace Fluid.Ast
             // Substitute the result if a custom callback is provided
             if (context.Captured != null)
             {
-                 result = await context.Captured.Invoke(Identifier, result);
+                 result = await context.Captured.Invoke(_identifier, result);
             }
 
             // Don't encode captured blocks
-            context.SetValue(Identifier, new StringValue(result, false));
+            context.SetValue(_identifier, new StringValue(result, false));
 
             return completion;
         }

--- a/Fluid/Ast/CommentStatement.cs
+++ b/Fluid/Ast/CommentStatement.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class CommentStatement : Statement
+    internal sealed class CommentStatement : Statement
     {
         private readonly TextSpan _text;
 

--- a/Fluid/Ast/ContinueStatement.cs
+++ b/Fluid/Ast/ContinueStatement.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class ContinueStatement : Statement
+    internal sealed class ContinueStatement : Statement
     {
         public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {

--- a/Fluid/Ast/CycleStatement.cs
+++ b/Fluid/Ast/CycleStatement.cs
@@ -1,36 +1,31 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Fluid.Values;
 
 namespace Fluid.Ast
 {
-    public sealed class CycleStatement : Statement
+    internal sealed class CycleStatement : Statement
     {
-        private readonly Expression[] _values;
+        private readonly List<Expression> _values;
+        private readonly Expression _group;
 
-        public CycleStatement(Expression group, Expression[] values)
+        public CycleStatement(Expression group, params Expression[] values) : this(group, new List<Expression>(values))
         {
-            Group = group;
+        }
+
+        public CycleStatement(Expression group, List<Expression> values)
+        {
+            _group = group;
             _values = values;
         }
-
-        public CycleStatement(Expression group, IList<Expression> values)
-        {
-            Group = group;
-            _values = values.ToArray();
-        }
-
-        public Expression Group { get; }
-        public IList<Expression> Values2 { get; }
 
         public override async ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
             context.IncrementSteps();
 
-            var groupValue = Group == null ? "$cycle_" : "$cycle_" + (await Group.EvaluateAsync(context)).ToStringValue();
+            var groupValue = _group == null ? "$cycle_" : "$cycle_" + (await _group.EvaluateAsync(context)).ToStringValue();
 
             var currentValue = context.GetValue(groupValue);
 
@@ -39,7 +34,7 @@ namespace Fluid.Ast
                 currentValue = NumberValue.Zero;
             }
 
-            var index = (uint) currentValue.ToNumberValue() % _values.Length;
+            var index = (int) currentValue.ToNumberValue() % _values.Count;
             var value = await _values[index].EvaluateAsync(context);
             context.SetValue(groupValue, NumberValue.Create(index + 1));
 

--- a/Fluid/Ast/DecrementStatement.cs
+++ b/Fluid/Ast/DecrementStatement.cs
@@ -5,14 +5,14 @@ using Fluid.Values;
 
 namespace Fluid.Ast
 {
-    public class DecrementStatement : Statement
+    internal sealed class DecrementStatement : Statement
     {
+        private readonly string _identifier;
+
         public DecrementStatement(string identifier)
         {
-            Identifier = identifier;
+            _identifier = identifier;
         }
-
-        public string Identifier { get; }
 
         public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
@@ -22,11 +22,11 @@ namespace Fluid.Ast
             // Variable identifiers don't represent the same slots as inc/dec ones.
             // c.f. https://shopify.github.io/liquid/tags/variable/
 
-            var prefixedIdentifier = IncrementStatement.Prefix + Identifier;
+            var prefixedIdentifier = IncrementStatement.Prefix + _identifier;
 
             var value = context.GetValue(prefixedIdentifier);
-            
-            if (value.IsNil()) 
+
+            if (value.IsNil())
             {
                 value = NumberValue.Zero;
             }

--- a/Fluid/Ast/ElseIfStatement.cs
+++ b/Fluid/Ast/ElseIfStatement.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class ElseIfStatement : TagStatement
+    internal sealed class ElseIfStatement : TagStatement
     {
         public ElseIfStatement(Expression condition, List<Statement> statements) : base(statements)
         {

--- a/Fluid/Ast/ElseStatement.cs
+++ b/Fluid/Ast/ElseStatement.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class ElseStatement : TagStatement
+    internal sealed class ElseStatement : TagStatement
     {
         public ElseStatement(List<Statement> statements) : base(statements)
         {
@@ -13,11 +13,12 @@ namespace Fluid.Ast
 
         public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
-            for (var i = 0; i < _statements.Count; i++)
+            var i = 0;
+            foreach (var statement in _statements.AsSpan())
             {
                 context.IncrementSteps();
 
-                var task = _statements[i].WriteToAsync(writer, encoder, context);
+                var task = statement.WriteToAsync(writer, encoder, context);
 
                 if (!task.IsCompletedSuccessfully)
                 {

--- a/Fluid/Ast/ForStatement.cs
+++ b/Fluid/Ast/ForStatement.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class ForStatement : TagStatement
+    internal sealed class ForStatement : TagStatement
     {
         public ForStatement(
             List<Statement> statements,

--- a/Fluid/Ast/IdentifierSegment.cs
+++ b/Fluid/Ast/IdentifierSegment.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 namespace Fluid.Ast
 {
     [DebuggerDisplay("{Identifier,nq}")]
-    public class IdentifierSegment : MemberSegment
+    internal sealed class IdentifierSegment : MemberSegment
     {
         public IdentifierSegment(string identifier)
         {

--- a/Fluid/Ast/IncrementStatement.cs
+++ b/Fluid/Ast/IncrementStatement.cs
@@ -5,15 +5,15 @@ using Fluid.Values;
 
 namespace Fluid.Ast
 {
-    public class IncrementStatement : Statement
+    internal sealed class IncrementStatement : Statement
     {
         public const string Prefix = "$$incdec$$$";
+        private readonly string _identifier;
+
         public IncrementStatement(string identifier)
         {
-            Identifier = identifier ?? "";
+            _identifier = identifier ?? "";
         }
-
-        public string Identifier { get; }
 
         public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
@@ -23,7 +23,7 @@ namespace Fluid.Ast
             // Variable identifiers don't represent the same slots as inc/dec ones.
             // c.f. https://shopify.github.io/liquid/tags/variable/
 
-            var prefixedIdentifier = Prefix + Identifier;
+            var prefixedIdentifier = Prefix + _identifier;
 
             var value = context.GetValue(prefixedIdentifier);
 

--- a/Fluid/Ast/IndexerSegment.cs
+++ b/Fluid/Ast/IndexerSegment.cs
@@ -3,18 +3,18 @@ using Fluid.Values;
 
 namespace Fluid.Ast
 {
-    public class IndexerSegment : MemberSegment
+    internal sealed class IndexerSegment : MemberSegment
     {
+        private readonly Expression _expression;
+
         public IndexerSegment(Expression expression)
         {
-            Expression = expression;
+            _expression = expression;
         }
-
-        public Expression Expression { get; }
 
         public override async ValueTask<FluidValue> ResolveAsync(FluidValue value, TemplateContext context)
         {
-            var index = await Expression.EvaluateAsync(context);
+            var index = await _expression.EvaluateAsync(context);
             return await value.GetIndexAsync(index, context);
         }
     }

--- a/Fluid/Ast/MacroStatement.cs
+++ b/Fluid/Ast/MacroStatement.cs
@@ -7,25 +7,25 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class MacroStatement : TagStatement
+    internal sealed class MacroStatement : TagStatement
     {
-        public MacroStatement(string identifier, IReadOnlyList<FunctionCallArgument> arguments, List<Statement> statements): base(statements)
-        {
-            Identifier = identifier;
-            Arguments = arguments;
-        }
+        private readonly string _identifier;
+        private readonly List<FunctionCallArgument> _arguments;
 
-        public string Identifier { get; }
-        public IReadOnlyList<FunctionCallArgument> Arguments { get; }
+        public MacroStatement(string identifier, List<FunctionCallArgument> arguments, List<Statement> statements): base(statements)
+        {
+            _identifier = identifier;
+            _arguments = arguments;
+        }
 
         public override async ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
             // Evaluate all default values only once
             var defaultValues = new Dictionary<string, FluidValue>();
 
-            for (var i = 0; i < Arguments.Count; i++)
+            for (var i = 0; i < _arguments.Count; i++)
             {
-                var argument = Arguments[i];
+                var argument = _arguments[i];
                 defaultValues[argument.Name] = argument.Expression == null ? NilValue.Instance : await argument.Expression.EvaluateAsync(context);
             }
 
@@ -51,7 +51,7 @@ namespace Fluid.Ast
 
                     for (var i = 0; i < args.Count; i++)
                     {
-                        var positionalName = Arguments[i].Name;
+                        var positionalName = _arguments[i].Name;
 
                         namedArguments |= args.HasNamed(positionalName);
 
@@ -88,7 +88,7 @@ namespace Fluid.Ast
                 }
             });
 
-            context.SetValue(Identifier, f);
+            context.SetValue(_identifier, f);
 
             return Completion.Normal;
         }

--- a/Fluid/Ast/NamedExpressionList.cs
+++ b/Fluid/Ast/NamedExpressionList.cs
@@ -2,7 +2,7 @@
 
 namespace Fluid.Ast
 {
-    public class NamedExpressionList
+    public sealed class NamedExpressionList
     {
         public static readonly NamedExpressionList Empty = new NamedExpressionList();
 

--- a/Fluid/Ast/OutputStatement.cs
+++ b/Fluid/Ast/OutputStatement.cs
@@ -1,12 +1,11 @@
-﻿using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Fluid.Values;
 
 namespace Fluid.Ast
 {
-    public class OutputStatement : Statement
+    internal sealed class OutputStatement : Statement
     {
         public OutputStatement(Expression expression)
         {
@@ -14,8 +13,6 @@ namespace Fluid.Ast
         }
 
         public Expression Expression { get; }
-
-        public IList<FilterExpression> Filters { get ; }
 
         public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {

--- a/Fluid/Ast/RangeExpression.cs
+++ b/Fluid/Ast/RangeExpression.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class RangeExpression : Expression
+    internal sealed class RangeExpression : Expression
     {
         public RangeExpression(Expression from, Expression to)
         {

--- a/Fluid/Ast/RawStatement.cs
+++ b/Fluid/Ast/RawStatement.cs
@@ -6,7 +6,7 @@ using Fluid.Utils;
 
 namespace Fluid.Ast
 {
-    public class RawStatement : Statement
+    internal sealed class RawStatement : Statement
     {
         private readonly TextSpan _text;
 

--- a/Fluid/Ast/TagStatement.cs
+++ b/Fluid/Ast/TagStatement.cs
@@ -4,7 +4,7 @@ namespace Fluid.Ast
 {
     public abstract class TagStatement : Statement
     {
-        protected readonly List<Statement> _statements;
+        internal readonly List<Statement> _statements;
 
         protected TagStatement(List<Statement> statements)
         {

--- a/Fluid/Ast/TextSpanStatement.cs
+++ b/Fluid/Ast/TextSpanStatement.cs
@@ -6,7 +6,7 @@ using Fluid.Utils;
 
 namespace Fluid.Ast
 {
-    public sealed class TextSpanStatement : Statement
+    internal sealed class TextSpanStatement : Statement
     {
         private bool _isStripped;
         private bool _isEmpty;
@@ -39,7 +39,7 @@ namespace Fluid.Ast
             if (!_isStripped)
             {
                 // Prevent two threads from strsipping the same statement in case WriteToAsync is called concurrently
-                // 
+                //
                 lock (_synLock)
                 {
                     if (!_isStripped)

--- a/Fluid/Ast/UnlessStatement.cs
+++ b/Fluid/Ast/UnlessStatement.cs
@@ -5,23 +5,23 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class UnlessStatement : TagStatement
+    internal sealed class UnlessStatement : TagStatement
     {
+        private readonly Expression _condition;
+        private readonly ElseStatement _else;
+
         public UnlessStatement(
             Expression condition,
             List<Statement> statements,
             ElseStatement elseStatement = null) : base(statements)
         {
-            Condition = condition;
-            Else = elseStatement;
+            _condition = condition;
+            _else = elseStatement;
         }
-
-        public Expression Condition { get; }
-        public ElseStatement Else { get; }
 
         public override async ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
-            var result = (await Condition.EvaluateAsync(context)).ToBooleanValue();
+            var result = (await _condition.EvaluateAsync(context)).ToBooleanValue();
 
             if (!result)
             {
@@ -42,9 +42,9 @@ namespace Fluid.Ast
             }
             else
             {
-                if (Else != null)
+                if (_else != null)
                 {
-                    await Else.WriteToAsync(writer, encoder, context);
+                    await _else.WriteToAsync(writer, encoder, context);
                 }
             }
 

--- a/Fluid/Ast/WhenStatement.cs
+++ b/Fluid/Ast/WhenStatement.cs
@@ -1,21 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class WhenStatement : TagStatement
+    internal sealed class WhenStatement : TagStatement
     {
-        private readonly IReadOnlyList<Expression> _options;
+        internal readonly List<Expression> _options;
 
-        public WhenStatement(IReadOnlyList<Expression> options, List<Statement> statements) : base(statements)
+        public WhenStatement(List<Expression> options, List<Statement> statements) : base(statements)
         {
-            _options = options ?? Array.Empty<Expression>();
+            _options = options ?? new List<Expression>();
         }
 
-        public IReadOnlyList<Expression> Options => _options;
+
 
         public override async ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {

--- a/Fluid/FilterArguments.cs
+++ b/Fluid/FilterArguments.cs
@@ -8,7 +8,7 @@ namespace Fluid
     /// Represents the list of arguments that are passed to a <see cref="FilterDelegate"/>
     /// when invoked.
     /// </summary>
-    public class FilterArguments
+    public sealed class FilterArguments
     {
         public static readonly FilterArguments Empty = new FilterArguments();
 

--- a/Fluid/FiltersCollection.cs
+++ b/Fluid/FiltersCollection.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Fluid
 {
-    public class FilterCollection : IEnumerable<KeyValuePair<string, FilterDelegate>>
+    public sealed class FilterCollection : IEnumerable<KeyValuePair<string, FilterDelegate>>
     {
         private Dictionary<string, FilterDelegate> _filters;
 

--- a/Fluid/Fluid.csproj
+++ b/Fluid/Fluid.csproj
@@ -10,6 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Fluid.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001001182125c952dc299d7cecc8ad125b0451fca4baecea957288b7865c6d333bc5110a265d97a502e716bb5b2cc71ea05648c3885f2955065eba8aec2e9225c3e84d5d9bd91929cd20354f479acaa60b76d340844d2161f213fdd324b55c8e79de5c292490c59261f46f97d1872be0cfd5db21a5ea1f02fd245ea35a9296e6e30a7" />
+    <InternalsVisibleTo Include="Fluid.ViewEngine, PublicKey=00240000048000009400000006020000002400005253413100040000010001001182125c952dc299d7cecc8ad125b0451fca4baecea957288b7865c6d333bc5110a265d97a502e716bb5b2cc71ea05648c3885f2955065eba8aec2e9225c3e84d5d9bd91929cd20354f479acaa60b76d340844d2161f213fdd324b55c8e79de5c292490c59261f46f97d1872be0cfd5db21a5ea1f02fd245ea35a9296e6e30a7" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Parlot" Version="0.0.19" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="1.1.1" />
     <PackageReference Include="TimeZoneConverter" Version="3.5.0" />

--- a/Fluid/FluidParser.cs
+++ b/Fluid/FluidParser.cs
@@ -53,7 +53,7 @@ namespace Fluid
         protected static readonly Parser<string> BinaryOr = Terms.Text("or");
         protected static readonly Parser<string> BinaryAnd = Terms.Text("and");
 
-        protected static readonly Parser<string> Identifier = SkipWhiteSpace(new IdentifierParser()).Then(x => x.ToString());
+        protected static readonly Parser<string> Identifier = SkipWhiteSpace(IdentifierParser.Instance).Then(x => x.ToString());
 
         protected readonly Parser<List<FilterArgument>> ArgumentsList;
         protected readonly Parser<List<FunctionCallArgument>> FunctionCallArgumentsList;
@@ -172,7 +172,7 @@ namespace Fluid
                             "and" => new AndBinaryExpression(previous, result),
                             _ => throw new ParseException()
                         };
-                        
+
                     }
 
                     return result;

--- a/Fluid/FunctionArguments.cs
+++ b/Fluid/FunctionArguments.cs
@@ -7,7 +7,7 @@ namespace Fluid
     /// <summary>
     /// Represents the list of arguments of a function.
     /// </summary>
-    public class FunctionArguments
+    public sealed class FunctionArguments
     {
         public static readonly FunctionArguments Empty = new FunctionArguments();
 

--- a/Fluid/ListExtensions.cs
+++ b/Fluid/ListExtensions.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Fluid;
+
+internal static class ListExtensions
+{
+    // we can (ab)use the fact that binary compatibility requires .NET to have fixed layout for type
+    private class ListLayout<T>
+    {
+        public T[] _items = Array.Empty<T>();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Span<T> AsSpan<T>(this List<T> list, int start = 0)
+    {
+#if NET5_0_OR_GREATER
+        return System.Runtime.InteropServices.CollectionsMarshal.AsSpan(list).Slice(start);
+#else
+        return System.Runtime.CompilerServices.Unsafe.As<List<T>, ListLayout<T>>(ref list)._items.AsSpan(start, list.Count - start);
+#endif
+    }
+}

--- a/Fluid/MemberNameStrategies.cs
+++ b/Fluid/MemberNameStrategies.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Fluid
 {
-    public class MemberNameStrategies
+    public static class MemberNameStrategies
     {
         public static readonly MemberNameStrategy Default = RenameDefault;
         public static readonly MemberNameStrategy CamelCase = RenameCamelCase;

--- a/Fluid/NullMemberAccessor.cs
+++ b/Fluid/NullMemberAccessor.cs
@@ -1,6 +1,6 @@
 ﻿namespace Fluid
 {
-    public class NullMemberAccessor : IMemberAccessor
+    internal sealed class NullMemberAccessor : IMemberAccessor
     {
         public static IMemberAccessor Instance = new NullMemberAccessor();
 
@@ -8,7 +8,7 @@
         {
 
         }
-        
+
         object IMemberAccessor.Get(object obj, string name, TemplateContext ctx)
         {
             return null;

--- a/Fluid/ParseException.cs
+++ b/Fluid/ParseException.cs
@@ -2,7 +2,7 @@
 
 namespace Fluid
 {
-    public class ParseException : Exception
+    public sealed class ParseException : Exception
     {
         //
         // Summary:

--- a/Fluid/Parser/CompositeFluidTemplate.cs
+++ b/Fluid/Parser/CompositeFluidTemplate.cs
@@ -5,26 +5,20 @@ using System.Threading.Tasks;
 
 namespace Fluid.Parser
 {
-    public class CompositeFluidTemplate : IFluidTemplate
+    public sealed class CompositeFluidTemplate : IFluidTemplate
     {
         private readonly List<IFluidTemplate> _templates;
-
-        public CompositeFluidTemplate(params IFluidTemplate[] templates)
-        {
-            _templates = new List<IFluidTemplate>(templates);
-        }
 
         public CompositeFluidTemplate(IEnumerable<IFluidTemplate> templates)
         {
             _templates = new List<IFluidTemplate>(templates);
         }
 
-        public IReadOnlyList<IFluidTemplate> Templates => _templates;
-
         public async ValueTask RenderAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
-            foreach (var template in Templates)
+            for (var i = 0; i < _templates.Count; i++)
             {
+                var template = _templates[i];
                 await template.RenderAsync(writer, encoder, context);
             }
         }

--- a/Fluid/Parser/FluidParseContext.cs
+++ b/Fluid/Parser/FluidParseContext.cs
@@ -4,7 +4,7 @@ using Parlot.Fluent;
 
 namespace Fluid.Parser
 {
-    public class FluidParseContext : ParseContext
+    internal sealed class FluidParseContext : ParseContext
     {
         public FluidParseContext(string text) : base(new Scanner(text))
         {

--- a/Fluid/Parser/IdentifierParser.cs
+++ b/Fluid/Parser/IdentifierParser.cs
@@ -3,8 +3,14 @@ using Parlot.Fluent;
 
 namespace Fluid.Parser
 {
-    public sealed class IdentifierParser : Parser<TextSpan>
+    internal sealed class IdentifierParser : Parser<TextSpan>
     {
+        public static readonly IdentifierParser Instance = new();
+
+        private IdentifierParser()
+        {
+        }
+
         public override bool Parse(ParseContext context, ref ParseResult<TextSpan> result)
         {
             context.EnterParser(this);

--- a/Fluid/Parser/ParserBlockStatement.cs
+++ b/Fluid/Parser/ParserBlockStatement.cs
@@ -21,7 +21,7 @@ namespace Fluid.Parser
 
         public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
-            return _render(Value, Statements, writer, encoder, context);
+            return _render(Value, _statements, writer, encoder, context);
         }
     }
 }

--- a/Fluid/Scope.cs
+++ b/Fluid/Scope.cs
@@ -5,7 +5,7 @@ using Fluid.Values;
 
 namespace Fluid
 {
-    public class Scope
+    public sealed class Scope
     {
         internal Dictionary<string, FluidValue> _properties;
         private readonly bool _forLoopScope;

--- a/Fluid/TemplateOptions.cs
+++ b/Fluid/TemplateOptions.cs
@@ -1,5 +1,4 @@
 ﻿using Fluid.Filters;
-using Fluid.Values;
 using Microsoft.Extensions.FileProviders;
 using System;
 using System.Collections.Generic;

--- a/Fluid/UnsafeMemberAccessStrategy.cs
+++ b/Fluid/UnsafeMemberAccessStrategy.cs
@@ -2,14 +2,14 @@
 
 namespace Fluid
 {
-    public class UnsafeMemberAccessStrategy : DefaultMemberAccessStrategy
+    public sealed class UnsafeMemberAccessStrategy : DefaultMemberAccessStrategy
     {
         public static readonly UnsafeMemberAccessStrategy Instance = new UnsafeMemberAccessStrategy();
 
         public override IMemberAccessor GetAccessor(Type type, string name)
         {
             var accessor = base.GetAccessor(type, name);
-            
+
             if (accessor != null)
             {
                 return accessor;


### PR DESCRIPTION
* internalize all types that can be internalized
* seal all types that can be sealed
* consistently take List<T> as parameter to expressions and statements
* add `AsSpan` helper for faster List<T> iteration, accesses the internal array directly (but cannot be used in async context, because Span is ref struct, works in many places where we try to avoid awaits)
* used InternalsVisible to allow some type/member access from test and view engine projects

Tested compilation with OrchardCore, NJsonSchema and FluentEmail. All these projects still compile with these changes after hiding and sealing members.

Please change this PR directly if you find types that you think should be public/non-sealed.

## Benchmarks

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=6.0.101
  [Host]     : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT
  DefaultJob : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT


```

### Before

|         Method |       Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Allocated |
|--------------- |-----------:|----------:|----------:|-------:|-------:|----------:|
|          Parse |   4.519 μs | 0.0131 μs | 0.0123 μs | 0.1526 |      - |      3 KB |
|       ParseBig |  23.141 μs | 0.0473 μs | 0.0395 μs | 0.7019 | 0.0305 |     12 KB |
|         Render | 222.656 μs | 0.2196 μs | 0.2054 μs | 5.6152 | 1.2207 |     96 KB |
| ParseAndRender | 225.082 μs | 0.8097 μs | 0.7574 μs | 5.8594 | 1.2207 |     99 KB |

### After

|         Method |       Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Allocated |
|--------------- |-----------:|----------:|----------:|-------:|-------:|----------:|
|          Parse |   4.472 μs | 0.0059 μs | 0.0052 μs | 0.1526 |      - |      3 KB |
|       ParseBig |  23.116 μs | 0.0611 μs | 0.0510 μs | 0.7019 | 0.0305 |     11 KB |
|         Render | 221.587 μs | 0.4490 μs | 0.4200 μs | 5.6152 | 1.2207 |     96 KB |
| ParseAndRender | 219.165 μs | 0.4073 μs | 0.3810 μs | 5.8594 | 1.2207 |     99 KB |

