### PR TITLE
Fix Handlebars benchmarks

### DIFF
--- a/Fluid.Benchmarks/BaseBenchmarks.cs
+++ b/Fluid.Benchmarks/BaseBenchmarks.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -47,11 +48,23 @@ namespace Fluid.Benchmarks
             }
         }
 
+        public void CheckBenchmark()
+        {
+            var result = ParseAndRender();
+            if (string.IsNullOrEmpty(result) ||
+                !result.Contains("<h2>Name0</h2>") ||
+                !result.Contains($"<h2>Name{ProductCount - 1}</h2>") ||
+                !result.Contains($"Lorem ipsum ...") ||
+                !result.Contains($"Only 0") ||
+                !result.Contains($"Only {ProductCount - 1}"))
+            {
+                throw new InvalidOperationException($"Template rendering failed: \n {result}");
+            }
+        }
+
         public abstract object Parse();
         public abstract object ParseBig();
-
         public abstract string Render();
-
         public abstract string ParseAndRender();
 
     }

--- a/Fluid.Benchmarks/BaseBenchmarks.cs
+++ b/Fluid.Benchmarks/BaseBenchmarks.cs
@@ -1,13 +1,13 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Fluid.Benchmarks
 {
     public abstract class BaseBenchmarks
     {
-        protected List<Product> Products = new List<Product>(ProductCount);
+        protected List<Product> Products = new(ProductCount);
 
-        protected const int ProductCount = 500;
+        protected const int ProductCount = 100;
 
         protected const string Lorem = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum";
 

--- a/Fluid.Benchmarks/ComparisonBenchmarks.cs
+++ b/Fluid.Benchmarks/ComparisonBenchmarks.cs
@@ -66,19 +66,22 @@ namespace Fluid.Benchmarks
             return _dotLiquidBenchmarks.Render();
         }
 
-        [Benchmark, BenchmarkCategory("Parse")]
+        // Ignored since Liquid.NET is much slower and not in active development
+        [BenchmarkCategory("Parse")]
         public object LiquidNet_Parse()
         {
             return _liquidNetBenchmarks.Parse();
         }
 
-        [Benchmark, BenchmarkCategory("ParseBig")]
+        // Ignored since Liquid.NET is much slower and not in active development
+        [BenchmarkCategory("ParseBig")]
         public object LiquidNet_ParseBig()
         {
             return _liquidNetBenchmarks.ParseBig();
         }
 
-        [Benchmark, BenchmarkCategory("Render")]
+        // Ignored since Liquid.NET is much slower and not in active development
+        [BenchmarkCategory("Render")]
         public string LiquidNet_Render()
         {
             return _liquidNetBenchmarks.Render();

--- a/Fluid.Benchmarks/CompiledFluidBenchmarks.cs
+++ b/Fluid.Benchmarks/CompiledFluidBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes;
 
 namespace Fluid.Benchmarks
 {
@@ -14,6 +14,8 @@ namespace Fluid.Benchmarks
             _options.MemberAccessStrategy.Register<Product>();
             _options.MemberAccessStrategy.MemberNameStrategy = MemberNameStrategies.CamelCase;
             _parser.TryParse(ProductTemplate, out _fluidTemplate, out var _);
+
+            CheckBenchmark();
         }
 
         [Benchmark]

--- a/Fluid.Benchmarks/DotLiquidBenchmarks.cs
+++ b/Fluid.Benchmarks/DotLiquidBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿using DotLiquid;
+using DotLiquid;
 using System.Linq;
 
 namespace Fluid.Benchmarks
@@ -11,6 +11,8 @@ namespace Fluid.Benchmarks
         {
             _dotLiquidTemplate = Template.Parse(ProductTemplate);
             _dotLiquidTemplate.MakeThreadSafe();
+
+            CheckBenchmark();
         }
 
         private Hash MakeProducts()

--- a/Fluid.Benchmarks/FluidBenchmarks.cs
+++ b/Fluid.Benchmarks/FluidBenchmarks.cs
@@ -12,9 +12,11 @@ namespace Fluid.Benchmarks
 
         public FluidBenchmarks()
         {
-            _options.MemberAccessStrategy.Register<Product>();
             _options.MemberAccessStrategy.MemberNameStrategy = MemberNameStrategies.CamelCase;
+            _options.MemberAccessStrategy.Register<Product>();
             _parser.TryParse(ProductTemplate, out _fluidTemplate, out var _);
+
+            CheckBenchmark();
         }
 
         [Benchmark]

--- a/Fluid.Benchmarks/HandlebarsBenchmarks.cs
+++ b/Fluid.Benchmarks/HandlebarsBenchmarks.cs
@@ -9,6 +9,12 @@ namespace Fluid.Benchmarks
 
         public HandlebarsBenchmarks()
         {
+            _handlebarsTemplate = CompileTemplate(ProductTemplateMustache);
+            CheckBenchmark();
+        }
+
+        private HandlebarsTemplate<object, object> CompileTemplate(string template)
+        {
             var handlebars = Handlebars.Create();
 
             using (handlebars.Configure())
@@ -23,7 +29,7 @@ namespace Fluid.Benchmarks
                     output.WriteSafeString(concat);
                 });
 
-                _handlebarsTemplate = handlebars.Compile(ProductTemplateMustache);
+                return handlebars.Compile(ProductTemplateMustache);
             }
         }
 
@@ -47,7 +53,7 @@ namespace Fluid.Benchmarks
 
         public override string ParseAndRender()
         {
-            var template = Handlebars.Compile(ProductTemplateMustache);
+            var template = CompileTemplate(ProductTemplateMustache);
             return template(new { products = Products });
         }
     }

--- a/Fluid.Benchmarks/HandlebarsBenchmarks.cs
+++ b/Fluid.Benchmarks/HandlebarsBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿using HandlebarsDotNet;
+using HandlebarsDotNet;
 using System;
 
 namespace Fluid.Benchmarks
@@ -9,7 +9,22 @@ namespace Fluid.Benchmarks
 
         public HandlebarsBenchmarks()
         {
-            _handlebarsTemplate = Handlebars.Compile(ProductTemplateMustache);
+            var handlebars = Handlebars.Create();
+
+            using (handlebars.Configure())
+            {
+                handlebars.RegisterHelper("truncate", (output, options, context, arguments) =>
+                {
+                    const string ellipsisStr = "...";
+                    var inputStr = options.Template();
+                    var length = Convert.ToInt32(arguments.Length > 0 ? arguments[0] : 50);
+                    var l = Math.Max(0, length - ellipsisStr.Length);
+                    var concat = string.Concat(inputStr.AsSpan().Slice(0, l), ellipsisStr);
+                    output.WriteSafeString(concat);
+                });
+
+                _handlebarsTemplate = handlebars.Compile(ProductTemplateMustache);
+            }
         }
 
         public override object Parse()

--- a/Fluid.Benchmarks/LiquidNetBenchmarks.cs
+++ b/Fluid.Benchmarks/LiquidNetBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿using Liquid.NET;
+using Liquid.NET;
 using Liquid.NET.Utils;
 
 namespace Fluid.Benchmarks
@@ -10,6 +10,7 @@ namespace Fluid.Benchmarks
         public LiquidNetBenchmarks()
         {
             _liquidNetTemplate = LiquidTemplate.Create(ProductTemplate);
+            CheckBenchmark();
         }
 
         public override object Parse()
@@ -25,6 +26,7 @@ namespace Fluid.Benchmarks
         public override string Render()
         {
             var context = new Liquid.NET.TemplateContext();
+            context.WithAllFilters();
             context.DefineLocalVariable("products", Products.ToLiquid());
             return _liquidNetTemplate.LiquidTemplate.Render(context).Result;
         }
@@ -33,6 +35,7 @@ namespace Fluid.Benchmarks
         {
             var template = LiquidTemplate.Create(ProductTemplate);
             var context = new Liquid.NET.TemplateContext();
+            context.WithAllFilters();
             context.DefineLocalVariable("products", Products.ToLiquid());
             return template.LiquidTemplate.Render(context).Result;
         }

--- a/Fluid.Benchmarks/Program.cs
+++ b/Fluid.Benchmarks/Program.cs
@@ -2,7 +2,6 @@ using BenchmarkDotNet.Running;
 
 namespace Fluid.Benchmarks
 {
-    // main
     class Program
     {
         static void Main(string[] args)

--- a/Fluid.Benchmarks/Program.cs
+++ b/Fluid.Benchmarks/Program.cs
@@ -1,7 +1,8 @@
-﻿using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Running;
 
 namespace Fluid.Benchmarks
 {
+    // main
     class Program
     {
         static void Main(string[] args)

--- a/Fluid.Benchmarks/ScribanBenchmarks.cs
+++ b/Fluid.Benchmarks/ScribanBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿using Scriban;
+using Scriban;
 using Scriban.Runtime;
 
 namespace Fluid.Benchmarks
@@ -10,6 +10,8 @@ namespace Fluid.Benchmarks
         public ScribanBenchmarks()
         {
             _scribanTemplate = Template.ParseLiquid(ProductTemplate);
+
+            CheckBenchmark();
         }
 
         public override object Parse()

--- a/Fluid.Benchmarks/product.mustache
+++ b/Fluid.Benchmarks/product.mustache
@@ -1,9 +1,9 @@
-﻿<ul id='products'>
+<ul id='products'>
   {{#products}}
     <li>
       <h2>{{ name }}</h2>
            Only {{ price }}
-           {{#truncate}}{{description}}{{/truncate}}
+           {{#truncate 15}}{{description}}{{/truncate}}
     </li>
   {{/products}}
 </ul>


### PR DESCRIPTION
Was wondering how this benchmark would not allocate as much as the others. It's actually not doing the same thing. The `{{#truncate}}` is not a thing unless implemented specifically.

Also changing the size of the list so the end result isn't too big. Will update the benchmark results in the other PR that has the charts.