### PR TITLE
Allow the `json` filter to bypass escaping non-ASCII characters.

### DIFF
--- a/Fluid.Tests/MiscFiltersTests.cs
+++ b/Fluid.Tests/MiscFiltersTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
@@ -800,8 +800,8 @@ namespace Fluid.Tests
         [InlineData(123456.00, "C2", "en-US", "$123,456.00")]
 
         // Skip tests with spaces as Linux and Windows implementation don't use the same space
-        //[InlineData(123456.00, "C2", "fr-FR", "123 456,00 €")]
-        //[InlineData("123456.00", "C2", "fr-FR", "123 456,00 €")]
+        //[InlineData(123456.00, "C2", "fr-FR", "123 456,00 €")]
+        //[InlineData("123456.00", "C2", "fr-FR", "123 456,00 €")]
         public async Task FormatNumber(object input, string format, string culture, string expected)
         {
             var cultureInfo = String.IsNullOrEmpty(culture)

--- a/Fluid.Tests/MiscFiltersTests.cs
+++ b/Fluid.Tests/MiscFiltersTests.cs
@@ -118,7 +118,7 @@ namespace Fluid.Tests
         [Theory]
         [InlineData("YTw+OmE/", "a<>:a?")]
         [InlineData("SGVsbA==", "Hell")]
-        [InlineData("SGVsbG8=", "Hello")]        
+        [InlineData("SGVsbG8=", "Hello")]
         public async Task Base64Decode(string value, string expected)
         {
             var input = new StringValue(value);
@@ -152,7 +152,7 @@ namespace Fluid.Tests
         [Theory]
         [InlineData("YTw-OmE_", "a<>:a?")]
         [InlineData("SGVsbA", "Hell")]
-        [InlineData("SGVsbG8", "Hello")]   
+        [InlineData("SGVsbG8", "Hello")]
         public async Task Base64UrlSafeDecode(string value, string expected)
         {
             // Arrange
@@ -776,6 +776,19 @@ namespace Fluid.Tests
             var input = FluidValue.Create(model, TemplateOptions.Default);
             var result = await MiscFilters.Json(input, new FilterArguments(), new TemplateContext(TemplateOptions.Default));
             var expected = "{\"a\":true,\"b\":1,\"c\":\"06/08/2017 12:53:10 -07:00\",\"d\":\"string\",\"e\":null,\"f\":{\"f_a\":1.2,\"f_b\":false,\"f_c\":\"\"},\"g\":[\"val1\",\"val2\"]}";
+            Assert.Equal(expected, result.ToStringValue());
+        }
+
+        [Theory]
+        [InlineData(true, "{\"message\":\"这是一条短信\"}", "{\r\n  \"message\": \"\\u8FD9\\u662F\\u4E00\\u6761\\u77ED\\u4FE1\"\r\n}")]
+        [InlineData(false, "{\"message\":\"这是一条短信\"}", "{\"message\":\"这是一条短信\"}")]
+        public async Task JsonWithEscapeUnicode(bool escapeUnicode, string jsonValue, string expected)
+        {
+            var value = JObject.Parse(jsonValue);
+            var input = FluidValue.Create(value, TemplateOptions.Default);
+            var arguments = new FilterArguments().Add("EscapeUnicode", BooleanValue.Create(escapeUnicode));
+
+            var result = await MiscFilters.Json(input, arguments, new TemplateContext(TemplateOptions.Default));
             Assert.Equal(expected, result.ToStringValue());
         }
 

--- a/Fluid/Filters/MiscFilters.cs
+++ b/Fluid/Filters/MiscFilters.cs
@@ -442,7 +442,7 @@ namespace Fluid.Filters
                                 }
                             case 'c':
                                 {
-                                    // c is defined as "%a %b %e %T %Y" but it's also supposed to be locale aware, so we are using the
+                                    // c is defined as "%a %b %e %T %Y" but it's also supposed to be locale aware, so we are using the 
                                     // C# standard format instead
                                     result.Append(upperCaseFlag ? value.ToString("F", context.CultureInfo).ToUpperInvariant() : value.ToString("F", context.CultureInfo));
                                     break;
@@ -584,7 +584,7 @@ namespace Fluid.Filters
                                 }
                             case 'x':
                                 {
-                                    // x is defined as "%m/%d/%y" but it's also supposed to be locale aware, so we are using the
+                                    // x is defined as "%m/%d/%y" but it's also supposed to be locale aware, so we are using the 
                                     // C# short date pattern standard format instead
 
                                     result.Append(upperCaseFlag ? value.ToString("d", context.CultureInfo).ToUpperInvariant() : value.ToString("d", context.CultureInfo));
@@ -592,7 +592,7 @@ namespace Fluid.Filters
                                 }
                             case 'X':
                                 {
-                                    // X is defined as "%T" but it's also supposed to be locale aware, so we are using the
+                                    // X is defined as "%T" but it's also supposed to be locale aware, so we are using the 
                                     // C# short time pattern standard format instead
 
                                     result.Append(upperCaseFlag ? value.ToString("t", context.CultureInfo).ToUpperInvariant() : value.ToString("t", context.CultureInfo));

--- a/Fluid/Filters/MiscFilters.cs
+++ b/Fluid/Filters/MiscFilters.cs
@@ -4,7 +4,9 @@ using System.Globalization;
 using System.Net;
 using System.Reflection;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Unicode;
 using TimeZoneConverter;
 
 namespace Fluid.Filters
@@ -440,7 +442,7 @@ namespace Fluid.Filters
                                 }
                             case 'c':
                                 {
-                                    // c is defined as "%a %b %e %T %Y" but it's also supposed to be locale aware, so we are using the 
+                                    // c is defined as "%a %b %e %T %Y" but it's also supposed to be locale aware, so we are using the
                                     // C# standard format instead
                                     result.Append(upperCaseFlag ? value.ToString("F", context.CultureInfo).ToUpperInvariant() : value.ToString("F", context.CultureInfo));
                                     break;
@@ -582,7 +584,7 @@ namespace Fluid.Filters
                                 }
                             case 'x':
                                 {
-                                    // x is defined as "%m/%d/%y" but it's also supposed to be locale aware, so we are using the 
+                                    // x is defined as "%m/%d/%y" but it's also supposed to be locale aware, so we are using the
                                     // C# short date pattern standard format instead
 
                                     result.Append(upperCaseFlag ? value.ToString("d", context.CultureInfo).ToUpperInvariant() : value.ToString("d", context.CultureInfo));
@@ -590,7 +592,7 @@ namespace Fluid.Filters
                                 }
                             case 'X':
                                 {
-                                    // X is defined as "%T" but it's also supposed to be locale aware, so we are using the 
+                                    // X is defined as "%T" but it's also supposed to be locale aware, so we are using the
                                     // C# short time pattern standard format instead
 
                                     result.Append(upperCaseFlag ? value.ToString("t", context.CultureInfo).ToUpperInvariant() : value.ToString("t", context.CultureInfo));
@@ -790,8 +792,13 @@ namespace Fluid.Filters
         public static async ValueTask<FluidValue> Json(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
             using var ms = new MemoryStream();
+
+            var shouldEscapeUnicode = !arguments.HasNamed("EscapeUnicode")
+                || arguments["EscapeUnicode"].ToBooleanValue();
+
             await using (var writer = new Utf8JsonWriter(ms, new JsonWriterOptions
             {
+                Encoder = shouldEscapeUnicode ? null : JavaScriptEncoder.Create(UnicodeRanges.All),
                 Indented = arguments.At(0).ToBooleanValue()
             }))
             {


### PR DESCRIPTION
The PR is to allow the `json` filter not to escape non-ASCII characters. The changes include:

1. Add one argument `EscapeUnicode` to configure the JSON writer options. If `EscapeUnicode` is false, the non-ASCII characters will not be escaped.
2. Add a unit test case for `EscapeUnicode` argument.