### PR TITLE
Fix System.Text.Json versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,23 +9,23 @@
 
     <!-- TFM specific reference since they could lift some framework dependencies -->
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="$(MicrosoftExtensionsFileProvidersAbstractionsPackageVersion)" />
-    
+
     <!-- Only used with netstandard2.0 -->
-    <PackageVersion Include="System.Text.Json" Version="9.0.3" />
+    <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonPackageVersion)" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-    
+
     <!-- Common to all TFMs -->
     <PackageVersion Include="Parlot" Version="1.3.5" />
     <PackageVersion Include="TimeZoneConverter" Version="7.0.0" />
-    
+
     <!-- Benchmarks -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="DotLiquid" Version="2.3.107" />
     <PackageVersion Include="Liquid.NET" Version="0.10.0" />
     <PackageVersion Include="Scriban" Version="6.0.0" />
     <PackageVersion Include="Handlebars.Net" Version="2.1.6" />
-    
+
     <!-- Testing -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/Fluid.Tests/TemplateTests.cs
+++ b/Fluid.Tests/TemplateTests.cs
@@ -1139,13 +1139,8 @@ after
             var camelCase = MemberNameStrategies.CamelCase(memberInfo);
             var snakeCase = MemberNameStrategies.SnakeCase(memberInfo);
 
-#if NET8_0_OR_GREATER
             Assert.Equal("uvIndex", camelCase);
             Assert.Equal("uv_index", snakeCase);
-#else
-            Assert.Equal("uVIndex", camelCase);
-            Assert.Equal("uv_index", snakeCase);
-#endif
         }
 
         [Fact]
@@ -1206,7 +1201,7 @@ after
                 {% assign people1 = "alice, bob, carol" | split: ", " %}
                 {% assign people2 = "alice, bob, carol" | split: ", " %}
 
-                {% if people1 == people2 %}true{%else%}false{% endif %} 
+                {% if people1 == people2 %}true{%else%}false{% endif %}
             """;
 
             _parser.TryParse(source, out var template);

--- a/Fluid/Fluid.csproj
+++ b/Fluid/Fluid.csproj
@@ -33,7 +33,7 @@
   <ItemGroup>
     <None Include="../Assets/logo_64x64.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Parlot" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" />
@@ -48,6 +48,7 @@
 
   <!-- Keep specific targets since it removes some dependencies -->
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">

--- a/Fluid/MemberNameStrategies.cs
+++ b/Fluid/MemberNameStrategies.cs
@@ -1,21 +1,16 @@
 using System.Reflection;
-#if NET8_0_OR_GREATER
 using System.Text.Json;
-#else
 using System.Text;
-#endif
+
 namespace Fluid
 {
     public sealed class MemberNameStrategies
     {
         private static string RenameDefault(MemberInfo member) => member.Name;
 
-        public static readonly MemberNameStrategy Default = RenameDefault;
-
-#if NET8_0_OR_GREATER
-
         private const string SwitchName = "Fluid.UseLegacyMemberNameStrategies";
 
+        public static readonly MemberNameStrategy Default = RenameDefault;
         public static readonly MemberNameStrategy CamelCase;
         public static readonly MemberNameStrategy SnakeCase;
 
@@ -36,6 +31,8 @@ namespace Fluid
                 SnakeCase = member => JsonNamingPolicy.SnakeCaseLower.ConvertName(member.Name);
             }
         }
+
+#if NET6_0_OR_GREATER
 
         public static string RenameCamelCase(MemberInfo member)
         {
@@ -83,10 +80,6 @@ namespace Fluid
             });
         }
 #else
-
-        public static readonly MemberNameStrategy CamelCase = RenameCamelCase;
-        public static readonly MemberNameStrategy SnakeCase = RenameSnakeCase;
-
         public static string RenameCamelCase(MemberInfo member)
         {
             var firstChar = member.Name[0];

--- a/Fluid/TemplateOptions.cs
+++ b/Fluid/TemplateOptions.cs
@@ -3,7 +3,6 @@ using Fluid.Values;
 using Microsoft.Extensions.FileProviders;
 using System.Globalization;
 using System.Text.Encodings.Web;
-using System.Text.Json;
 
 namespace Fluid
 {

--- a/Versions.props
+++ b/Versions.props
@@ -1,10 +1,12 @@
 <Project>
   <!-- This file define constants that can be changed per TFM -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <SystemTextJsonPackageVersion>8.0.5</SystemTextJsonPackageVersion>
     <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>6.0.1</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <SystemTextJsonPackageVersion>8.0.5</SystemTextJsonPackageVersion>
     <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>6.0.1</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Use LTS version (8.0.5) when the dependency is required: 
- netstandard2.0 required the STJ package
- net6.0 doesn't have `JsonNamingPolicy` so the package is referenced
