### PR TITLE
Ability to set template cache key

### DIFF
--- a/Fluid.ViewEngine/FluidViewEngineOptions.cs
+++ b/Fluid.ViewEngine/FluidViewEngineOptions.cs
@@ -74,5 +74,15 @@ namespace Fluid.ViewEngine
         /// Gets or sets the delegate to execute when a view is rendered.
         /// </summary>
         public RenderingViewDelegate RenderingViewAsync { get; set; }
+
+        /// <summary>
+        /// Represents the method that will generate a cache key for a supplied template path.  Allows templates to be cached based on any external factor.
+        /// </summary>
+        public delegate string TemplateCacheKeyProviderDelegate(string path);
+
+        /// <summary>
+        /// Gets or sets the delegate to execute when a template cache key is required
+        /// </summary>
+        public TemplateCacheKeyProviderDelegate TemplateCacheKeyProvider { get; set; }
     }
 }

--- a/Fluid.ViewEngine/FluidViewRenderer.cs
+++ b/Fluid.ViewEngine/FluidViewRenderer.cs
@@ -14,7 +14,7 @@ namespace Fluid.ViewEngine
     /// </summary>
     public class FluidViewRenderer : IFluidViewRenderer
     {
-        private record struct LayoutKey (string ViewPath, string LayoutPath);
+        private record struct LayoutKey(string ViewPath, string LayoutPath);
 
         private class CacheEntry
         {
@@ -92,7 +92,7 @@ namespace Fluid.ViewEngine
         {
             var viewStarts = new List<string>();
             int index = viewPath.Length - 1;
-            
+
             while (!String.IsNullOrEmpty(viewPath))
             {
                 if (index == -1)
@@ -214,7 +214,14 @@ namespace Fluid.ViewEngine
                 return cacheEntry;
             });
 
-            if (cache.TemplateCache.TryGetValue(path, out var template))
+            // Allow templates to be cached by external factors
+            string cacheKey = path;
+            if (_fluidViewEngineOptions.TemplateCacheKeyProvider != null)
+            {
+                cacheKey = _fluidViewEngineOptions.TemplateCacheKeyProvider.Invoke(path);
+            }
+
+            if (cache.TemplateCache.TryGetValue(cacheKey, out var template))
             {
                 return template;
             }
@@ -236,7 +243,7 @@ namespace Fluid.ViewEngine
             }
 
             var subTemplates = new List<IFluidTemplate>();
-                
+
             if (includeViewStarts)
             {
                 // Add ViewStart files


### PR DESCRIPTION
This allows implementers to provide a delegate for generating the key that's used for template caching/retrieval.  Therefore it allows templates to be cached based on something other than (just) their path + name.
Used with a custom file provider it allows different templates to be served based on arbitrary request properties - e.g. user-agent, cookie etc.
Possible solution for #470 
