### PR TITLE
Make color filter independent of CultureInfo.CurrentCulture

### DIFF
--- a/Fluid.Tests/ColorFiltersTests.cs
+++ b/Fluid.Tests/ColorFiltersTests.cs
@@ -1,7 +1,8 @@
-﻿using Fluid.Values;
-using Fluid.Filters;
-using Xunit;
+﻿using Fluid.Filters;
+using Fluid.Values;
+using System.Globalization;
 using System.Linq;
+using Xunit;
 
 namespace Fluid.Tests
 {
@@ -34,6 +35,27 @@ namespace Fluid.Tests
 
             // Assert
             Assert.Equal(expected, result.Result.ToStringValue());
+        }
+
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("de")]
+        [InlineData("fr-FR")]
+        [InlineData("zh-Hans")]
+        public void ToRgbShouldNotBeAffectedByCurrentCulture(string culture)
+        {
+            // Arrange
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
+
+            var input = new StringValue("hsla(0.5, 77.3%, 49.1%, 0.5)");
+            var context = new TemplateContext();
+
+            // Act
+            var result = ColorFilters.ToRgb(input, FilterArguments.Empty, context);
+
+            // Assert
+            Assert.Equal("rgba(222, 30, 28, 0.5)", result.Result.ToStringValue());
         }
 
         [Theory]
@@ -70,6 +92,27 @@ namespace Fluid.Tests
         }
 
         [Theory]
+        [InlineData("en-US")]
+        [InlineData("de")]
+        [InlineData("fr-FR")]
+        [InlineData("zh-Hans")]
+        public void ToHexShouldNotBeAffectedByCurrentCulture(string culture)
+        {
+            // Arrange
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
+
+            var input = new StringValue("hsla(0.5, 77.3%, 49.1%, 0.5)");
+            var context = new TemplateContext();
+
+            // Act
+            var result = ColorFilters.ToHex(input, FilterArguments.Empty, context);
+
+            // Assert
+            Assert.Equal("#de1e1c", result.Result.ToStringValue());
+        }
+
+        [Theory]
         [InlineData("#fff", "hsl(0, 0%, 100%)")]
         [InlineData("#000", "hsl(0, 0%, 0%)")]
         [InlineData("#f00", "hsl(0, 100%, 50%)")]
@@ -94,6 +137,27 @@ namespace Fluid.Tests
 
             // Assert
             Assert.Equal(expected, result.Result.ToStringValue());
+        }
+
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("de")]
+        [InlineData("fr-FR")]
+        [InlineData("zh-Hans")]
+        public void ToHslShouldNotBeAffectedByCurrentCulture(string culture)
+        {
+            // Arrange
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
+
+            var input = new StringValue("rgba(124, 26, 1, 0.5)");
+            var context = new TemplateContext();
+
+            // Act
+            var result = ColorFilters.ToHsl(input, FilterArguments.Empty, context);
+
+            // Assert
+            Assert.Equal("hsla(12, 98%, 25%, 0.5)", result.Result.ToStringValue());
         }
 
         [Theory]
@@ -134,6 +198,30 @@ namespace Fluid.Tests
         }
 
         [Theory]
+        [InlineData("en-US")]
+        [InlineData("de")]
+        [InlineData("fr-FR")]
+        [InlineData("zh-Hans")]
+        public void ColorExtractShouldNotBeAffectedByCurrentCulture(string culture)
+        {
+            // Arrange
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
+
+            var input = new StringValue("hsl(100, 38%, 54%, 0.5)");
+            var context = new TemplateContext();
+            var arguments = new FluidValue[] {
+                FluidValue.Create("alpha", TemplateOptions.Default),
+            };
+
+            // Act
+            var result = ColorFilters.ColorExtract(input, new FilterArguments(arguments), context);
+
+            // Assert
+            Assert.Equal("0.5", result.Result.ToStringValue());
+        }
+
+        [Theory]
         [InlineData("#7bb65d", new object[] { "red", 255 }, "#ffb65d")]
         [InlineData("#7bb65d", new object[] { "green", 255 }, "#7bff5d")]
         [InlineData("#7bb65d", new object[] { "blue", 255 }, "#7bb6ff")]
@@ -162,10 +250,35 @@ namespace Fluid.Tests
             var context = new TemplateContext();
 
             // Act
-              var result = ColorFilters.ColorModify(input, new FilterArguments(arguments.Select(x => FluidValue.Create(x, TemplateOptions.Default)).ToArray()), context);
+            var result = ColorFilters.ColorModify(input, new FilterArguments(arguments.Select(x => FluidValue.Create(x, TemplateOptions.Default)).ToArray()), context);
 
             // Assert
             Assert.Equal(expected, result.Result.ToStringValue());
+        }
+
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("de")]
+        [InlineData("fr-FR")]
+        [InlineData("zh-Hans")]
+        public void ColorModifyShouldNotBeAffectedByCurrentCulture(string culture)
+        {
+            // Arrange
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
+
+            var input = new StringValue("hsla(100, 38%, 54%, 0.5)");
+            var context = new TemplateContext();
+            var arguments = new FluidValue[] {
+                FluidValue.Create("alpha", TemplateOptions.Default),
+                FluidValue.Create("0.8", TemplateOptions.Default),
+            };
+
+            // Act
+            var result = ColorFilters.ColorModify(input, new FilterArguments(arguments), context);
+
+            // Assert
+            Assert.Equal("hsla(100, 38%, 54%, 0.8)", result.Result.ToStringValue());
         }
 
         [Theory]
@@ -218,7 +331,7 @@ namespace Fluid.Tests
             // Assert
             Assert.Equal(expected, result.Result.ToStringValue());
         }
-        
+
         [Theory]
         [InlineData("#7bb65d", new object[] { 30 }, "#d1e6c7")]
         [InlineData("rgb(123, 182, 93)", new object[] { 30 }, "rgb(209, 230, 199)")]

--- a/Fluid.Tests/ColorFiltersTests.cs
+++ b/Fluid.Tests/ColorFiltersTests.cs
@@ -45,8 +45,7 @@ namespace Fluid.Tests
         public void ToRgbShouldNotBeAffectedByCurrentCulture(string culture)
         {
             // Arrange
-            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
-            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
+            SetCurrentCulture(culture);
 
             var input = new StringValue("hsla(0.5, 77.3%, 49.1%, 0.5)");
             var context = new TemplateContext();
@@ -99,8 +98,7 @@ namespace Fluid.Tests
         public void ToHexShouldNotBeAffectedByCurrentCulture(string culture)
         {
             // Arrange
-            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
-            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
+            SetCurrentCulture(culture);
 
             var input = new StringValue("hsla(0.5, 77.3%, 49.1%, 0.5)");
             var context = new TemplateContext();
@@ -147,8 +145,7 @@ namespace Fluid.Tests
         public void ToHslShouldNotBeAffectedByCurrentCulture(string culture)
         {
             // Arrange
-            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
-            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
+            SetCurrentCulture(culture);
 
             var input = new StringValue("rgba(124, 26, 1, 0.5)");
             var context = new TemplateContext();
@@ -205,8 +202,7 @@ namespace Fluid.Tests
         public void ColorExtractShouldNotBeAffectedByCurrentCulture(string culture)
         {
             // Arrange
-            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
-            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
+            SetCurrentCulture(culture);
 
             var input = new StringValue("hsl(100, 38%, 54%, 0.5)");
             var context = new TemplateContext();
@@ -264,8 +260,7 @@ namespace Fluid.Tests
         public void ColorModifyShouldNotBeAffectedByCurrentCulture(string culture)
         {
             // Arrange
-            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
-            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
+            SetCurrentCulture(culture);
 
             var input = new StringValue("hsla(100, 38%, 54%, 0.5)");
             var context = new TemplateContext();
@@ -415,6 +410,12 @@ namespace Fluid.Tests
 
             // Assert
             Assert.Equal(expected, result.Result.ToNumberValue());
+        }
+
+        private static void SetCurrentCulture(string culture)
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
         }
     }
 }

--- a/Fluid/Filters/ColorFilters.cs
+++ b/Fluid/Filters/ColorFilters.cs
@@ -687,13 +687,6 @@ namespace Fluid.Filters
                 {
                     var rgbColor = value.Split(_colorSeparators, StringSplitOptions.RemoveEmptyEntries);
 
-                    // We will parse these values with NumberStyles.Float, because it gets "close enough" to the actual CSS Standard.
-                    // In reality, we would need to also parse number like '.2' to 0.2.
-                    // See: https://developer.mozilla.org/en-US/docs/Web/CSS/number
-
-                    // Every value of rbg or rgba could also be a percentage in the CSS standard.
-                    // This is currently not supported by this function.
-                    // See: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb
                     if (rgbColor.Length == 4 &&
                         Int32.TryParse(rgbColor[1], NumberStyles.Float, CultureInfo.InvariantCulture, out int red) &&
                         Int32.TryParse(rgbColor[2], NumberStyles.Float, CultureInfo.InvariantCulture, out int green) &&
@@ -868,14 +861,6 @@ namespace Fluid.Filters
                 {
                     var hslColor = value.Split(_colorSeparators, StringSplitOptions.RemoveEmptyEntries);
 
-                    // We will parse these values with NumberStyles.Float, because it gets "close enough" to the actual CSS Standard.
-                    // In reality, we would need to also parse number like '.2' to 0.2.
-                    // See: https://developer.mozilla.org/en-US/docs/Web/CSS/number
-
-                    // The hue is always represented in the CSS unit <number> and never in the CSS unit <angle>.
-                    // This means the hue is always in degrees, other units defined by the CSS standard are not
-                    // supported by this function.
-                    // See: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl
                     if (hslColor.Length == 4 && hslColor[2].EndsWith("%") && hslColor[3].EndsWith("%") &&
                         Double.TryParse(hslColor[1], NumberStyles.Float, CultureInfo.InvariantCulture, out double hue) &&
                         Double.TryParse(hslColor[2].TrimEnd('%'), NumberStyles.Float, CultureInfo.InvariantCulture, out double saturation) &&
@@ -886,8 +871,6 @@ namespace Fluid.Filters
                         return true;
                     }
 
-                    // Alpha could also be a percentage in the CSS standard. This is currently not supported by this function.
-                    // See: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl
                     if (hslColor.Length == 5 && hslColor[2].EndsWith("%") && hslColor[3].EndsWith("%") &&
                         Double.TryParse(hslColor[1], NumberStyles.Float, CultureInfo.InvariantCulture, out hue) &&
                         Double.TryParse(hslColor[2].TrimEnd('%'), NumberStyles.Float, CultureInfo.InvariantCulture, out saturation) &&

--- a/Fluid/Filters/ColorFilters.cs
+++ b/Fluid/Filters/ColorFilters.cs
@@ -805,8 +805,8 @@ namespace Fluid.Filters
             }
 
             public override string ToString() => (A == DefaultTransperency)
-                ? $"rgb({R}, {G}, {B})".ToString(CultureInfo.InvariantCulture)
-                : $"rgba({R}, {G}, {B}, {Math.Round(A, 1)})".ToString(CultureInfo.InvariantCulture);
+                ? FormattableString.Invariant($"rgb({R}, {G}, {B})")
+                : FormattableString.Invariant($"rgba({R}, {G}, {B}, {Math.Round(A, 1)})");
 
             public bool Equals(RgbColor other) => R == other.R && G == other.G && B == other.B;
         }
@@ -948,8 +948,8 @@ namespace Fluid.Filters
             }
 
             public override string ToString() => (A == DefaultTransparency)
-                ? $"hsl({H}, {S * 100.0}%, {L * 100.0}%)".ToString(CultureInfo.InvariantCulture)
-                : $"hsla({H}, {S * 100.0}%, {L * 100.0}%, {Math.Round(A, 1)})".ToString(CultureInfo.InvariantCulture);
+                ? FormattableString.Invariant($"hsl({H}, {S * 100.0}%, {L * 100.0}%)")
+                : FormattableString.Invariant($"hsla({H}, {S * 100.0}%, {L * 100.0}%, {Math.Round(A, 1)})");
         }
     }
 }

--- a/Fluid/Filters/ColorFilters.cs
+++ b/Fluid/Filters/ColorFilters.cs
@@ -804,7 +804,7 @@ namespace Fluid.Filters
                     );
             }
 
-            public override string ToString() => (A == DefaultTransperency)
+            public override string ToString() => A == DefaultTransperency
                 ? FormattableString.Invariant($"rgb({R}, {G}, {B})")
                 : FormattableString.Invariant($"rgba({R}, {G}, {B}, {Math.Round(A, 1)})");
 
@@ -947,7 +947,7 @@ namespace Fluid.Filters
                 return new HslColor(Convert.ToInt32(h), Math.Round(s, 2), Math.Round(l, 2), rgbColor.A);
             }
 
-            public override string ToString() => (A == DefaultTransparency)
+            public override string ToString() => A == DefaultTransparency
                 ? FormattableString.Invariant($"hsl({H}, {S * 100.0}%, {L * 100.0}%)")
                 : FormattableString.Invariant($"hsla({H}, {S * 100.0}%, {L * 100.0}%, {Math.Round(A, 1)})");
         }

--- a/Fluid/Filters/ColorFilters.cs
+++ b/Fluid/Filters/ColorFilters.cs
@@ -1,8 +1,9 @@
-﻿using System;
+﻿using Fluid.Values;
+using System;
 using System.Drawing;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
-using Fluid.Values;
 
 namespace Fluid.Filters
 {
@@ -115,13 +116,13 @@ namespace Fluid.Filters
 
             return arguments.At(0).ToStringValue() switch
             {
-                "alpha" => new StringValue(rgbColor.A.ToString()),
-                "red" => new StringValue(rgbColor.R.ToString()),
-                "green" => new StringValue(rgbColor.G.ToString()),
-                "blue" => new StringValue(rgbColor.B.ToString()),
-                "hue" => new StringValue(hslColor.H.ToString()),
-                "saturation" => new StringValue(Convert.ToInt32(hslColor.S * 100.0).ToString()),
-                "lightness" => new StringValue(Convert.ToInt32(hslColor.L * 100.0).ToString()),
+                "alpha" => new StringValue(rgbColor.A.ToString(CultureInfo.InvariantCulture)),
+                "red" => new StringValue(rgbColor.R.ToString(CultureInfo.InvariantCulture)),
+                "green" => new StringValue(rgbColor.G.ToString(CultureInfo.InvariantCulture)),
+                "blue" => new StringValue(rgbColor.B.ToString(CultureInfo.InvariantCulture)),
+                "hue" => new StringValue(hslColor.H.ToString(CultureInfo.InvariantCulture)),
+                "saturation" => new StringValue(Convert.ToInt32(hslColor.S * 100.0).ToString(CultureInfo.InvariantCulture)),
+                "lightness" => new StringValue(Convert.ToInt32(hslColor.L * 100.0).ToString(CultureInfo.InvariantCulture)),
                 _ => NilValue.Empty,
             };
         }
@@ -685,10 +686,18 @@ namespace Fluid.Filters
                 if ((value.StartsWith("rgb(") || value.StartsWith("rgba(")) && value.EndsWith(")"))
                 {
                     var rgbColor = value.Split(_colorSeparators, StringSplitOptions.RemoveEmptyEntries);
+
+                    // We will parse these values with NumberStyles.Float, because it gets "close enough" to the actual CSS Standard.
+                    // In reality, we would need to also parse number like '.2' to 0.2.
+                    // See: https://developer.mozilla.org/en-US/docs/Web/CSS/number
+
+                    // Every value of rbg or rgba could also be a percentage in the CSS standard.
+                    // This is currently not supported by this function.
+                    // See: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb
                     if (rgbColor.Length == 4 &&
-                        Int32.TryParse(rgbColor[1], out int red) &&
-                        Int32.TryParse(rgbColor[2], out int green) &&
-                        Int32.TryParse(rgbColor[3], out int blue))
+                        Int32.TryParse(rgbColor[1], NumberStyles.Float, CultureInfo.InvariantCulture, out int red) &&
+                        Int32.TryParse(rgbColor[2], NumberStyles.Float, CultureInfo.InvariantCulture, out int green) &&
+                        Int32.TryParse(rgbColor[3], NumberStyles.Float, CultureInfo.InvariantCulture, out int blue))
                     {
                         color = new RgbColor(red, green, blue);
 
@@ -696,10 +705,10 @@ namespace Fluid.Filters
                     }
 
                     if (rgbColor.Length == 5 &&
-                        Int32.TryParse(rgbColor[1], out red) &&
-                        Int32.TryParse(rgbColor[2], out green) &&
-                        Int32.TryParse(rgbColor[3], out blue) &&
-                        Single.TryParse(rgbColor[4], out float alpha))
+                        Int32.TryParse(rgbColor[1], NumberStyles.Float, CultureInfo.InvariantCulture, out red) &&
+                        Int32.TryParse(rgbColor[2], NumberStyles.Float, CultureInfo.InvariantCulture, out green) &&
+                        Int32.TryParse(rgbColor[3], NumberStyles.Float, CultureInfo.InvariantCulture, out blue) &&
+                        Single.TryParse(rgbColor[4], NumberStyles.Float, CultureInfo.InvariantCulture, out float alpha))
                     {
                         color = new RgbColor(red, green, blue, alpha);
 
@@ -802,9 +811,19 @@ namespace Fluid.Filters
                     );
             }
 
-            public override string ToString() => A == DefaultTransperency
-                ? $"rgb({R}, {G}, {B})"
-                : $"rgba({R}, {G}, {B}, {Math.Round(A, 1)})";
+            public override string ToString()
+            {
+                if (A == DefaultTransperency)
+                {
+                    FormattableString format = $"rgb({R}, {G}, {B})";
+                    return format.ToString(CultureInfo.InvariantCulture);
+                }
+                else
+                {
+                    FormattableString format = $"rgba({R}, {G}, {B}, {Math.Round(A, 1)})";
+                    return format.ToString(CultureInfo.InvariantCulture);
+                }
+            }
 
             public bool Equals(RgbColor other) => R == other.R && G == other.G && B == other.B;
         }
@@ -858,21 +877,32 @@ namespace Fluid.Filters
                 if ((value.StartsWith("hsl(") || value.StartsWith("hsla(")) && value.EndsWith(")"))
                 {
                     var hslColor = value.Split(_colorSeparators, StringSplitOptions.RemoveEmptyEntries);
+
+                    // We will parse these values with NumberStyles.Float, because it gets "close enough" to the actual CSS Standard.
+                    // In reality, we would need to also parse number like '.2' to 0.2.
+                    // See: https://developer.mozilla.org/en-US/docs/Web/CSS/number
+
+                    // The hue is always represented in the CSS unit <number> and never in the CSS unit <angle>.
+                    // This means the hue is always in degrees, other units defined by the CSS standard are not
+                    // supported by this function.
+                    // See: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl
                     if (hslColor.Length == 4 && hslColor[2].EndsWith("%") && hslColor[3].EndsWith("%") &&
-                        Double.TryParse(hslColor[1], out double hue) &&
-                        Double.TryParse(hslColor[2].TrimEnd('%'), out double saturation) &&
-                        Double.TryParse(hslColor[3].TrimEnd('%'), out double lightness))
+                        Double.TryParse(hslColor[1], NumberStyles.Float, CultureInfo.InvariantCulture, out double hue) &&
+                        Double.TryParse(hslColor[2].TrimEnd('%'), NumberStyles.Float, CultureInfo.InvariantCulture, out double saturation) &&
+                        Double.TryParse(hslColor[3].TrimEnd('%'), NumberStyles.Float, CultureInfo.InvariantCulture, out double lightness))
                     {
                         color = new HslColor(hue, saturation / 100.0, lightness / 100.0);
 
                         return true;
                     }
 
+                    // Alpha could also be a percentage in the CSS standard. This is currently not supported by this function.
+                    // See: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl
                     if (hslColor.Length == 5 && hslColor[2].EndsWith("%") && hslColor[3].EndsWith("%") &&
-                        Double.TryParse(hslColor[1], out hue) &&
-                        Double.TryParse(hslColor[2].TrimEnd('%'), out saturation) &&
-                        Double.TryParse(hslColor[3].TrimEnd('%'), out lightness) &&
-                        Double.TryParse(hslColor[4], out double alpha))
+                        Double.TryParse(hslColor[1], NumberStyles.Float, CultureInfo.InvariantCulture, out hue) &&
+                        Double.TryParse(hslColor[2].TrimEnd('%'), NumberStyles.Float, CultureInfo.InvariantCulture, out saturation) &&
+                        Double.TryParse(hslColor[3].TrimEnd('%'), NumberStyles.Float, CultureInfo.InvariantCulture, out lightness) &&
+                        Double.TryParse(hslColor[4], NumberStyles.Float, CultureInfo.InvariantCulture, out double alpha))
                     {
                         color = new HslColor(hue, saturation / 100.0, lightness / 100.0, alpha);
 
@@ -944,9 +974,20 @@ namespace Fluid.Filters
                 return new HslColor(Convert.ToInt32(h), Math.Round(s, 2), Math.Round(l, 2), rgbColor.A);
             }
 
-            public override string ToString() => A == DefaultTransparency
-                ? $"hsl({H}, {S * 100.0}%, {L * 100.0}%)"
-                : $"hsla({H}, {S * 100.0}%, {L * 100.0}%, {Math.Round(A, 1)})";
+            public override string ToString()
+            {
+                if (A == DefaultTransparency)
+                {
+                    FormattableString format = $"hsl({H}, {S * 100.0}%, {L * 100.0}%)";
+                    return format.ToString(CultureInfo.InvariantCulture);
+                }
+                else
+                {
+                    FormattableString format = $"hsla({H}, {S * 100.0}%, {L * 100.0}%, {Math.Round(A, 1)})";
+                    return format.ToString(CultureInfo.InvariantCulture);
+                }
+            }
+
         }
     }
 }

--- a/Fluid/Filters/ColorFilters.cs
+++ b/Fluid/Filters/ColorFilters.cs
@@ -811,19 +811,9 @@ namespace Fluid.Filters
                     );
             }
 
-            public override string ToString()
-            {
-                if (A == DefaultTransperency)
-                {
-                    FormattableString format = $"rgb({R}, {G}, {B})";
-                    return format.ToString(CultureInfo.InvariantCulture);
-                }
-                else
-                {
-                    FormattableString format = $"rgba({R}, {G}, {B}, {Math.Round(A, 1)})";
-                    return format.ToString(CultureInfo.InvariantCulture);
-                }
-            }
+            public override string ToString() => (A == DefaultTransperency)
+                ? $"rgb({R}, {G}, {B})".ToString(CultureInfo.InvariantCulture)
+                : $"rgba({R}, {G}, {B}, {Math.Round(A, 1)})".ToString(CultureInfo.InvariantCulture);
 
             public bool Equals(RgbColor other) => R == other.R && G == other.G && B == other.B;
         }
@@ -974,20 +964,9 @@ namespace Fluid.Filters
                 return new HslColor(Convert.ToInt32(h), Math.Round(s, 2), Math.Round(l, 2), rgbColor.A);
             }
 
-            public override string ToString()
-            {
-                if (A == DefaultTransparency)
-                {
-                    FormattableString format = $"hsl({H}, {S * 100.0}%, {L * 100.0}%)";
-                    return format.ToString(CultureInfo.InvariantCulture);
-                }
-                else
-                {
-                    FormattableString format = $"hsla({H}, {S * 100.0}%, {L * 100.0}%, {Math.Round(A, 1)})";
-                    return format.ToString(CultureInfo.InvariantCulture);
-                }
-            }
-
+            public override string ToString() => (A == DefaultTransparency)
+                ? $"hsl({H}, {S * 100.0}%, {L * 100.0}%)".ToString(CultureInfo.InvariantCulture)
+                : $"hsla({H}, {S * 100.0}%, {L * 100.0}%, {Math.Round(A, 1)})".ToString(CultureInfo.InvariantCulture);
         }
     }
 }


### PR DESCRIPTION
I actually wanted to fix a different bug regarding layout file resolution, but all color tests were failing on my german Windows machine so this had to come first. 

Color filters need to generate and parse valid CSS values. The syntax of
these is always independent of the currently set culture, so the filters
must reflect that by using CultureInfo.InvariantCulture.

The Visual Studio auto formatter also changed stuff like 
```
if ((uint) red > 255)
```
to
```
if ((uint)red > 255)
```

There seems to be no `.editorconfig` in this repository so I don't know if this is right 🤷‍♂️. If you don't want this, I will change it back :).