### PR TITLE
Add module level SkipLocalsInit

### DIFF
--- a/Fluid/Properties/AssemblyInfo.cs
+++ b/Fluid/Properties/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+[module: System.Runtime.CompilerServices.SkipLocalsInit]


### PR DESCRIPTION
Let's extract some free perf with the magic attribute. Fluid doesn't expect specific initialization and usages should be safe. Same thing is used in Parlot, Esprima and Jint.

## Fluid.Benchmarks.FluidBenchmarks

| **Diff**|Method|Toolchain|Mean|Error|Allocated|
|------- |-------|-------|-------:|-------|-------:|
| Old |Parse|Default|4.455 μs|0.0235 μs|2.68 KB|
| **New** |	| **Default** | **4.345 μs (-2%)** | **0.0164 μs** | **2.68 KB (0%)** |
| Old |ParseBig|Default|23.970 μs|0.1198 μs|11.61 KB|
| **New** |	| **Default** | **23.470 μs (-2%)** | **0.0663 μs** | **11.61 KB (0%)** |
| Old |Render|Default|189.348 μs|0.6141 μs|95.86 KB|
| **New** |	| **Default** | **191.471 μs (+1%)** | **0.7625 μs** | **95.86 KB (0%)** |
| Old |ParseAndRender|Default|200.195 μs|0.4416 μs|99.01 KB|
| **New** |	| **Default** | **197.654 μs (-1%)** | **0.5037 μs** | **99.01 KB (0%)** |


