### PR TITLE
Reduce value type boxing in interop calls

### DIFF
--- a/Fluid/Accessors/PropertyInfoAccessor.cs
+++ b/Fluid/Accessors/PropertyInfoAccessor.cs
@@ -12,7 +12,7 @@ namespace Fluid.Accessors
         {
             Delegate d;
 
-            if (!propertyInfo.DeclaringType.IsValueType)
+            if (!propertyInfo.DeclaringType?.IsValueType == true)
             {
                 var delegateType = typeof(Func<,>).MakeGenericType(propertyInfo.DeclaringType, propertyInfo.PropertyType);
                 d = propertyInfo.GetGetMethod().CreateDelegate(delegateType);
@@ -31,51 +31,50 @@ namespace Fluid.Accessors
                 _invoker = null;
             }
 
+            Type invokerType;
             if (propertyInfo.PropertyType == typeof(bool))
             {
-                var invokerType = typeof(BooleanInvoker<>).MakeGenericType(propertyInfo.DeclaringType);
-                _invoker = (Invoker) Activator.CreateInstance(invokerType, [d]);
+                invokerType = typeof(BooleanInvoker<>).MakeGenericType(propertyInfo.DeclaringType);
             }
             else if (propertyInfo.PropertyType == typeof(int))
             {
-                var invokerType = typeof(Int32Invoker<>).MakeGenericType(propertyInfo.DeclaringType);
-                _invoker = (Invoker) Activator.CreateInstance(invokerType, [d]);
+                invokerType = typeof(Int32Invoker<>).MakeGenericType(propertyInfo.DeclaringType);
             }
             else
             {
-                var invokerType = typeof(Invoker<,>).MakeGenericType(propertyInfo.DeclaringType, propertyInfo.PropertyType);
-                _invoker = (Invoker) Activator.CreateInstance(invokerType, [d]);
+                invokerType = typeof(Invoker<,>).MakeGenericType(propertyInfo.DeclaringType, propertyInfo.PropertyType);
             }
+
+            _invoker = (Invoker) Activator.CreateInstance(invokerType, [d]);
         }
 
-        public object Get(object obj, string name, TemplateContext ctx)
-        {
-            return _invoker?.Invoke(obj);
-        }
+        public object Get(object obj, string name, TemplateContext ctx) => _invoker.Invoke(obj);
 
         private static Delegate GetGetter(Type declaringType, string fieldName)
         {
-            string[] names = [fieldName.ToLowerInvariant(), $"<{fieldName}>k__BackingField", "_" + fieldName.ToLowerInvariant()];
+            string[] names = [fieldName.ToLowerInvariant(), $"<{fieldName}>k__BackingField", $"_{fieldName.ToLowerInvariant()}"];
 
-            var field = names
-                .Select(n => declaringType.GetField(n, BindingFlags.Instance | BindingFlags.NonPublic))
-                .FirstOrDefault(x => x != null);
-
-            if (field == null)
+            foreach (var n in names)
             {
-                return null;
+                var field = declaringType.GetField(n, BindingFlags.Instance | BindingFlags.NonPublic);
+                if (field == null)
+                {
+                    continue;
+                }
+
+                var parameterTypes = new[] { typeof(object), declaringType };
+
+                var method = new DynamicMethod(fieldName + "Get", field.FieldType, parameterTypes, typeof(PropertyInfoAccessor).Module, true);
+
+                var emitter = method.GetILGenerator();
+                emitter.Emit(OpCodes.Ldarg_1);
+                emitter.Emit(OpCodes.Ldfld, field);
+                emitter.Emit(OpCodes.Ret);
+
+                return method.CreateDelegate(typeof(Func<,>).MakeGenericType(declaringType, field.FieldType));
             }
 
-            var parameterTypes = new[] { typeof(object), declaringType };
-
-            var method = new DynamicMethod(fieldName + "Get", field.FieldType, parameterTypes, typeof(PropertyInfoAccessor).Module, true);
-
-            var emitter = method.GetILGenerator();
-            emitter.Emit(OpCodes.Ldarg_1);
-            emitter.Emit(OpCodes.Ldfld, field);
-            emitter.Emit(OpCodes.Ret);
-
-            return method.CreateDelegate(typeof(Func<,>).MakeGenericType(declaringType, field.FieldType));
+            return null;
         }
 
         private abstract class Invoker
@@ -83,50 +82,25 @@ namespace Fluid.Accessors
             public abstract object Invoke(object target);
         }
 
-        private sealed class Invoker<T, TResult> : Invoker
+        private sealed class Invoker<T, TResult>(Delegate d) : Invoker
         {
-            private readonly Func<T, TResult> _d;
+            private readonly Func<T, TResult> _d = (Func<T, TResult>) d;
 
-            public Invoker(Delegate d)
-            {
-                _d = (Func<T, TResult>)d;
-            }
-
-            public override object Invoke(object target)
-            {
-                return _d((T)target);
-            }
+            public override object Invoke(object target) => _d((T) target);
         }
 
-        private sealed class BooleanInvoker<T> : Invoker
+        private sealed class BooleanInvoker<T>(Delegate d) : Invoker
         {
-            private readonly Func<T, bool> _d;
+            private readonly Func<T, bool> _d = (Func<T, bool>) d;
 
-            public BooleanInvoker(Delegate d)
-            {
-                _d = (Func<T, bool>)d;
-            }
-
-            public override object Invoke(object target)
-            {
-                return _d((T)target) ? BooleanValue.True : BooleanValue.False;
-            }
+            public override object Invoke(object target) => _d((T) target) ? BooleanValue.True : BooleanValue.False;
         }
 
-        private sealed class Int32Invoker<T> : Invoker
+        private sealed class Int32Invoker<T>(Delegate d) : Invoker
         {
-            private readonly Func<T, int> _d;
+            private readonly Func<T, int> _d = (Func<T, int>) d;
 
-            public Int32Invoker(Delegate d)
-            {
-                _d = (Func<T, int>)d;
-            }
-
-            public override object Invoke(object target)
-            {
-                var value = _d((T)target);
-                return NumberValue.Create(value);
-            }
+            public override object Invoke(object target) => NumberValue.Create(_d((T) target));
         }
     }
 }


### PR DESCRIPTION
* special case common bool and int property access
* use abstract class instead of interface do reduce virtual dispatch cost

When profiling NJsonSchema, found out that now after optimizations almost 10% of allocations originate from boolean value boxing (very common in code generation templates).

![image](https://github.com/user-attachments/assets/eea8ff77-5a1b-4b49-b234-b37a696380c7)
