### PR TITLE
Use single dictionary in DefaultMemberAccessStrategy

### DIFF
--- a/Fluid/Ast/TextSpanStatement.cs
+++ b/Fluid/Ast/TextSpanStatement.cs
@@ -7,7 +7,7 @@ namespace Fluid.Ast
     public sealed class TextSpanStatement : Statement
     {
         private bool _isBufferPrepared;
-        private readonly object _synLock = new();
+        private readonly Lock _synLock = new();
         private TextSpan _text;
         internal string _preparedBuffer;
 

--- a/Fluid/Shims.cs
+++ b/Fluid/Shims.cs
@@ -1,32 +1,34 @@
-#if !NET6_0_OR_GREATER
-using System.Runtime.CompilerServices;
-
 #nullable enable
 
 namespace Fluid
 {
+#if !NET6_0_OR_GREATER
     /// <summary>
     /// Filling missing bits between netstandard2.0 and higher libs and frameworks.
     /// </summary>
     internal static class Shims
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static string[] Split(this string s, string? separator, StringSplitOptions options = StringSplitOptions.None)
         {
-            return s.Split(new[] { separator }, options);
+            return s.Split([separator], options);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining | (MethodImplOptions)512)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static bool EndsWith(this string s, char c)
         {
             return s.Length > 0 && s[^1] == c;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static bool Contains(this string s, char c)
         {
             return s.IndexOf(c) != -1;
         }
     }
-}
 #endif
+
+#if !NET9_0_OR_GREATER
+    internal sealed class Lock;
+#endif
+}


### PR DESCRIPTION
It's wasteful do do a doble lookup to get onto type's member level. Now using single key. Added also simple `Lock` shim for non NET  9 targets.