### PR TITLE
Seal types not suitable for extending

### DIFF
--- a/Fluid/Accessors/AsyncDelegateAccessor.cs
+++ b/Fluid/Accessors/AsyncDelegateAccessor.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Accessors
 {
-    public class AsyncDelegateAccessor : AsyncDelegateAccessor<object, object>
+    public sealed class AsyncDelegateAccessor : AsyncDelegateAccessor<object, object>
     {
         public AsyncDelegateAccessor(Func<object, string, Task<object>> getter) : base((obj, name, ctx) => getter(obj, name))
         {

--- a/Fluid/Accessors/DelegateAccessor.cs
+++ b/Fluid/Accessors/DelegateAccessor.cs
@@ -2,7 +2,7 @@
 
 namespace Fluid.Accessors
 {
-    public class DelegateAccessor : DelegateAccessor<object, object>
+    public sealed class DelegateAccessor : DelegateAccessor<object, object>
     {
         public DelegateAccessor(Func<object, string, object> getter) : base((obj, name, ctx) => getter(obj, name))
         {

--- a/Fluid/Accessors/MethodInfoAccessor.cs
+++ b/Fluid/Accessors/MethodInfoAccessor.cs
@@ -2,7 +2,7 @@
 
 namespace Fluid.Accessors
 {
-    public class MethodInfoAccessor : IMemberAccessor
+    public sealed class MethodInfoAccessor : IMemberAccessor
     {
         private readonly MethodInfo _methodInfo;
 

--- a/Fluid/Accessors/PropertyInfoAccessor.cs
+++ b/Fluid/Accessors/PropertyInfoAccessor.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 namespace Fluid.Accessors
 {
-    public class PropertyInfoAccessor : IMemberAccessor
+    public sealed class PropertyInfoAccessor : IMemberAccessor
     {
         private readonly IInvoker _invoker;
 

--- a/Fluid/Ast/AssignStatement.cs
+++ b/Fluid/Ast/AssignStatement.cs
@@ -5,7 +5,7 @@ using Fluid.Values;
 
 namespace Fluid.Ast
 {
-    public class AssignStatement : Statement
+    public sealed class AssignStatement : Statement
     {
         public AssignStatement(string identifier, Expression value)
         {

--- a/Fluid/Ast/BinaryExpressions/StartsWithBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/StartsWithBinaryExpression.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public class StartsWithBinaryExpression : BinaryExpression
+    public sealed class StartsWithBinaryExpression : BinaryExpression
     {
         public StartsWithBinaryExpression(Expression left, Expression right) : base(left, right)
         {

--- a/Fluid/Ast/BinaryExpressions/SubstractBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/SubstractBinaryExpression.cs
@@ -2,7 +2,7 @@
 
 namespace Fluid.Ast.BinaryExpressions
 {
-    public class SubstractBinaryExpression : BinaryExpression
+    public sealed class SubstractBinaryExpression : BinaryExpression
     {
         public SubstractBinaryExpression(Expression left, Expression right) : base(left, right)
         {

--- a/Fluid/Ast/BreakStatement.cs
+++ b/Fluid/Ast/BreakStatement.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class BreakStatement : Statement
+    public sealed class BreakStatement : Statement
     {
         public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {

--- a/Fluid/Ast/CallbackStatement.cs
+++ b/Fluid/Ast/CallbackStatement.cs
@@ -8,7 +8,7 @@ namespace Fluid.Ast
     /// <summary>
     /// An instance of this class is used to execute some custom code in a template.
     /// </summary>
-    public class CallbackStatement : Statement
+    public sealed class CallbackStatement : Statement
     {
         public CallbackStatement(Func<TextWriter, TextEncoder, TemplateContext, ValueTask<Completion>> action)
         {

--- a/Fluid/Ast/CaptureStatement.cs
+++ b/Fluid/Ast/CaptureStatement.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class CaptureStatement : TagStatement
+    public sealed class CaptureStatement : TagStatement
     {
         public CaptureStatement(string identifier, List<Statement> statements): base(statements)
         {

--- a/Fluid/Ast/CaseStatement.cs
+++ b/Fluid/Ast/CaseStatement.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class CaseStatement : TagStatement
+    public sealed class CaseStatement : TagStatement
     {
         private readonly WhenStatement[] _whenStatements;
 

--- a/Fluid/Ast/CommentStatement.cs
+++ b/Fluid/Ast/CommentStatement.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class CommentStatement : Statement
+    public sealed class CommentStatement : Statement
     {
         private readonly TextSpan _text;
 

--- a/Fluid/Ast/ContinueStatement.cs
+++ b/Fluid/Ast/ContinueStatement.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class ContinueStatement : Statement
+    public sealed class ContinueStatement : Statement
     {
         public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {

--- a/Fluid/Ast/DecrementStatement.cs
+++ b/Fluid/Ast/DecrementStatement.cs
@@ -5,7 +5,7 @@ using Fluid.Values;
 
 namespace Fluid.Ast
 {
-    public class DecrementStatement : Statement
+    public sealed class DecrementStatement : Statement
     {
         public DecrementStatement(string identifier)
         {

--- a/Fluid/Ast/ElseIfStatement.cs
+++ b/Fluid/Ast/ElseIfStatement.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class ElseIfStatement : TagStatement
+    public sealed class ElseIfStatement : TagStatement
     {
         public ElseIfStatement(Expression condition, List<Statement> statements) : base(statements)
         {

--- a/Fluid/Ast/ElseStatement.cs
+++ b/Fluid/Ast/ElseStatement.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class ElseStatement : TagStatement
+    public sealed class ElseStatement : TagStatement
     {
         public ElseStatement(List<Statement> statements) : base(statements)
         {

--- a/Fluid/Ast/FilterExpression.cs
+++ b/Fluid/Ast/FilterExpression.cs
@@ -4,7 +4,7 @@ using Fluid.Values;
 
 namespace Fluid.Ast
 {
-    public class FilterExpression : Expression
+    public sealed class FilterExpression : Expression
     {
         public FilterExpression(Expression input, string name, List<FilterArgument> parameters)
         {

--- a/Fluid/Ast/ForStatement.cs
+++ b/Fluid/Ast/ForStatement.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class ForStatement : TagStatement
+    public sealed class ForStatement : TagStatement
     {
         private bool _isContinueOffset;
         private string _continueOffsetLiteral;

--- a/Fluid/Ast/FunctionCallSegment.cs
+++ b/Fluid/Ast/FunctionCallSegment.cs
@@ -5,7 +5,7 @@ using Fluid.Values;
 
 namespace Fluid.Ast
 {
-    public class FunctionCallSegment : MemberSegment
+    public sealed class FunctionCallSegment : MemberSegment
     {
         private static readonly FunctionArguments NonCacheableArguments = new();
         private volatile FunctionArguments _cachedArguments;

--- a/Fluid/Ast/IdentifierSegment.cs
+++ b/Fluid/Ast/IdentifierSegment.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 namespace Fluid.Ast
 {
     [DebuggerDisplay("{Identifier,nq}")]
-    public class IdentifierSegment : MemberSegment
+    public sealed class IdentifierSegment : MemberSegment
     {
         public IdentifierSegment(string identifier)
         {

--- a/Fluid/Ast/IfStatement.cs
+++ b/Fluid/Ast/IfStatement.cs
@@ -6,7 +6,7 @@ using Fluid.Values;
 
 namespace Fluid.Ast
 {
-    public class IfStatement : TagStatement
+    public sealed class IfStatement : TagStatement
     {
         private readonly List<ElseIfStatement> _elseIfStatements;
 

--- a/Fluid/Ast/IncludeStatement.cs
+++ b/Fluid/Ast/IncludeStatement.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace Fluid.Ast
 {
 #pragma warning disable CA1001 // Types that own disposable fields should be disposable
-    public class IncludeStatement : Statement
+    public sealed class IncludeStatement : Statement
 #pragma warning restore CA1001
     {
         public const string ViewExtension = ".liquid";

--- a/Fluid/Ast/IncrementStatement.cs
+++ b/Fluid/Ast/IncrementStatement.cs
@@ -5,7 +5,7 @@ using Fluid.Values;
 
 namespace Fluid.Ast
 {
-    public class IncrementStatement : Statement
+    public sealed class IncrementStatement : Statement
     {
         public const string Prefix = "$$incdec$$$";
         public IncrementStatement(string identifier)

--- a/Fluid/Ast/IndexerSegment.cs
+++ b/Fluid/Ast/IndexerSegment.cs
@@ -3,7 +3,7 @@ using Fluid.Values;
 
 namespace Fluid.Ast
 {
-    public class IndexerSegment : MemberSegment
+    public sealed class IndexerSegment : MemberSegment
     {
         public IndexerSegment(Expression expression)
         {

--- a/Fluid/Ast/LiquidStatement.cs
+++ b/Fluid/Ast/LiquidStatement.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class LiquidStatement : TagStatement
+    public sealed class LiquidStatement : TagStatement
     {
         public LiquidStatement(List<Statement> statements) : base(statements)
         {

--- a/Fluid/Ast/MacroStatement.cs
+++ b/Fluid/Ast/MacroStatement.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class MacroStatement : TagStatement
+    public sealed class MacroStatement : TagStatement
     {
         public MacroStatement(string identifier, IReadOnlyList<FunctionCallArgument> arguments, List<Statement> statements): base(statements)
         {

--- a/Fluid/Ast/MemberExpression.cs
+++ b/Fluid/Ast/MemberExpression.cs
@@ -5,7 +5,7 @@ using Fluid.Values;
 
 namespace Fluid.Ast
 {
-    public class MemberExpression : Expression
+    public sealed class MemberExpression : Expression
     {
         public MemberExpression(params MemberSegment[] segments)
         {

--- a/Fluid/Ast/NamedExpressionList.cs
+++ b/Fluid/Ast/NamedExpressionList.cs
@@ -2,7 +2,7 @@
 
 namespace Fluid.Ast
 {
-    public class NamedExpressionList
+    public sealed class NamedExpressionList
     {
         public static readonly NamedExpressionList Empty = new NamedExpressionList();
 

--- a/Fluid/Ast/OutputStatement.cs
+++ b/Fluid/Ast/OutputStatement.cs
@@ -6,7 +6,7 @@ using Fluid.Values;
 
 namespace Fluid.Ast
 {
-    public class OutputStatement : Statement
+    public sealed class OutputStatement : Statement
     {
         public OutputStatement(Expression expression)
         {

--- a/Fluid/Ast/RangeExpression.cs
+++ b/Fluid/Ast/RangeExpression.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class RangeExpression : Expression
+    public sealed class RangeExpression : Expression
     {
         public RangeExpression(Expression from, Expression to)
         {

--- a/Fluid/Ast/RawStatement.cs
+++ b/Fluid/Ast/RawStatement.cs
@@ -6,7 +6,7 @@ using Fluid.Utils;
 
 namespace Fluid.Ast
 {
-    public class RawStatement : Statement
+    public sealed class RawStatement : Statement
     {
         private readonly TextSpan _text;
 

--- a/Fluid/Ast/RenderStatement.cs
+++ b/Fluid/Ast/RenderStatement.cs
@@ -13,7 +13,7 @@ namespace Fluid.Ast
     /// The render tag can only access immutable environments, which means the scope of the context that was passed to the main template, the options' scope, and the model.
     /// </summary>
 #pragma warning disable CA1001 // Types that own disposable fields should be disposable
-    public class RenderStatement : Statement
+    public sealed class RenderStatement : Statement
 #pragma warning restore CA1001
     {
         public const string ViewExtension = ".liquid";

--- a/Fluid/Ast/UnlessStatement.cs
+++ b/Fluid/Ast/UnlessStatement.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class UnlessStatement : TagStatement
+    public sealed class UnlessStatement : TagStatement
     {
         public UnlessStatement(
             Expression condition,

--- a/Fluid/Ast/WhenStatement.cs
+++ b/Fluid/Ast/WhenStatement.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Ast
 {
-    public class WhenStatement : TagStatement
+    public sealed class WhenStatement : TagStatement
     {
         private readonly IReadOnlyList<Expression> _options;
 

--- a/Fluid/FilterArguments.cs
+++ b/Fluid/FilterArguments.cs
@@ -8,7 +8,7 @@ namespace Fluid
     /// Represents the list of arguments that are passed to a <see cref="FilterDelegate"/>
     /// when invoked.
     /// </summary>
-    public class FilterArguments
+    public sealed class FilterArguments
     {
         public static readonly FilterArguments Empty = new FilterArguments();
 

--- a/Fluid/FiltersCollection.cs
+++ b/Fluid/FiltersCollection.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Fluid
 {
-    public class FilterCollection : IEnumerable<KeyValuePair<string, FilterDelegate>>
+    public sealed class FilterCollection : IEnumerable<KeyValuePair<string, FilterDelegate>>
     {
         private Dictionary<string, FilterDelegate> _filters;
 

--- a/Fluid/FunctionArguments.cs
+++ b/Fluid/FunctionArguments.cs
@@ -7,7 +7,7 @@ namespace Fluid
     /// <summary>
     /// Represents the list of arguments of a function.
     /// </summary>
-    public class FunctionArguments
+    public sealed class FunctionArguments
     {
         public static readonly FunctionArguments Empty = new FunctionArguments();
 

--- a/Fluid/MemberNameStrategies.cs
+++ b/Fluid/MemberNameStrategies.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Fluid
 {
-    public class MemberNameStrategies
+    public sealed class MemberNameStrategies
     {
         public static readonly MemberNameStrategy Default = RenameDefault;
         public static readonly MemberNameStrategy CamelCase = RenameCamelCase;

--- a/Fluid/NullMemberAccessor.cs
+++ b/Fluid/NullMemberAccessor.cs
@@ -1,6 +1,6 @@
 ﻿namespace Fluid
 {
-    public class NullMemberAccessor : IMemberAccessor
+    public sealed class NullMemberAccessor : IMemberAccessor
     {
         public static readonly IMemberAccessor Instance = new NullMemberAccessor();
 

--- a/Fluid/ParseException.cs
+++ b/Fluid/ParseException.cs
@@ -2,7 +2,7 @@
 
 namespace Fluid
 {
-    public class ParseException : Exception
+    public sealed class ParseException : Exception
     {
         //
         // Summary:

--- a/Fluid/Parser/CompositeFluidTemplate.cs
+++ b/Fluid/Parser/CompositeFluidTemplate.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Parser
 {
-    public class CompositeFluidTemplate : IFluidTemplate
+    public sealed class CompositeFluidTemplate : IFluidTemplate
     {
         private readonly List<IFluidTemplate> _templates;
 

--- a/Fluid/Parser/FluidTemplate.cs
+++ b/Fluid/Parser/FluidTemplate.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Fluid.Parser
 {
-    public class FluidTemplate : IFluidTemplate
+    public sealed class FluidTemplate : IFluidTemplate
     {
         private readonly List<Statement> _statements;
 

--- a/Fluid/Scope.cs
+++ b/Fluid/Scope.cs
@@ -5,7 +5,7 @@ using Fluid.Values;
 
 namespace Fluid
 {
-    public class Scope
+    public sealed class Scope
     {
         private Dictionary<string, FluidValue> _properties;
         private readonly bool _forLoopScope;

--- a/Fluid/UnsafeMemberAccessStrategy.cs
+++ b/Fluid/UnsafeMemberAccessStrategy.cs
@@ -2,7 +2,7 @@
 
 namespace Fluid
 {
-    public class UnsafeMemberAccessStrategy : DefaultMemberAccessStrategy
+    public sealed class UnsafeMemberAccessStrategy : DefaultMemberAccessStrategy
     {
         public static readonly UnsafeMemberAccessStrategy Instance = new UnsafeMemberAccessStrategy();
 


### PR DESCRIPTION
CLR can make better decisions when it knows there's no worry to do virtual calls to ensure that possible overridden method would be correctly called. Types really don't have extension points via inheritance.

## Fluid.Benchmarks.FluidBenchmarks

| **Diff**|Method|Mean|Error|Allocated|
|------- |-------|-------:|-------|-------:|
| Old |Parse|3.193 μs|0.0312 μs|2.68 KB|
| **New** |	| **3.152 μs (-1%)** | **0.0307 μs** | **2.68 KB (0%)** |
| Old |ParseBig|16.892 μs|0.2980 μs|11.61 KB|
| **New** |	| **16.840 μs (0%)** | **0.2747 μs** | **11.61 KB (0%)** |
| Old |Render|133.681 μs|2.5941 μs|95.86 KB|
| **New** |	| **130.399 μs (-2%)** | **1.4315 μs** | **95.86 KB (0%)** |
| Old |ParseAndRender|135.980 μs|1.5126 μs|99.01 KB|
| **New** |	| **135.876 μs (0%)** | **2.0597 μs** | **99.01 KB (0%)** |


