### PR TITLE
Remove explicit FileVersion configuration

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -26,7 +26,6 @@
     <BuildNumber Condition="'$(BuildNumber)' == ''">0</BuildNumber>
     <VersionPrefix>2.0.0</VersionPrefix>
     <VersionSuffix>beta-$(BuildNumber)</VersionSuffix>
-    <FileVersion>$(VersionPrefix).$(BuildNumber)</FileVersion>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
The file is being stamped as 2.0.0 and I think this causes Wix installer to skip applying updates, seen this before. 

https://nuget.info/packages/Fluid.Core/2.12.0

![image](https://github.com/user-attachments/assets/d42cf908-4a2a-4210-bbee-c271f81d98ef)

After removing the property I get local build using a fictional 2.3.4 version parameter (like in publish GH workflow):

![image](https://github.com/user-attachments/assets/5bfb3c45-bc6e-4c80-a8be-e1c79537bc18)

Might be the source of [#5035](https://github.com/RicoSuter/NSwag/issues/5035)