### PR TITLE
Add translate filter and supporting infrastructure.

### DIFF
--- a/Fluid.Tests/Fluid.Tests.csproj
+++ b/Fluid.Tests/Fluid.Tests.csproj
@@ -25,4 +25,10 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Update="SR.resx">
+      <Generator></Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>

--- a/Fluid.Tests/MiscFiltersTests.cs
+++ b/Fluid.Tests/MiscFiltersTests.cs
@@ -738,6 +738,36 @@ namespace Fluid.Tests
             Assert.Equal("c7ac4687585ab5d3d5030db5a5cfc959fdf4e608cc396f1f615db345e35adb9e", result.ToStringValue());
         }
 
+        /// <summary>
+        /// <see cref="MiscFilters.Translate"/> filter tests.
+        /// </summary>
+        /// <remarks>
+        /// The default <see cref="NullResourcesProvider"/> is used for these tests. This provider just returns the
+        /// requested resource key as-is.
+        /// </remarks>
+        [Theory]
+        [InlineData("Hello", new object[] {}, null, "Hello")]
+        [InlineData("Hello {0}", new object[] {"there!"}, null, "Hello there!")]
+        [InlineData("Price: {0:C}", new object[] {123.45}, "en-US", "Price: $123.45")]
+        [InlineData("Price: {0:C}", new object[] {123.45}, "fr-FR", "Price: 123,45 €")]
+        public async Task Translate(object input, object[] args, string culture, string expected)
+        {
+            // Arrange
+            var cultureInfo = String.IsNullOrEmpty(culture)
+                    ? CultureInfo.InvariantCulture
+                    : CultureInfo.CreateSpecificCulture(culture)
+                    ;
+            
+            var context = new TemplateContext(new TemplateOptions { CultureInfo = cultureInfo });
+            var arguments = new FilterArguments(args.Select(x => FluidValue.Create(x, context.Options)).ToArray());
+            
+            // Act
+            var result = await MiscFilters.Translate(FluidValue.Create(input, context.Options), arguments, context);
+
+            // Assert
+            Assert.Equal(expected, result.ToStringValue());
+        }
+        
         public static class TestObjects
         {
             public class Node

--- a/Fluid.Tests/ResourcesProviderTests.cs
+++ b/Fluid.Tests/ResourcesProviderTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Fluid.Tests
+{
+    public class ResourcesProviderTests
+    {
+        [Theory]
+        [InlineData("Hello", null, "Hello")]
+        [InlineData("Hello", "fr-FR", "Bonjour")]
+        [InlineData("Hello", "pl-PL", "Cześć")]
+        [InlineData("Hello", "de-DE", "Hello")] // No translations for German - fallback.
+        [InlineData("Missing", null, null)]
+        public async Task GetStringShouldSucceed(string key, string culture, string expected)
+        {
+            // Arrange
+            var cultureInfo = String.IsNullOrEmpty(culture)
+                    ? CultureInfo.InvariantCulture
+                    : CultureInfo.CreateSpecificCulture(culture)
+                ;            
+            var rp = new ResxResourcesProvider("Fluid.Tests.SR", GetType().Assembly);
+
+            // Act
+            var result = await rp.GetString(key, cultureInfo);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/Fluid.Tests/SR.fr.resx
+++ b/Fluid.Tests/SR.fr.resx
@@ -1,0 +1,17 @@
+<root>
+    <resheader name="resmimetype">
+        <value>text/microsoft-resx</value>
+    </resheader>
+    <resheader name="version">
+        <value>1.3</value>
+    </resheader>
+    <resheader name="reader">
+        <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+    <resheader name="writer">
+        <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+    <data name="Hello" xml:space="preserve">
+        <value>Bonjour</value>
+    </data>
+</root>

--- a/Fluid.Tests/SR.pl.resx
+++ b/Fluid.Tests/SR.pl.resx
@@ -1,0 +1,17 @@
+<root>
+    <resheader name="resmimetype">
+        <value>text/microsoft-resx</value>
+    </resheader>
+    <resheader name="version">
+        <value>1.3</value>
+    </resheader>
+    <resheader name="reader">
+        <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+    <resheader name="writer">
+        <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+    <data name="Hello" xml:space="preserve">
+        <value>Cześć</value>
+    </data>
+</root>

--- a/Fluid.Tests/SR.resx
+++ b/Fluid.Tests/SR.resx
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<root>
+    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <xsd:element name="root" msdata:IsDataSet="true">
+            
+        </xsd:element>
+    </xsd:schema>
+    <resheader name="resmimetype">
+        <value>text/microsoft-resx</value>
+    </resheader>
+    <resheader name="version">
+        <value>1.3</value>
+    </resheader>
+    <resheader name="reader">
+        <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+    <resheader name="writer">
+        <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+    <data name="Hello" xml:space="preserve">
+        <value>Hello</value>
+    </data>
+</root>

--- a/Fluid/IResourcesProvider.cs
+++ b/Fluid/IResourcesProvider.cs
@@ -1,0 +1,20 @@
+﻿using System.Globalization;
+using System.Threading.Tasks;
+
+namespace Fluid
+{
+    /// <summary>
+    /// Provider to lookup resource values (translations). Used by the 'translate' filter.
+    /// </summary>
+    public interface IResourcesProvider
+    {
+        /// <summary>
+        /// Look up a resource value for a particular name in the specified culture.
+        /// </summary>
+        /// <param name="name">Name of the resource value to lookup</param>
+        /// <param name="culture">If provided, looks up the resource value for the specified
+        /// <see cref="CultureInfo"/>. If <c>null</c>, the current culture is used.</param>
+        /// <returns>The resource value for the given <paramref name="name"/> or <c>null</c> if not found.</returns>
+        ValueTask<string> GetString(string name, CultureInfo culture);
+    }
+}

--- a/Fluid/NullResourcesProvider.cs
+++ b/Fluid/NullResourcesProvider.cs
@@ -1,0 +1,15 @@
+﻿using System.Globalization;
+using System.Threading.Tasks;
+
+namespace Fluid
+{
+    /// <summary>
+    /// Default implementation of <see cref="IResourcesProvider"/> that simply returns the resource name
+    /// as the value.
+    /// </summary>
+    public class NullResourcesProvider : IResourcesProvider
+    {
+        /// <inheritdoc />
+        public ValueTask<string> GetString(string name, CultureInfo culture) => new ValueTask<string>(name);
+    }
+}

--- a/Fluid/ResxResourcesProvider.cs
+++ b/Fluid/ResxResourcesProvider.cs
@@ -1,0 +1,33 @@
+﻿using System.Globalization;
+using System.Reflection;
+using System.Resources;
+using System.Threading.Tasks;
+
+namespace Fluid
+{
+    /// <summary>
+    /// <see cref="IResourcesProvider"/> implementation to load resource strings from standard .NET .resx files.
+    /// </summary>
+    public class ResxResourcesProvider : IResourcesProvider
+    {
+        /// <summary>
+        /// Initialises a new <see cref="ResxResourcesProvider"/>.
+        /// </summary>
+        /// <param name="baseName">The root name of the resource file without its extension but including any
+        /// fully qualified namespace name. For example, the root name for the resource file
+        /// 'MyApplication.MyResources.en-US.resx' is 'MyApplication.MyResources'.</param>
+        /// <param name="assembly">The main assembly for the resources.</param>
+        /// <remarks>For performance reasons, create a single instance of this class for a given resource
+        /// bundle for your application.</remarks>
+        public ResxResourcesProvider(string baseName, Assembly assembly)
+        {
+            _resourceManager = new ResourceManager(baseName, assembly);
+        }
+
+        private readonly ResourceManager _resourceManager;
+
+        /// <inheritdoc />
+        public ValueTask<string> GetString(string name, CultureInfo culture) =>
+            new ValueTask<string>(_resourceManager.GetString(name, culture));
+    }
+}

--- a/Fluid/TemplateContext.cs
+++ b/Fluid/TemplateContext.cs
@@ -52,6 +52,7 @@ namespace Fluid
             LocalScope = new Scope(options.Scope);
             RootScope = LocalScope;
             CultureInfo = options.CultureInfo;
+            ResourcesProvider = options.ResourcesProvider;
             TimeZone = options.TimeZone;
             Captured = options.Captured;
             Now = options.Now;
@@ -90,6 +91,12 @@ namespace Fluid
         /// </summary>
         public CultureInfo CultureInfo { get; set; } = TemplateOptions.Default.CultureInfo;
 
+        /// <summary>
+        /// Gets or sets the <see cref="IResourcesProvider"/> used to lookup resource strings (translations) for the
+        /// 'translate' filter.
+        /// </summary>
+        public IResourcesProvider ResourcesProvider { get; set; } = TemplateOptions.Default.ResourcesProvider;        
+        
         /// <summary>
         /// Gets or sets the value to returned by the "now" keyword.
         /// </summary>

--- a/Fluid/TemplateOptions.cs
+++ b/Fluid/TemplateOptions.cs
@@ -23,6 +23,12 @@ namespace Fluid
         public IFileProvider FileProvider { get; set; } = new NullFileProvider();
 
         /// <summary>
+        /// Gets or sets the <see cref="IResourcesProvider"/> used to lookup resource strings (translations) for the
+        /// 'translate' filter.
+        /// </summary>
+        public IResourcesProvider ResourcesProvider { get; set; } = new NullResourcesProvider();        
+        
+        /// <summary>
         /// Gets or sets the maximum number of steps a script can execute. Leave to 0 for unlimited.
         /// </summary>
         public int MaxSteps { get; set; }

--- a/README.md
+++ b/README.md
@@ -368,6 +368,48 @@ Tuesday, August 1, 2017
 
 <br>
 
+### Using Resource Files
+
+`TemplateOptions` and `TemplateContext` provides a property to define an `IResourcesProvider` to load resources (translations)
+for use by the `translate` (or `t` shorthand) filter.
+
+> For performance reasons, it is best practice to use a single instance of `ResxResourcesProvider` for a given resource bundle.
+
+#### Source
+```charp
+var rp = new ResxResourcesProvider("MyApp.Resources", GetType().Assembly);
+var context = new TemplateContext { ResourcesProvider = rp } ;
+var result = template.Render(context);
+```
+
+```resx
+<?xml version="1.0" encoding="utf-8"?>
+<!-- MyApp.Resources.resx -->
+<root>
+    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    </xsd:schema>
+
+    <data name="Welcome" xml:space="preserve">
+        <value>Hello there!</value>
+    </data>
+    <data name="Footer" xml:space="preserve">
+        <value>Goodbye, {0}.</value>
+    </data>    
+</root>
+```
+
+```liquid
+<p>{{ "Welcome" | t }}</p>
+<p>{{ "Goodbye" | t: "Bob"}}</p>
+```
+
+#### Result
+```html
+<p>Hello there!</p>
+<p>Goodbye Bob.</p>
+```
+<br>
+
 ## Time zones
 
 ### System time zone


### PR DESCRIPTION
Hi there, I had a requirement for something like See https://shopify.dev/themes/architecture/locales/storefront-locale-files to use translations from resx files.

Not sure if it's something you'd like in the base library but here's a PR for it.

- Adds a `translate` (or `t`) filter to load and use translations from an external source.
- Adds an `IResourcesProvider` to `TemplateContext` and `TemplateOptions` for the filter to load translations.
- Adds a concrete `ResxResourcesProvider` to load translations from standard .NET resx files.

There is also a `NullResourcesProvider` which simply returns the translation key unmodified - this is installed by default. I'm not 100% sure about this. I added it so that using `t` wouldn't cause a crash if a suitable `IResourcesProvider` wasnt configured but maybe it's better to throw an exception.

Use it like this:
```charp
var rp = new ResxResourcesProvider("MyApp.Resources", GetType().Assembly);
var context = new TemplateContext { ResourcesProvider = rp } ;
var result = template.Render(context);
```

```resx
<?xml version="1.0" encoding="utf-8"?>
<!-- MyApp.Resources.resx -->
<root>
    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
    </xsd:schema>
    <data name="Welcome" xml:space="preserve">
        <value>Hello there!</value>
    </data>
    <data name="Footer" xml:space="preserve">
        <value>Goodbye, {0}.</value>
    </data>    
</root>
```

```liquid
<p>{{ "Welcome" | t }}</p>
<p>{{ "Goodbye" | t: "Bob"}}</p>
```

#### Result
```html
<p>Hello there!</p>
<p>Goodbye Bob.</p>
```