### PR TITLE
Ensure `ObjectValue.ToStringValue()` doesn’t return `null`

### DIFF
--- a/Fluid/Values/ObjectValueBase.cs
+++ b/Fluid/Values/ObjectValueBase.cs
@@ -177,7 +177,7 @@ namespace Fluid.Values
 
         public override string ToStringValue()
         {
-            return Convert.ToString(Value);
+            return Convert.ToString(Value) ?? "";
         }
 
         public override object ToObjectValue()


### PR DESCRIPTION
Since [`ToString()` can return `null`](https://github.com/dotnet/coreclr/pull/23466), we must guard against this to prevent an `ArgumentNullException` later in `WriteToAsync()` when the string value gets encoded.