### PR TITLE
sebastienros/fluid#578 Implement tag names

### DIFF
--- a/Fluid.Tests/Extensibility/ExtensibilityTests.cs
+++ b/Fluid.Tests/Extensibility/ExtensibilityTests.cs
@@ -1,4 +1,5 @@
 ﻿using Fluid.Ast;
+using Fluid.Parser;
 using Parlot.Fluent;
 using System;
 using Xunit;
@@ -19,10 +20,12 @@ namespace Fluid.Tests.Extensibility
                 return Statement.Normal();
             });
 
-            var template = parser.Parse("{% hello %}");
+            var template = (FluidTemplate) parser.Parse("{% hello %}");
             var result = template.Render();
 
             Assert.Equal("Hello World", result);
+            Assert.True(template.Statements.Count == 1);
+            Assert.True(((IHasTagName)template.Statements[0]).TagName == "hello");
         }
 
         [Fact]
@@ -53,10 +56,12 @@ namespace Fluid.Tests.Extensibility
                 return Statement.Normal();
             });
 
-            var template = parser.Parse("{% hello test %}");
+            var template = (FluidTemplate)parser.Parse("{% hello test %}");
             var result = template.Render();
 
             Assert.Equal("Hello test", result);
+            Assert.True(template.Statements.Count == 1);
+            Assert.True(((IHasTagName)template.Statements[0]).TagName == "hello");
         }
 
         [Fact]
@@ -70,10 +75,12 @@ namespace Fluid.Tests.Extensibility
                 return s.RenderStatementsAsync(w, e, c);
             });
 
-            var template = parser.Parse("{% hello %} hi {%- endhello %}");
+            var template = (FluidTemplate)parser.Parse("{% hello %} hi {%- endhello %}");
             var result = template.Render();
 
             Assert.Equal("Hello World hi", result);
+            Assert.True(template.Statements.Count == 1);
+            Assert.True(((IHasTagName)template.Statements[0]).TagName == "hello");
         }
 
         [Fact]
@@ -88,10 +95,12 @@ namespace Fluid.Tests.Extensibility
                 return s.RenderStatementsAsync(w, e, c);
             });
 
-            var template = parser.Parse("{% hello test %} hi {%- endhello %}");
+            var template = (FluidTemplate)parser.Parse("{% hello test %} hi {%- endhello %}");
             var result = template.Render();
 
             Assert.Equal("Hello test hi", result);
+            Assert.True(template.Statements.Count == 1);
+            Assert.True(((IHasTagName)template.Statements[0]).TagName == "hello");
         }
 
         [Fact]

--- a/Fluid.Tests/Extensibility/ExtensibilityTests.cs
+++ b/Fluid.Tests/Extensibility/ExtensibilityTests.cs
@@ -61,7 +61,8 @@ namespace Fluid.Tests.Extensibility
 
             Assert.Equal("Hello test", result);
             Assert.True(template.Statements.Count == 1);
-            Assert.True(((IHasTagName)template.Statements[0]).TagName == "hello");
+            Assert.Equal("hello", ((IHasTagName)template.Statements[0]).TagName);
+            Assert.Equal("test", ((IHasValue)template.Statements[0]).Value);
         }
 
         [Fact]
@@ -100,7 +101,8 @@ namespace Fluid.Tests.Extensibility
 
             Assert.Equal("Hello test hi", result);
             Assert.True(template.Statements.Count == 1);
-            Assert.True(((IHasTagName)template.Statements[0]).TagName == "hello");
+            Assert.Equal("hello", ((IHasTagName)template.Statements[0]).TagName);
+            Assert.Equal("test", ((IHasValue)template.Statements[0]).Value);
         }
 
         [Fact]

--- a/Fluid/FluidParser.cs
+++ b/Fluid/FluidParser.cs
@@ -540,25 +540,25 @@ namespace Fluid
         public void RegisterParserBlock<T>(string tagName, Parser<T> parser, Func<T, IReadOnlyList<Statement>, TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> render)
         {
             RegisteredTags[tagName] = parser.AndSkip(TagEnd).And(AnyTagsList).AndSkip(CreateTag("end" + tagName).ElseError($"'{{% end{tagName} %}}' was expected"))
-                .Then<Statement>(x => new ParserBlockStatement<T>(x.Item1, x.Item2, render))
+                .Then<Statement>(x => new ParserBlockStatement<T>(tagName, x.Item1, x.Item2, render))
                 .ElseError($"Invalid {tagName} tag")
                 ;
         }
 
         public void RegisterParserTag<T>(string tagName, Parser<T> parser, Func<T, TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> render)
         {
-            RegisteredTags[tagName] = parser.AndSkip(TagEnd).Then<Statement>(x => new ParserTagStatement<T>(x, render));
+            RegisteredTags[tagName] = parser.AndSkip(TagEnd).Then<Statement>(x => new ParserTagStatement<T>(tagName, x, render));
         }
 
         public void RegisterEmptyTag(string tagName, Func<TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> render)
         {
-            RegisteredTags[tagName] = TagEnd.Then<Statement>(x => new EmptyTagStatement(render)).ElseError($"Unexpected arguments in {tagName} tag");
+            RegisteredTags[tagName] = TagEnd.Then<Statement>(x => new EmptyTagStatement(tagName, render)).ElseError($"Unexpected arguments in {tagName} tag");
         }
 
         public void RegisterEmptyBlock(string tagName, Func<IReadOnlyList<Statement>, TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> render)
         {
             RegisteredTags[tagName] = TagEnd.SkipAnd(AnyTagsList).AndSkip(CreateTag("end" + tagName).ElseError($"'{{% end{tagName} %}}' was expected"))
-                .Then<Statement>(x => new EmptyBlockStatement(x, render))
+                .Then<Statement>(x => new EmptyBlockStatement(tagName, x, render))
                 .ElseError($"Invalid '{tagName}' tag")
                 ;
         }

--- a/Fluid/IFluidTemplate.cs
+++ b/Fluid/IFluidTemplate.cs
@@ -1,6 +1,8 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using Fluid.Ast;
 
 namespace Fluid
 {

--- a/Fluid/Parser/EmptyBlockStatement.cs
+++ b/Fluid/Parser/EmptyBlockStatement.cs
@@ -7,16 +7,18 @@ using System.Threading.Tasks;
 
 namespace Fluid.Parser
 {
-    internal sealed class EmptyBlockStatement : Statement
+    internal sealed class EmptyBlockStatement : Statement, IHasTagName
     {
         private readonly Func<IReadOnlyList<Statement>, TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> _render;
 
-        public EmptyBlockStatement(List<Statement> statements, Func<IReadOnlyList<Statement>, TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> render)
+        public EmptyBlockStatement(string tagName, List<Statement> statements, Func<IReadOnlyList<Statement>, TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> render)
         {
             _render = render ?? throw new ArgumentNullException(nameof(render));
+            TagName = tagName;
             Statements = statements ?? throw new ArgumentNullException(nameof(statements));
         }
 
+        public string TagName { get; init; }
         public List<Statement> Statements { get; }
 
         public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)

--- a/Fluid/Parser/EmptyTagStatement.cs
+++ b/Fluid/Parser/EmptyTagStatement.cs
@@ -6,14 +6,17 @@ using System.Threading.Tasks;
 
 namespace Fluid.Parser
 {
-    internal sealed class EmptyTagStatement : Statement
+    internal sealed class EmptyTagStatement : Statement, IHasTagName
     {
         private readonly Func<TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> _render;
 
-        public EmptyTagStatement(Func<TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> render)
+        public EmptyTagStatement(string tagName, Func<TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> render)
         {
             _render = render ?? throw new ArgumentNullException(nameof(render));
+            TagName = tagName;
         }
+
+        public string TagName { get; init; }
 
         public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {

--- a/Fluid/Parser/IHasTagName.cs
+++ b/Fluid/Parser/IHasTagName.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Fluid.Parser
+{
+    public interface IHasTagName
+    {
+        string TagName { get; }
+    }
+}

--- a/Fluid/Parser/IHasValue.cs
+++ b/Fluid/Parser/IHasValue.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Fluid.Parser
+{
+    public interface IHasValue
+    {
+        object Value { get; }
+    }
+
+    public interface IHasValue<out T> : IHasValue
+    {
+        new T Value { get; }
+    }
+}

--- a/Fluid/Parser/ParserBlockStatement.cs
+++ b/Fluid/Parser/ParserBlockStatement.cs
@@ -7,17 +7,19 @@ using System.Threading.Tasks;
 
 namespace Fluid.Parser
 {
-    internal sealed class ParserBlockStatement<T> : TagStatement
+    internal sealed class ParserBlockStatement<T> : TagStatement, IHasTagName
     {
         private readonly Func<T, IReadOnlyList<Statement>, TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> _render;
 
-        public ParserBlockStatement(T value, List<Statement> statements, Func<T, IReadOnlyList<Statement>, TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> render) : base(statements)
+        public ParserBlockStatement(string tagName, T value, List<Statement> statements, Func<T, IReadOnlyList<Statement>, TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> render) : base(statements)
         {
             Value = value;
+            TagName = tagName;
             _render = render ?? throw new ArgumentNullException(nameof(render));
         }
 
         public T Value { get; }
+        public string TagName { get; init; }
 
         public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {

--- a/Fluid/Parser/ParserBlockStatement.cs
+++ b/Fluid/Parser/ParserBlockStatement.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Parser
 {
-    internal sealed class ParserBlockStatement<T> : TagStatement, IHasTagName
+    internal sealed class ParserBlockStatement<T> : TagStatement, IHasTagName, IHasValue<T>
     {
         private readonly Func<T, IReadOnlyList<Statement>, TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> _render;
 
@@ -20,6 +20,7 @@ namespace Fluid.Parser
 
         public T Value { get; }
         public string TagName { get; init; }
+        object IHasValue.Value => Value;
 
         public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {

--- a/Fluid/Parser/ParserTagStatement.cs
+++ b/Fluid/Parser/ParserTagStatement.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Parser
 {
-    internal sealed class ParserTagStatement<T> : Statement, IHasTagName
+    internal sealed class ParserTagStatement<T> : Statement, IHasTagName, IHasValue<T>
     {
         private readonly Func<T, TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> _render;
 
@@ -19,6 +19,7 @@ namespace Fluid.Parser
 
         public string TagName { get; init; }
         public T Value { get; }
+        object IHasValue.Value => Value;
 
         public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {

--- a/Fluid/Parser/ParserTagStatement.cs
+++ b/Fluid/Parser/ParserTagStatement.cs
@@ -6,16 +6,18 @@ using System.Threading.Tasks;
 
 namespace Fluid.Parser
 {
-    internal sealed class ParserTagStatement<T> : Statement
+    internal sealed class ParserTagStatement<T> : Statement, IHasTagName
     {
         private readonly Func<T, TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> _render;
 
-        public ParserTagStatement(T value, Func<T, TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> render)
+        public ParserTagStatement(string tagName, T value, Func<T, TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> render)
         {
+            TagName = tagName;
             Value = value;
             _render = render ?? throw new ArgumentNullException(nameof(render));
         }
 
+        public string TagName { get; init; }
         public T Value { get; }
 
         public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)


### PR DESCRIPTION
I've implemented support to retrieve tag names from the statement list as discussed in #578.

`ExtensibilityTests` have been amended; let me know if I've missed anything obvious.

In terms of design, I opted to add another interface `IHasTagName` for a few reasons:

1. It means that the various statement types (`EmptyBlockStatement`, `EmptyTagStatement`, `ParserBlockStatement`, `ParserTagStatement`) now have a shared interface type
2. The above types were all `internal` and this hasn't changed visibility
3. The root class `Statement` is used throughout the codebase and wasn't an appropriate change point.

The change means that I can do what I needed to do quite simply, basically

`template.Statements.Where(x => x.GetType() == typeof(IHasTagName)).First(y => y.TagName == "what i'm looking for")`

I've also added an interface `IHasValue` for retrieving the interface value from a statement. This Value will hold an individual value passed in, or in the case of using `ArgumentsList` you'll get an `List` of `FilterArgument`.

If you need any amendments let me know.