### PR TITLE
Adjust Where filter to properly handle truthy comparisons.

### DIFF
--- a/Fluid.Tests/ArrayFiltersTests.cs
+++ b/Fluid.Tests/ArrayFiltersTests.cs
@@ -372,6 +372,34 @@ namespace Fluid.Tests
         }
 
         [Fact]
+        public async Task WhereWithTruthy()
+        {
+            var input = new ArrayValue(new[]
+            {
+                new ObjectValue(new { Title = "a", Pinned = true, Missing = 1 }),
+                new ObjectValue(new { Title = "b", Pinned = false }),
+                new ObjectValue(new { Title = "c", Pinned = true, Missing = 1 })
+            });
+
+            var options = new TemplateOptions();
+            var context = new TemplateContext(options);
+            options.MemberAccessStrategy.Register(new { Title = "a", Pinned = true }.GetType());
+            options.MemberAccessStrategy.Register(new { Title = "a", Pinned = true, Missing = 1 }.GetType());
+
+            var arguments1 = new FilterArguments().Add(new StringValue("Missing"));
+            var result1 = await ArrayFilters.Where(input, arguments1, context);
+
+            Assert.Equal(2, result1.Enumerate(context).Count());
+
+            var arguments2 = new FilterArguments()
+                .Add(new StringValue("Missing"))
+                .Add(BooleanValue.False);
+
+            var result2 = await ArrayFilters.Where(input, arguments2, context);
+            Assert.Single(result2.Enumerate(context));
+        }
+
+        [Fact]
         public async Task WhereShouldNotThrow()
         {
             var input = new ArrayValue(new[] {

--- a/Fluid.Tests/ArrayFiltersTests.cs
+++ b/Fluid.Tests/ArrayFiltersTests.cs
@@ -386,10 +386,14 @@ namespace Fluid.Tests
             options.MemberAccessStrategy.Register(new { Title = "a", Pinned = true }.GetType());
             options.MemberAccessStrategy.Register(new { Title = "a", Pinned = true, Missing = 1 }.GetType());
 
+            // x | where: "Missing"
+
             var arguments1 = new FilterArguments().Add(new StringValue("Missing"));
             var result1 = await ArrayFilters.Where(input, arguments1, context);
 
             Assert.Equal(2, result1.Enumerate(context).Count());
+
+            // x | where: "Missing", false
 
             var arguments2 = new FilterArguments()
                 .Add(new StringValue("Missing"))
@@ -397,6 +401,23 @@ namespace Fluid.Tests
 
             var result2 = await ArrayFilters.Where(input, arguments2, context);
             Assert.Single(result2.Enumerate(context));
+
+            // x | where: "Title"
+
+            var arguments3 = new FilterArguments()
+                .Add(new StringValue("Title"));
+
+            var result3 = await ArrayFilters.Where(input, arguments3, context);
+            Assert.Equal(3, result3.Enumerate(context).Count());
+
+            // x | where: "Missing", true
+
+            var arguments4 = new FilterArguments()
+                .Add(new StringValue("Missing"))
+                .Add(BooleanValue.True);
+
+            var result4 = await ArrayFilters.Where(input, arguments4, context);
+            Assert.Equal(2, result4.Enumerate(context).Count());
         }
 
         [Fact]

--- a/Fluid/Filters/ArrayFilters.cs
+++ b/Fluid/Filters/ArrayFilters.cs
@@ -141,7 +141,11 @@ namespace Fluid.Filters
             var member = arguments.At(0).ToStringValue();
 
             // Second argument is the value to match, or 'true' if none is defined
-            var targetValue = arguments.At(1).Or(BooleanValue.True);
+            var targetValue = arguments.At(1);
+            if (targetValue.IsNil()) 
+            { 
+                targetValue = BooleanValue.True; 
+            }
 
             var list = new List<FluidValue>();
 
@@ -149,7 +153,7 @@ namespace Fluid.Filters
             {
                 var itemValue = await item.GetValueAsync(member, context);
 
-                if (itemValue.Equals(targetValue))
+                if (targetValue.Equals(itemValue))
                 {
                     list.Add(item);
                 }


### PR DESCRIPTION
Corrects where to follow the `where` documentation from liquid language repository.  Additionally, it deals with a case where the comparison value is actually false, which would lead to the comparison being performed with a true value.

Corrects #620 
