### PR TITLE
Stop inheriting options and add the view renderer to services.

### DIFF
--- a/Fluid.MvcSample/Startup.cs
+++ b/Fluid.MvcSample/Startup.cs
@@ -1,4 +1,5 @@
 ﻿using Fluid.MvcViewEngine;
+using Fluid.ViewEngine;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,7 +13,7 @@ namespace Fluid.MvcSample
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
-            services.Configure<FluidMvcViewOptions>(options =>
+            services.Configure<FluidViewEngineOptions>(options =>
             {
                 options.Parser = new CustomFluidViewParser(new FluidParserOptions());
                 options.TemplateOptions.MemberAccessStrategy = UnsafeMemberAccessStrategy.Instance;

--- a/Fluid.MvcViewEngine/FluidMvcViewOptions.cs
+++ b/Fluid.MvcViewEngine/FluidMvcViewOptions.cs
@@ -1,16 +1,15 @@
-﻿using Fluid.ViewEngine;
-using Microsoft.AspNetCore.Mvc.Rendering;
+﻿using Microsoft.AspNetCore.Mvc.Rendering;
 using System.Threading.Tasks;
 
 namespace Fluid.MvcViewEngine
 {
-    public class FluidMvcViewOptions : FluidViewEngineOptions
+    public class FluidMvcViewOptions
     {
         public delegate ValueTask RenderingMvcViewDelegate(string path, ViewContext viewContext, TemplateContext context);
 
         /// <summary>
         /// Gets or sets the delegate to execute when a view is rendered.
         /// </summary>
-        public new RenderingMvcViewDelegate RenderingViewAsync { get; set; }
+        public RenderingMvcViewDelegate RenderingViewAsync { get; set; }
     }
 }

--- a/Fluid.MvcViewEngine/FluidViewEngine.cs
+++ b/Fluid.MvcViewEngine/FluidViewEngine.cs
@@ -19,11 +19,11 @@ namespace Fluid.MvcViewEngine
         private readonly IWebHostEnvironment _hostingEnvironment;
         private const string ControllerKey = "controller";
         private const string AreaKey = "area";
-        private FluidMvcViewOptions _options;
+        private FluidViewEngineOptions _options;
         private ConcurrentDictionary<LocationCacheKey, FluidView> _locationCache = new();
 
         public FluidViewEngine(FluidRendering fluidRendering,
-            IOptions<FluidMvcViewOptions> optionsAccessor,
+            IOptions<FluidViewEngineOptions> optionsAccessor,
             IWebHostEnvironment hostingEnvironment)
         {
             _options = optionsAccessor.Value;

--- a/Fluid.MvcViewEngine/FluidViewEngineOptionsSetup.cs
+++ b/Fluid.MvcViewEngine/FluidViewEngineOptionsSetup.cs
@@ -1,5 +1,7 @@
 ﻿using Fluid.ViewEngine;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Options;
 
 namespace Fluid.MvcViewEngine
@@ -7,13 +9,17 @@ namespace Fluid.MvcViewEngine
     /// <summary>
     /// Defines the default configuration of <see cref="FluidMvcViewOptions"/>.
     /// </summary>
-    internal class FluidViewEngineOptionsSetup : ConfigureOptions<FluidMvcViewOptions>
+    internal class FluidViewEngineOptionsSetup : ConfigureOptions<FluidViewEngineOptions>
     {
         public FluidViewEngineOptionsSetup(IWebHostEnvironment webHostEnvironment)
             : base(options =>
             {
                 options.PartialsFileProvider = new FileProviderMapper(webHostEnvironment.ContentRootFileProvider, "Views");
                 options.ViewsFileProvider = new FileProviderMapper(webHostEnvironment.ContentRootFileProvider, "Views");
+
+                options.TemplateOptions.FileProvider = options.PartialsFileProvider;
+                options.TemplateOptions.MemberAccessStrategy.Register<ViewDataDictionary>();
+                options.TemplateOptions.MemberAccessStrategy.Register<ModelStateDictionary>();
 
                 options.ViewsLocationFormats.Clear();
                 options.ViewsLocationFormats.Add("/{1}/{0}" + Constants.ViewExtension);
@@ -30,5 +36,5 @@ namespace Fluid.MvcViewEngine
             })
         {
         }
-    }    
+    }
 }

--- a/Fluid.MvcViewEngine/MvcViewFeaturesMvcBuilderExtensions.cs
+++ b/Fluid.MvcViewEngine/MvcViewFeaturesMvcBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace Fluid.MvcViewEngine
 {
     public static class MvcViewFeaturesMvcBuilderExtensions
     {
-        public static IMvcBuilder AddFluid(this IMvcBuilder builder, Action<FluidViewEngineOptions> setupAction = null)
+        public static IMvcBuilder AddFluid(this IMvcBuilder builder, Action<FluidViewEngineOptions> viewEngineSetupAction = null, Action<FluidMvcViewOptions> setupAction = null)
         {
             if (builder == null)
             {
@@ -16,16 +16,28 @@ namespace Fluid.MvcViewEngine
             }
 
             builder.Services.AddOptions();
-            builder.Services.AddTransient<IConfigureOptions<FluidMvcViewOptions>, FluidViewEngineOptionsSetup>();
+            builder.Services.AddTransient<IConfigureOptions<FluidViewEngineOptions>, FluidViewEngineOptionsSetup>();
 
             if (setupAction != null)
             {
                 builder.Services.Configure(setupAction);
             }
 
+            if(viewEngineSetupAction != null)
+            {
+                builder.Services.Configure(viewEngineSetupAction);
+            }
+
             builder.Services.AddTransient<IConfigureOptions<MvcViewOptions>, MvcViewOptionsSetup>();
             builder.Services.AddSingleton<FluidRendering>();
             builder.Services.AddSingleton<IFluidViewEngine, FluidViewEngine>();
+
+            builder.Services.AddSingleton<IFluidViewRenderer>(sp =>
+            {
+                var options = sp.GetRequiredService<IOptions<FluidViewEngineOptions>>().Value;
+                return new FluidViewRenderer(options);
+            });
+
             return builder;
 
         }

--- a/README.md
+++ b/README.md
@@ -753,7 +753,7 @@ You can also define other variables or render some content.
 
 ### Custom views locations
 
-It is possible to add custom file locations containing views by adding them to `FluidMvcViewOptions.ViewsLocationFormats`.
+It is possible to add custom file locations containing views by adding them to `FluidViewEngineOptions.ViewsLocationFormats`.
 
 The default ones are:
 - `Views/{1}/{0}.liquid`
@@ -761,7 +761,7 @@ The default ones are:
 
 Where `{0}` is the view name, and `{1}` is the controller name.
 
-For partials, the list is defined in `FluidMvcViewOptions.PartialsLocationFormats`:
+For partials, the list is defined in `FluidViewEngineOptions.PartialsLocationFormats`:
 - `Views/{0}.liquid`
 - `Views/Partials/{0}.liquid`
 - `Views/Partials/{1}/{0}.liquid`


### PR DESCRIPTION
In reference to https://github.com/sebastienros/fluid/pull/601


- To reduce confusion between the configurations I've decoupled the `FluidMvcViewOptions` from the `FluidViewEngineOptions`
- Added The `IFluidViewRenderer` in a similar way to `MinimalApis.LiquidViews`
- This change breaks applications configuring `FluidMvcViewOptions.RenderingViewAsync`, which would need to use the second optional parameter.

Currently:
```c#
services.AddMvc().AddFluid(options => {
	// All configuration here doesn't work as if it's not being set
});
```

More problem details here

![image](https://github.com/sebastienros/fluid/assets/8115419/22b35e25-2162-4b5e-b811-79893aa849d3)
