### PR TITLE
Add net8.0 target, remove obsolete, update packages

### DIFF
--- a/Fluid.Benchmarks/Fluid.Benchmarks.csproj
+++ b/Fluid.Benchmarks/Fluid.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);NU5104</NoWarn>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -26,11 +26,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
-    <PackageReference Include="DotLiquid" Version="2.2.656" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
+    <PackageReference Include="DotLiquid" Version="2.2.692" />
     <PackageReference Include="Liquid.NET" Version="0.10.0" />
-    <PackageReference Include="Scriban" Version="5.5.0" />
-    <PackageReference Include="Handlebars.Net" Version="2.1.2" />
+    <PackageReference Include="Scriban" Version="5.9.0" />
+    <PackageReference Include="Handlebars.Net" Version="2.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Fluid.MinimalApisSample/Fluid.MinimalApisSample.csproj
+++ b/Fluid.MinimalApisSample/Fluid.MinimalApisSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-	<TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>net8.0</TargetFramework>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<OutputType>Exe</OutputType>
     <NoWarn>$(NoWarn);NU5104</NoWarn>

--- a/Fluid.MvcSample/Fluid.MvcSample.csproj
+++ b/Fluid.MvcSample/Fluid.MvcSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <NoWarn>$(NoWarn);NU5104</NoWarn>
     <IsPackable>false</IsPackable>

--- a/Fluid.MvcViewEngine/Fluid.MvcViewEngine.csproj
+++ b/Fluid.MvcViewEngine/Fluid.MvcViewEngine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PackageIcon>logo_64x64.png</PackageIcon>
     <IsPackable>true</IsPackable>
@@ -19,15 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" Version="3.1.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" Version="5.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
@@ -36,6 +28,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)'=='net7.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Fluid.Tests/Fluid.Tests.csproj
+++ b/Fluid.Tests/Fluid.Tests.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <DefineConstants Condition="'$(Compiled)' == 'true'">$(DefineConstants);COMPILED</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.analyzers" Version="1.0.0" />
+    <PackageReference Include="xunit.analyzers" Version="1.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Fluid.ViewEngine/Fluid.ViewEngine.csproj
+++ b/Fluid.ViewEngine/Fluid.ViewEngine.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>true</IsPackable>
     <PackageIcon>logo_64x64.png</PackageIcon>
-    <!-- Ignore: The target framework '...' is out of support and will not receive security updates in the future -->
-    <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Fluid/Fluid.csproj
+++ b/Fluid/Fluid.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <IsPackable>true</IsPackable>
@@ -13,8 +13,8 @@
   <ItemGroup>
     <PackageReference Include="Parlot" Version="0.0.24" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="1.1.1" />
-    <PackageReference Include="TimeZoneConverter" Version="6.0.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
+    <PackageReference Include="TimeZoneConverter" Version="6.1.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
@@ -28,16 +28,13 @@
   </ItemGroup>
 
   <!-- Keep specific targets since it removes some dependencies -->
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net7.0'">
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
   </ItemGroup>
 
   <PropertyGroup>

--- a/MinimalApis.LiquidViews/MinimalApis.LiquidViews.csproj
+++ b/MinimalApis.LiquidViews/MinimalApis.LiquidViews.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <IsPackable>true</IsPackable>
     <PackageIcon>logo_64x64.png</PackageIcon>
@@ -19,6 +19,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)'=='net7.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" Version="8.0.0" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Time to let go of `netoreapp3.1` and `net5.0`. `net7.0` will be obsolete soon too but left it. To sweeten the deal here are the benchmark numbers comparing jump from NET 7.0 to NET 8.0. And then for vanity comparison benchmarks under net8.0

## Runtime comparison

```

BenchmarkDotNet v0.13.10, Windows 11 (10.0.23590.1000)
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK 8.0.100
  [Host]     : .NET 7.0.14 (7.0.1423.51910), X64 RyuJIT AVX2
  Job-PXTLYP : .NET 7.0.14 (7.0.1423.51910), X64 RyuJIT AVX2
  Job-ZZEUIR : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2


```
| Method         | Runtime  | Mean       | Error     | StdDev    | Ratio | Gen0   | Gen1   | Allocated | Alloc Ratio |
|--------------- |--------- |-----------:|----------:|----------:|------:|-------:|-------:|----------:|------------:|
| Parse          | .NET 7.0 |   4.915 μs | 0.0294 μs | 0.0275 μs |  1.00 | 0.1602 |      - |   2.68 KB |        1.00 |
| Parse          | .NET 8.0 |   4.636 μs | 0.0181 μs | 0.0170 μs |  0.94 | 0.1602 |      - |   2.68 KB |        1.00 |
|                |          |            |           |           |       |        |        |           |             |
| ParseBig       | .NET 7.0 |  25.978 μs | 0.0445 μs | 0.0416 μs |  1.00 | 0.7019 |      - |  11.61 KB |        1.00 |
| ParseBig       | .NET 8.0 |  24.504 μs | 0.0960 μs | 0.0851 μs |  0.94 | 0.7019 |      - |  11.61 KB |        1.00 |
|                |          |            |           |           |       |        |        |           |             |
| Render         | .NET 7.0 | 266.880 μs | 0.3826 μs | 0.2987 μs |  1.00 | 5.3711 |      - |  95.86 KB |        1.00 |
| Render         | .NET 8.0 | 200.908 μs | 1.2976 μs | 1.2138 μs |  0.75 | 5.6152 | 0.2441 |  95.86 KB |        1.00 |
|                |          |            |           |           |       |        |        |           |             |
| ParseAndRender | .NET 7.0 | 273.829 μs | 1.0554 μs | 0.9356 μs |  1.00 | 5.8594 |      - |  99.01 KB |        1.00 |
| ParseAndRender | .NET 8.0 | 206.873 μs | 0.9483 μs | 0.8406 μs |  0.76 | 5.8594 | 0.2441 |  99.01 KB |        1.00 |


## Library comparsion

```

BenchmarkDotNet v0.13.10, Windows 11 (10.0.23590.1000)
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK 8.0.100
  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2


```
| Method             | Mean          | Error       | StdDev      | Ratio  | RatioSD | Gen0      | Gen1    | Gen2    | Allocated   | Alloc Ratio |
|------------------- |--------------:|------------:|------------:|-------:|--------:|----------:|--------:|--------:|------------:|------------:|
| Fluid_Parse        |      4.810 μs |   0.0900 μs |   0.0963 μs |   1.00 |    0.00 |    0.1602 |       - |       - |     2.68 KB |        1.00 |
| Scriban_Parse      |      5.084 μs |   0.1014 μs |   0.0996 μs |   1.06 |    0.03 |    0.4349 |  0.0153 |       - |     7.14 KB |        2.67 |
| DotLiquid_Parse    |      9.048 μs |   0.1742 μs |   0.2007 μs |   1.89 |    0.07 |    0.9918 |  0.0153 |       - |    16.21 KB |        6.05 |
| LiquidNet_Parse    |     36.824 μs |   0.1128 μs |   0.1000 μs |   7.66 |    0.19 |    3.7842 |  0.3052 |       - |    62.04 KB |       23.15 |
| Handlebars_Parse   |  2,916.884 μs |  14.6940 μs |  13.0259 μs | 606.94 |   13.33 |    7.8125 |  3.9063 |       - |   156.44 KB |       58.38 |
|                    |               |             |             |        |         |           |         |         |             |             |
| Fluid_ParseBig     |     25.489 μs |   0.3152 μs |   0.2632 μs |   1.00 |    0.00 |    0.7019 |       - |       - |    11.61 KB |        1.00 |
| Scriban_ParseBig   |     25.959 μs |   0.0947 μs |   0.0886 μs |   1.02 |    0.01 |    1.9531 |  0.2747 |       - |    32.06 KB |        2.76 |
| DotLiquid_ParseBig |     37.296 μs |   0.3281 μs |   0.2908 μs |   1.46 |    0.02 |    5.7373 |  0.2441 |       - |    94.36 KB |        8.13 |
| LiquidNet_ParseBig | 16,282.790 μs | 171.7901 μs | 160.6926 μs | 639.95 |   10.71 | 1718.7500 | 62.5000 |       - | 28543.39 KB |    2,458.65 |
|                    |               |             |             |        |         |           |         |         |             |             |
| Fluid_Render       |    202.840 μs |   0.4475 μs |   0.3967 μs |   1.00 |    0.00 |    5.6152 |  0.2441 |       - |    95.86 KB |        1.00 |
| Scriban_Render     |    803.347 μs |   6.0097 μs |   5.3274 μs |   3.96 |    0.03 |   68.3594 | 68.3594 | 68.3594 |   498.43 KB |        5.20 |
| DotLiquid_Render   |  1,957.585 μs |  27.8971 μs |  26.0950 μs |   9.66 |    0.13 |  203.1250 | 85.9375 | 23.4375 |  3367.85 KB |       35.13 |
| LiquidNet_Render   |  1,107.375 μs |  11.5056 μs |   9.6077 μs |   5.46 |    0.05 |  191.4063 | 82.0313 |       - |  3131.22 KB |       32.66 |
| Handlebars_Render  |    247.913 μs |   1.0110 μs |   0.8962 μs |   1.22 |    0.01 |   11.7188 |  1.9531 |       - |   194.92 KB |        2.03 |
