### PR TITLE
Avoid creating empty ArrayValue instances

### DIFF
--- a/Fluid/Values/FluidValue.cs
+++ b/Fluid/Values/FluidValue.cs
@@ -215,7 +215,7 @@ namespace Fluid.Values
                             return new DictionaryValue(new DictionaryDictionaryFluidIndexable(otherDictionary, options));
 
                         case FluidValue[] array:
-                            return new ArrayValue(array);
+                            return array.Length > 0 ? new ArrayValue(array) : ArrayValue.Empty;
                     }
 
                     // Check if it's a more specific IDictionary<string, V>, e.g. JObject
@@ -249,12 +249,22 @@ namespace Fluid.Values
                     switch (value)
                     {
                         case IReadOnlyList<FluidValue> list:
+                            if (list.Count == 0)
+                            {
+                                return ArrayValue.Empty;
+                            }
+
                             return new ArrayValue(list);
 
                         case IEnumerable<FluidValue> enumerable:
                             return new ArrayValue(enumerable.ToArray());
 
                         case IList list:
+                            if (list.Count == 0)
+                            {
+                                return ArrayValue.Empty;
+                            }
+
                             var values = new FluidValue[list.Count];
                             for (var i = 0; i < values.Length; i++)
                             {
@@ -264,20 +274,24 @@ namespace Fluid.Values
                             return new ArrayValue(values);
 
                         case IEnumerable enumerable:
-                            var fluidValues = new List<FluidValue>();
+                            List<FluidValue> fluidValues = null;
                             foreach (var item in enumerable)
                             {
+                                fluidValues ??= [];
                                 fluidValues.Add(Create(item, options));
                             }
-                            return new ArrayValue(fluidValues);
+                            return fluidValues != null ? new ArrayValue(fluidValues) : ArrayValue.Empty;
                     }
 
                     return new ObjectValue(value);
+
                 case TypeCode.DateTime:
                     return new DateTimeValue((DateTime)value);
+
                 case TypeCode.Char:
                 case TypeCode.String:
                     return new StringValue(Convert.ToString(value, options.CultureInfo));
+
                 default:
                     throw new InvalidOperationException();
             }

--- a/Fluid/Values/FluidValue.cs
+++ b/Fluid/Values/FluidValue.cs
@@ -282,7 +282,10 @@ namespace Fluid.Values
                                 fluidValues ??= [];
                                 fluidValues.Add(Create(item, options));
                             }
-                            return fluidValues != null ? new ArrayValue(fluidValues) : ArrayValue.Empty;
+
+                            return fluidValues != null
+                                ? new ArrayValue(fluidValues)
+                                : ArrayValue.Empty;
                     }
 
                     return new ObjectValue(value);

--- a/Fluid/Values/FluidValue.cs
+++ b/Fluid/Values/FluidValue.cs
@@ -215,7 +215,9 @@ namespace Fluid.Values
                             return new DictionaryValue(new DictionaryDictionaryFluidIndexable(otherDictionary, options));
 
                         case FluidValue[] array:
-                            return array.Length > 0 ? new ArrayValue(array) : ArrayValue.Empty;
+                            return array.Length > 0
+                                ? new ArrayValue(array)
+                                : ArrayValue.Empty;
                     }
 
                     // Check if it's a more specific IDictionary<string, V>, e.g. JObject


### PR DESCRIPTION
To my understanding, these ad hoc conversions required when doing interop between model and the template so these a transient and will not need to later reflect any state changes done in models. In NSwag there are properties that return empty enumerables with dynamic LINQ where outcome is an empty enumerator 90% of the cases.