### PR TITLE
Trigger “default” filter when value would result in empty output after `ToStringValue()`

### DIFF
--- a/Fluid/Filters/MiscFilters.cs
+++ b/Fluid/Filters/MiscFilters.cs
@@ -128,7 +128,7 @@ namespace Fluid.Filters
             }
             else
             {
-                if (input.IsNil() || input == BooleanValue.False || EmptyValue.Instance.Equals(input))
+                if (input.IsNil() || input == BooleanValue.False || EmptyValue.Instance.Equals(input) || input.ToStringValue() == "")
                 {
                     return arguments.At(0);
                 }


### PR DESCRIPTION
I have some model items that go like this, so they result in their value when they’re tagged without specifying a property:

```csharp
public class MyModel
{
    public string Value = "";
    public string Description = "Something something";
    public override string ToString() => this.Value;
}
```

In this configuration the default filter will see that the object is present and not display the default value, even though the object will later be rendered as an empty string.

```csharp
var template = fluidParser.Parse("{{ InterestingItem | default: '—' }}");

var dict = new Dictionary<string, object>() { ["InterestingItem"] = new MyModel() };

var html = template.Render(new TemplateContext(dict)); // html is "", but I would expect "—"
```

This PR adds a check for the object's actual string value, so the default filter will do its thing.

Cheers :)