### PR TITLE
Allow FluidParserOptions to be configured using Fluid.MvcViewEngine

### DIFF
--- a/Fluid.MvcSample/CustomFluidViewParser.cs
+++ b/Fluid.MvcSample/CustomFluidViewParser.cs
@@ -5,7 +5,7 @@ namespace Fluid.MvcSample
 {
     public class CustomFluidViewParser : FluidViewParser
     {
-        public CustomFluidViewParser()
+        public CustomFluidViewParser(FluidParserOptions options) : base(options)
         {
             RegisterEmptyTag("mytag", static async (w, e, c) =>
             {

--- a/Fluid.MvcSample/Startup.cs
+++ b/Fluid.MvcSample/Startup.cs
@@ -14,7 +14,7 @@ namespace Fluid.MvcSample
         {
             services.Configure<FluidMvcViewOptions>(options =>
             {
-                options.Parser = new CustomFluidViewParser();
+                options.Parser = new CustomFluidViewParser(new FluidParserOptions());
                 options.TemplateOptions.MemberAccessStrategy = UnsafeMemberAccessStrategy.Instance;
             });
 

--- a/Fluid.Tests/MvcViewEngine/SampleTests.cs
+++ b/Fluid.Tests/MvcViewEngine/SampleTests.cs
@@ -29,7 +29,7 @@ This is the footer
 
 {% mytag %}
 ";
-            var parser = new FluidViewParser();
+            var parser = new FluidViewParser(new FluidParserOptions());
 
             parser.RegisterEmptyTag("mytag", static async (w, e, c) =>
             {

--- a/Fluid.ViewEngine/FluidViewEngineOptions.cs
+++ b/Fluid.ViewEngine/FluidViewEngineOptions.cs
@@ -12,7 +12,7 @@ namespace Fluid.ViewEngine
         /// <remarks>
         /// To add custom tags which require special primitive elements, create a sub-class of <see cref="FluidViewParser"/>.
         /// </remarks>
-        public FluidViewParser Parser { get; set; } = new FluidViewParser(new FluidParserOptions());
+        public FluidViewParser Parser { get; set; } = new FluidViewParser();
 
         /// <summary>
         /// Gets or sets the text encoder to use during rendering.

--- a/Fluid.ViewEngine/FluidViewEngineOptions.cs
+++ b/Fluid.ViewEngine/FluidViewEngineOptions.cs
@@ -12,7 +12,7 @@ namespace Fluid.ViewEngine
         /// <remarks>
         /// To add custom tags which require special primitive elements, create a sub-class of <see cref="FluidViewParser"/>.
         /// </remarks>
-        public FluidViewParser Parser { get; set; } = new FluidViewParser();
+        public FluidViewParser Parser { get; set; } = new FluidViewParser(new FluidParserOptions());
 
         /// <summary>
         /// Gets or sets the text encoder to use during rendering.

--- a/Fluid.ViewEngine/FluidViewParser.cs
+++ b/Fluid.ViewEngine/FluidViewParser.cs
@@ -9,7 +9,7 @@ namespace Fluid.ViewEngine
 {
     public class FluidViewParser : FluidParser
     {
-        public FluidViewParser()
+        public FluidViewParser(FluidParserOptions parserOptions) : base(parserOptions)
         {
             RegisterIdentifierTag("rendersection", static async (identifier, writer, encoder, context) =>
             {

--- a/Fluid.ViewEngine/FluidViewParser.cs
+++ b/Fluid.ViewEngine/FluidViewParser.cs
@@ -9,6 +9,10 @@ namespace Fluid.ViewEngine
 {
     public class FluidViewParser : FluidParser
     {
+        public FluidViewParser() : this (new())
+        {
+        }
+
         public FluidViewParser(FluidParserOptions parserOptions) : base(parserOptions)
         {
             RegisterIdentifierTag("rendersection", static async (identifier, writer, encoder, context) =>


### PR DESCRIPTION
A small set of further changes to support the recent work allowing for FunctionValues. 

- Update to FluidViewParser constructor to pass FluidParserOptions argument  
- Update to sample projects to use the new constructor
