### PR TITLE
Assigned delegate

### DIFF
--- a/Fluid.Tests/ArrayFiltersTests.cs
+++ b/Fluid.Tests/ArrayFiltersTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Fluid.Values;
 using Fluid.Filters;
 using Xunit;
@@ -44,7 +44,7 @@ namespace Fluid.Tests
         }
 
         [Fact]
-        public async Task First_EmptyArray()
+        public async Task FirstEmptyArray()
         {
             var input = new ArrayValue(new StringValue[0]);
 

--- a/Fluid.Tests/AssignmentCaptureTests.cs
+++ b/Fluid.Tests/AssignmentCaptureTests.cs
@@ -1,0 +1,55 @@
+using System.Linq;
+using Fluid.Values;
+using Fluid.Filters;
+using Xunit;
+using System.Threading.Tasks;
+using Fluid.Tests.Extensibility;
+
+namespace Fluid.Tests
+{
+    public class AssignmentCaptureTests
+    {
+#if COMPILED
+        private static FluidParser _parser = new FluidParser(new FluidParserOptions { AllowFunctions = true }).Compile();
+#else
+        private static FluidParser _parser = new FluidParser(new FluidParserOptions { AllowFunctions = true });
+#endif
+
+
+        [Fact]
+        public async Task Assign()
+        {
+            string buffer = null;
+
+            var source = @"
+                {% assign a = 'b' %}
+            ";
+
+            _parser.TryParse(source, out var template, out var error);
+            var context = new TemplateContext
+            {
+                Assigned = (v) => buffer = v.ToStringValue()
+            };
+            var result = await template.RenderAsync(context);
+            Assert.Equal("b", buffer);
+        }
+
+        [Fact]
+        public async Task Capture()
+        {
+            string buffer = null;
+
+            var source = @"
+                {% capture a %}b{% endcapture %}
+            ";
+
+            _parser.TryParse(source, out var template, out var error);
+            var context = new TemplateContext
+            {
+                Assigned = (v) => buffer = v.ToStringValue()
+            };
+            var result = await template.RenderAsync(context);
+            Assert.Equal("b", buffer);
+        }
+    }
+}

--- a/Fluid.Tests/AssignmentCaptureTests.cs
+++ b/Fluid.Tests/AssignmentCaptureTests.cs
@@ -17,39 +17,18 @@ namespace Fluid.Tests
 
         [Fact]
         public async Task Assign()
-
         {
-            string buffer = null;
-
             var source = @"
-                {% assign a = 'b' %}
+                {%- assign a = 'b' %}{{a-}}
             ";
 
             _parser.TryParse(source, out var template, out var error);
             var context = new TemplateContext
             {
-                Assigned = (v) => buffer = v.ToStringValue()
+                Assigned = (identifier, value, context) => new StringValue(value.ToStringValue() + "_altered")
             };
             var result = await template.RenderAsync(context);
-            Assert.Equal("b", buffer);
-        }
-
-        [Fact]
-        public async Task Capture()
-        {
-            string buffer = null;
-
-            var source = @"
-                {% capture a %}b{% endcapture %}
-            ";
-
-            _parser.TryParse(source, out var template, out var error);
-            var context = new TemplateContext
-            {
-                Assigned = (v) => buffer = v.ToStringValue()
-            };
-            var result = await template.RenderAsync(context);
-            Assert.Equal("b", buffer);
+            Assert.Equal("b_altered", result);
         }
     }
 }

--- a/Fluid.Tests/AssignmentCaptureTests.cs
+++ b/Fluid.Tests/AssignmentCaptureTests.cs
@@ -15,9 +15,9 @@ namespace Fluid.Tests
         private static FluidParser _parser = new FluidParser(new FluidParserOptions { AllowFunctions = true });
 #endif
 
-
         [Fact]
         public async Task Assign()
+
         {
             string buffer = null;
 

--- a/Fluid.Tests/TemplateTests.cs
+++ b/Fluid.Tests/TemplateTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text.Encodings.Web;
@@ -120,7 +120,7 @@ namespace Fluid.Tests
         public async Task ShouldCustomizeCaptures()
         {
             _parser.TryParse("{% capture foo %}hello <br /> world{% endcapture %}{{ foo }}", out var template, out var error);
-            var result = await template.RenderAsync(new TemplateContext { Captured = (identifier, captured) => new ValueTask<string>(captured.ToUpper()) }, HtmlEncoder.Default);
+            var result = await template.RenderAsync(new TemplateContext { Captured = (identifier, captured, context) => new ValueTask<FluidValue>(new StringValue(captured.ToStringValue().ToUpper(), false)) }, HtmlEncoder.Default);
             Assert.Equal("HELLO <BR /> WORLD", result);
         }
 

--- a/Fluid/Ast/AssignStatement.cs
+++ b/Fluid/Ast/AssignStatement.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Encodings.Web;
+using System.Text.Encodings.Web;
 using Fluid.Values;
 
 namespace Fluid.Ast
@@ -31,6 +31,8 @@ namespace Fluid.Ast
             {
                 return Awaited(task, context, Identifier);
             }
+
+            context.Assigned?.Invoke(task.Result);
 
             context.SetValue(Identifier, task.Result);
             return new ValueTask<Completion>(Completion.Normal);

--- a/Fluid/Ast/CaptureStatement.cs
+++ b/Fluid/Ast/CaptureStatement.cs
@@ -1,4 +1,4 @@
-﻿using Fluid.Utils;
+using Fluid.Utils;
 using Fluid.Values;
 using System.Text.Encodings.Web;
 
@@ -38,6 +38,8 @@ namespace Fluid.Ast
             {
                 result = await context.Captured.Invoke(Identifier, result);
             }
+
+            context.Assigned?.Invoke(new StringValue(result));
 
             // Don't encode captured blocks
             context.SetValue(Identifier, new StringValue(result, false));

--- a/Fluid/Ast/CaptureStatement.cs
+++ b/Fluid/Ast/CaptureStatement.cs
@@ -31,18 +31,16 @@ namespace Fluid.Ast
                 }
             }
 
-            var result = sw.ToString();
+            FluidValue result = new StringValue(sw.ToString(), false);
 
             // Substitute the result if a custom callback is provided
             if (context.Captured != null)
             {
-                result = await context.Captured.Invoke(Identifier, result);
+                result = await context.Captured.Invoke(Identifier, result, context);
             }
 
-            context.Assigned?.Invoke(new StringValue(result));
-
             // Don't encode captured blocks
-            context.SetValue(Identifier, new StringValue(result, false));
+            context.SetValue(Identifier, result);
 
             return completion;
         }

--- a/Fluid/TemplateContext.cs
+++ b/Fluid/TemplateContext.cs
@@ -159,7 +159,6 @@ namespace Fluid
         /// </summary>
         public Func<string, string, ValueTask<string>> Captured { get; set; }
 
-
         /// <summary>
         /// Gets or sets the delegate to execute when a member has been assigned via capture or assign
         /// </summary>

--- a/Fluid/TemplateContext.cs
+++ b/Fluid/TemplateContext.cs
@@ -157,12 +157,12 @@ namespace Fluid
         /// <summary>
         /// Gets or sets the delegate to execute when a Capture tag has been evaluated.
         /// </summary>
-        public Func<string, string, ValueTask<string>> Captured { get; set; }
+        public TemplateOptions.CapturedDelegate Captured { get; set; }
 
         /// <summary>
-        /// Gets or sets the delegate to execute when a member has been assigned via capture or assign
+        /// Gets or sets the delegate to execute when an Assign tag has been evaluated.
         /// </summary>
-        public Action<FluidValue> Assigned { get; set; }
+        public TemplateOptions.AssignedDelegate Assigned { get; set; }
 
         /// <summary>
         /// Creates a new isolated child scope. After than any value added to this content object will be released once

--- a/Fluid/TemplateContext.cs
+++ b/Fluid/TemplateContext.cs
@@ -1,4 +1,4 @@
-﻿using Fluid.Values;
+using Fluid.Values;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 
@@ -53,6 +53,7 @@ namespace Fluid
             CultureInfo = options.CultureInfo;
             TimeZone = options.TimeZone;
             Captured = options.Captured;
+            Assigned = options.Assigned;
             Now = options.Now;
             MaxSteps = options.MaxSteps;
             ModelNamesComparer = modelNamesComparer ?? options.ModelNamesComparer;
@@ -157,6 +158,12 @@ namespace Fluid
         /// Gets or sets the delegate to execute when a Capture tag has been evaluated.
         /// </summary>
         public Func<string, string, ValueTask<string>> Captured { get; set; }
+
+
+        /// <summary>
+        /// Gets or sets the delegate to execute when a member has been assigned via capture or assign
+        /// </summary>
+        public Action<FluidValue> Assigned { get; set; }
 
         /// <summary>
         /// Creates a new isolated child scope. After than any value added to this content object will be released once

--- a/Fluid/TemplateOptions.cs
+++ b/Fluid/TemplateOptions.cs
@@ -7,6 +7,18 @@ namespace Fluid
 {
     public class TemplateOptions
     {
+        /// <param name="identifier">The name of the property that is assigned.</param>
+        /// <param name="value">The value that is assigned.</param>
+        /// <param name="context">The <see cref="TemplateContext" /> instance used for rendering the template.</param>
+        /// <returns>The value which should be assigned to the property.</returns>
+        public delegate ValueTask<FluidValue> AssignedDelegate(string identifier, FluidValue value, TemplateContext context);
+
+        /// <param name="identifier">The name of the property that is assigned.</param>
+        /// <param name="value">The value that is assigned.</param>
+        /// <param name="context">The <see cref="TemplateContext" /> instance used for rendering the template.</param>
+        /// <returns>The value which should be captured.</returns>
+        public delegate ValueTask<FluidValue> CapturedDelegate(string identifier, FluidValue value, TemplateContext context);
+
         public static readonly TemplateOptions Default = new();
 
         /// <summary>
@@ -70,12 +82,12 @@ namespace Fluid
         /// <summary>
         /// Gets or sets the delegate to execute when a Capture tag has been evaluated.
         /// </summary>
-        public Func<string, string, ValueTask<string>> Captured { get; set; }
+        public CapturedDelegate Captured { get; set; }
 
         /// <summary>
-        /// Gets or sets the delegate to execute when a member has been assigned via capture or assign
+        /// Gets or sets the delegate to execute when an Assign tag has been evaluated.
         /// </summary>
-        public Action<FluidValue> Assigned { get; set; }
+        public AssignedDelegate Assigned { get; set; }
 
         /// <summary>
         /// Gets or sets the default trimming rules.

--- a/Fluid/TemplateOptions.cs
+++ b/Fluid/TemplateOptions.cs
@@ -1,4 +1,5 @@
-﻿using Fluid.Filters;
+using Fluid.Filters;
+using Fluid.Values;
 using Microsoft.Extensions.FileProviders;
 using System.Globalization;
 
@@ -70,6 +71,11 @@ namespace Fluid
         /// Gets or sets the delegate to execute when a Capture tag has been evaluated.
         /// </summary>
         public Func<string, string, ValueTask<string>> Captured { get; set; }
+
+        /// <summary>
+        /// Gets or sets the delegate to execute when a member has been assigned via capture or assign
+        /// </summary>
+        public Action<FluidValue> Assigned { get; set; }
 
         /// <summary>
         /// Gets or sets the default trimming rules.

--- a/Fluid/Values/StringValue.cs
+++ b/Fluid/Values/StringValue.cs
@@ -1,4 +1,4 @@
-﻿using Fluid.Utils;
+using Fluid.Utils;
 using Parlot;
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -88,7 +88,10 @@ namespace Fluid.Values
 
         public override bool Equals(FluidValue other)
         {
-            if (other.Type == FluidValues.String) return _value == other.ToStringValue();
+            if (other.Type == FluidValues.String)
+            {
+                return _value == other.ToStringValue();
+            }
 
             // Delegating other types 
             if (other == BlankValue.Instance || other == NilValue.Instance || other == EmptyValue.Instance)


### PR DESCRIPTION
Allows the execution of a C# delegate whenever values are assigned via an `assign` or `capture` tag.