### PR TITLE
Added Sum ArrayFilter with 2 different options

### DIFF
--- a/Fluid.Tests/ArrayFiltersTests.cs
+++ b/Fluid.Tests/ArrayFiltersTests.cs
@@ -3,6 +3,8 @@ using Fluid.Values;
 using Fluid.Filters;
 using Xunit;
 using System.Threading.Tasks;
+using Fluid.Ast;
+using Fluid.Tests.Extensibility;
 
 namespace Fluid.Tests
 {
@@ -427,6 +429,180 @@ namespace Fluid.Tests
             var result = await ArrayFilters.Sum(input, new FilterArguments(), context);
             
             Assert.Equal(102, result.ToNumberValue());
+        }
+
+        [Fact]
+        public async Task SumWithNumericStrings()
+        {
+            var input = new ArrayValue(new FluidValue[] {
+                NumberValue.Create(1),
+                NumberValue.Create(2),
+                StringValue.Create("3"),
+                StringValue.Create("4")
+            });
+            
+            var options = new TemplateOptions();
+            var context = new TemplateContext(options);
+
+            var result = await ArrayFilters.Sum(input, new FilterArguments(), context);
+            
+            Assert.Equal(10, result.ToNumberValue());
+        }
+
+        [Fact]
+        public async Task SumWithNestedArrays()
+        {
+            var input = new ArrayValue(new FluidValue[] {
+                NumberValue.Create(1),
+                new ArrayValue(new FluidValue[]
+                {
+                    NumberValue.Create(2),
+                    new ArrayValue(new FluidValue[]
+                    {
+                        NumberValue.Create(3),
+                        NumberValue.Create(4)
+                    })
+                })
+            });
+            
+            var options = new TemplateOptions();
+            var context = new TemplateContext(options);
+
+            var result = await ArrayFilters.Sum(input, new FilterArguments(), context);
+            
+            Assert.Equal(10, result.ToNumberValue());
+        }
+
+        [Fact]
+        public async Task SumWithMixedValues()
+        {
+            var input = new ArrayValue(new FluidValue[] {
+                NumberValue.Create(1),
+                BooleanValue.True,
+                NilValue.Instance,
+                new ObjectValue(new { Value = 12  })
+            });
+            
+            var options = new TemplateOptions();
+            var context = new TemplateContext(options);
+
+            var result = await ArrayFilters.Sum(input, new FilterArguments(), context);
+            
+            Assert.Equal(1, result.ToNumberValue());
+        }
+
+        [Fact]
+        public void SumWithoutArgumentRender()
+        {
+            var options = new TemplateOptions();
+            var context = new TemplateContext(options);
+
+            context.SetValue("foo", new [] { 1m });
+            var parser = new CustomParser();
+
+            var template = parser.Parse("{{ foo | sum }}");
+            template.Render(context);
+        }
+        
+        [Fact]
+        public void SumWithArgumentRender()
+        {
+            var options = new TemplateOptions();
+            var context = new TemplateContext(options);
+
+            context.SetValue("foo", new [] { new { Quantity = 1 }});
+            var parser = new CustomParser();
+
+            var template = parser.Parse("{{ foo | sum: 'Quantity' }}");
+            template.Render(context);
+        }
+
+        [Fact]
+        public async Task SumWithDecimals()
+        {
+            var input = new ArrayValue(new FluidValue[] {
+                NumberValue.Create(0.1m),
+                NumberValue.Create(0.2m),
+                NumberValue.Create(-0.3m)
+            });
+            
+            var options = new TemplateOptions();
+            var context = new TemplateContext(options);
+
+            var result = await ArrayFilters.Sum(input, new FilterArguments(), context);
+            
+            Assert.Equal(0.0m, result.ToNumberValue());
+        }
+
+        [Fact]
+        public async Task SumWithDecimalStrings()
+        {
+            var input = new ArrayValue(new FluidValue[] {
+                NumberValue.Create(0.1m),
+                StringValue.Create("0.2"),
+                StringValue.Create("0.3")
+            });
+            
+            var options = new TemplateOptions();
+            var context = new TemplateContext(options);
+
+            var result = await ArrayFilters.Sum(input, new FilterArguments(), context);
+            
+            Assert.Equal(0.6m, result.ToNumberValue());
+        }
+
+        [Fact]
+        public async Task SumResultingInNegativeDecimal()
+        {
+            var input = new ArrayValue(new FluidValue[] {
+                NumberValue.Create(0.1m),
+                NumberValue.Create(-0.2m),
+                NumberValue.Create(-0.3m)
+            });
+            
+            var options = new TemplateOptions();
+            var context = new TemplateContext(options);
+
+            var result = await ArrayFilters.Sum(input, new FilterArguments(), context);
+            
+            Assert.Equal(-0.4m, result.ToNumberValue());
+        }
+
+        [Theory]
+        [InlineData("", 0.0)]
+        [InlineData("Quantity", 0.2)]
+        [InlineData("Weight", 0.1)]
+        [InlineData("Subtotal", 0.0)]
+        public async Task SumWithDecimalsAndArguments(string filterArgument, decimal expectedValue)
+        {
+            var quantityAndWeightObjectType = new
+            {
+                Quantity = (decimal)0,
+                Weight = (decimal)0
+            };
+            
+            var weightObjectType = new
+            {
+                Weight = (decimal)0
+            };
+            
+            var input = new ArrayValue(new FluidValue[]
+            {
+                new ObjectValue(new { Quantity = 1 }),
+                new ObjectValue(new { Quantity = 0.2m, Weight = -0.3m }),
+                new ObjectValue(new { Weight = 0.4m }),
+            });
+            
+            var arguments = new FilterArguments().Add(new StringValue(filterArgument));
+            
+            var options = new TemplateOptions();
+            var context = new TemplateContext(options);
+            options.MemberAccessStrategy.Register(weightObjectType.GetType(), filterArgument);
+            options.MemberAccessStrategy.Register(quantityAndWeightObjectType.GetType(), filterArgument);
+            
+            var result = await ArrayFilters.Sum(input, arguments, context);
+            
+            Assert.Equal(expectedValue, result.ToNumberValue());
         }
     }
 }

--- a/Fluid.Tests/ArrayFiltersTests.cs
+++ b/Fluid.Tests/ArrayFiltersTests.cs
@@ -570,7 +570,7 @@ namespace Fluid.Tests
 
         [Theory]
         [InlineData("", 0.0)]
-        [InlineData("Quantity", 0.2)]
+        [InlineData("Quantity", 1.2)]
         [InlineData("Weight", 0.1)]
         [InlineData("Subtotal", 0.0)]
         public async Task SumWithDecimalsAndArguments(string filterArgument, decimal expectedValue)
@@ -581,6 +581,11 @@ namespace Fluid.Tests
                 Weight = (decimal)0
             };
             
+            var quantityObjectType = new
+            {
+                Quantity = (decimal)0
+            };
+            
             var weightObjectType = new
             {
                 Weight = (decimal)0
@@ -588,7 +593,7 @@ namespace Fluid.Tests
             
             var input = new ArrayValue(new FluidValue[]
             {
-                new ObjectValue(new { Quantity = 1 }),
+                new ObjectValue(new { Quantity = 1m }),
                 new ObjectValue(new { Quantity = 0.2m, Weight = -0.3m }),
                 new ObjectValue(new { Weight = 0.4m }),
             });
@@ -597,6 +602,8 @@ namespace Fluid.Tests
             
             var options = new TemplateOptions();
             var context = new TemplateContext(options);
+            
+            options.MemberAccessStrategy.Register(quantityObjectType.GetType(), filterArgument);
             options.MemberAccessStrategy.Register(weightObjectType.GetType(), filterArgument);
             options.MemberAccessStrategy.Register(quantityAndWeightObjectType.GetType(), filterArgument);
             

--- a/Fluid.Tests/ArrayFiltersTests.cs
+++ b/Fluid.Tests/ArrayFiltersTests.cs
@@ -389,5 +389,44 @@ namespace Fluid.Tests
 
             Assert.Empty(result1.Enumerate(context));
         }
+
+        [Fact]
+        public async Task Sum()
+        {
+            var sample = new { Value = 0 };
+
+            var input = new ArrayValue(new[] {
+                new ObjectValue(new { Value = 12  }),
+                new ObjectValue(new { Value = 34 }),
+                new ObjectValue(new { Value = 56 })
+            });
+            
+            var arguments = new FilterArguments().Add(new StringValue("Value"));
+            
+            var options = new TemplateOptions();
+            var context = new TemplateContext(options);
+            options.MemberAccessStrategy.Register(sample.GetType(), "Value");
+
+            var result = await ArrayFilters.Sum(input, arguments, context);
+            
+            Assert.Equal(102, result.ToNumberValue());
+        }
+
+        [Fact]
+        public async Task SumWithoutArgument()
+        {
+            var input = new ArrayValue(new[] {
+                NumberValue.Create(12),
+                NumberValue.Create(34),
+                NumberValue.Create(56)
+            });
+            
+            var options = new TemplateOptions();
+            var context = new TemplateContext(options);
+
+            var result = await ArrayFilters.Sum(input, new FilterArguments(), context);
+            
+            Assert.Equal(102, result.ToNumberValue());
+        }
     }
 }

--- a/Fluid/Filters/ArrayFilters.cs
+++ b/Fluid/Filters/ArrayFilters.cs
@@ -226,12 +226,12 @@ namespace Fluid.Filters
 
         public static async ValueTask<FluidValue> Sum(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            var member = arguments.At(0);
-
-            if (member.Equals(NilValue.Instance))
+            if (arguments.Count == 0)
             {
                 return NumberValue.Create(input.Enumerate(context).Select(x => x.ToNumberValue()).Sum());
             }
+            
+            var member = arguments.At(0);
             
             var sumList = new List<decimal>();
 

--- a/Fluid/Filters/ArrayFilters.cs
+++ b/Fluid/Filters/ArrayFilters.cs
@@ -21,6 +21,7 @@ namespace Fluid.Filters
             filters.AddFilter("sort_natural", SortNatural);
             filters.AddFilter("uniq", Uniq);
             filters.AddFilter("where", Where);
+            filters.AddFilter("sum", Sum);
             return filters;
         }
 
@@ -221,6 +222,26 @@ namespace Fluid.Filters
         public static ValueTask<FluidValue> Uniq(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
             return new ArrayValue(input.Enumerate(context).Distinct().ToArray());
+        }
+
+        public static async ValueTask<FluidValue> Sum(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            var member = arguments.At(0);
+
+            if (member.Equals(NilValue.Instance))
+            {
+                return NumberValue.Create(input.Enumerate(context).Select(x => x.ToNumberValue()).Sum());
+            }
+            
+            var sumList = new List<decimal>();
+
+            foreach(var item in input.Enumerate(context))
+            {
+                var value = await item.GetValueAsync(member.ToStringValue(), context);
+                sumList.Add(value.ToNumberValue());
+            }
+            
+            return NumberValue.Create(sumList.Sum());
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1018,5 +1018,6 @@ Fluid is known to be used in the following projects:
 - [NSwag](https://github.com/RicoSuter/NSwag) Swagger/OpenAPI 2.0 and 3.0 toolchain for .NET
 - [Optimizely](https://world.optimizely.com/blogs/deane-barker/dates/2023/1/introducing-liquid-templating/) An enterprise .NET CMS
 - [Rock](https://github.com/SparkDevNetwork/Rock) Relationship Management System
+- [TemplateTo](https://templateto.com) Powerful Template Based Document Generation
 
 _Please file an issue to be listed here._


### PR DESCRIPTION
Added "Sum" ArrayFilter so that others can use it also.

2 options:

- Can include an argument to indicate which member to Sum on an array of objects
- No argument which will attempt to Sum the array items value

Tests included with Pull Request which check both of these scenario's

We use Fluid quite a lot at TemplateTo and hope you don't mind us putting our link in your UsedBy section, Fluid can be used by our users as well when building out their templates.