### PR TITLE
Mark FluidValue.WriteToAsync() as abstract

### DIFF
--- a/Fluid/Values/FluidValue.cs
+++ b/Fluid/Values/FluidValue.cs
@@ -15,7 +15,7 @@ namespace Fluid.Values
             WriteToAsync(writer, encoder, cultureInfo).GetAwaiter().GetResult();
         }
 
-        public abstract ValueTask WriteToAsync(TextWriter writer, TextEncoder encoder, CultureInfo cultureInfo);
+        public virtual ValueTask WriteToAsync(TextWriter writer, TextEncoder encoder, CultureInfo cultureInfo);
 
         private static Dictionary<Type, Type> _genericDictionaryTypeCache = new();
 

--- a/Fluid/Values/FluidValue.cs
+++ b/Fluid/Values/FluidValue.cs
@@ -15,7 +15,7 @@ namespace Fluid.Values
             WriteToAsync(writer, encoder, cultureInfo).GetAwaiter().GetResult();
         }
 
-        public virtual ValueTask WriteToAsync(TextWriter writer, TextEncoder encoder, CultureInfo cultureInfo);
+        public virtual ValueTask WriteToAsync(TextWriter writer, TextEncoder encoder, CultureInfo cultureInfo) => default;
 
         private static Dictionary<Type, Type> _genericDictionaryTypeCache = new();
 

--- a/Fluid/Values/FluidValue.cs
+++ b/Fluid/Values/FluidValue.cs
@@ -12,7 +12,7 @@ namespace Fluid.Values
         [Obsolete("WriteTo is obsolete, prefer the WriteToAsync method.")]
         public virtual void WriteTo(TextWriter writer, TextEncoder encoder, CultureInfo cultureInfo)
         {
-            WriteToAsync(writer, encoder, cultureInfo);
+            WriteToAsync(writer, encoder, cultureInfo).GetAwaiter().GetResult();
         }
 
         public abstract ValueTask WriteToAsync(TextWriter writer, TextEncoder encoder, CultureInfo cultureInfo);

--- a/Fluid/Values/FluidValue.cs
+++ b/Fluid/Values/FluidValue.cs
@@ -10,15 +10,12 @@ namespace Fluid.Values
 #pragma warning restore CA1067
     {
         [Obsolete("WriteTo is obsolete, prefer the WriteToAsync method.")]
-        public abstract void WriteTo(TextWriter writer, TextEncoder encoder, CultureInfo cultureInfo);
-
-        public virtual ValueTask WriteToAsync(TextWriter writer, TextEncoder encoder, CultureInfo cultureInfo)
+        public virtual void WriteTo(TextWriter writer, TextEncoder encoder, CultureInfo cultureInfo)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            WriteTo(writer, encoder, cultureInfo);
-#pragma warning restore CS0618 // Type or member is obsolete
-            return default;
+            WriteToAsync(writer, encoder, cultureInfo);
         }
+
+        public abstract ValueTask WriteToAsync(TextWriter writer, TextEncoder encoder, CultureInfo cultureInfo);
 
         private static Dictionary<Type, Type> _genericDictionaryTypeCache = new();
 


### PR DESCRIPTION
While I'm working on https://github.com/OrchardCMS/OrchardCore/pull/16956 I notice that subclass `FluidValue` forces me to implement `Write()` instead of `WriteAsync()` and a warning shows up because the first method is obsolete. A better option is to mark `WriteAsync()` as `abstract` so the default implement is async and `Write()` method is still valid for backward compatibility
