### PR TITLE
Drop obsolete .NET 6.0 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,20 +19,19 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: | 
-          6.0.x
+        dotnet-version: |
           8.0.x
         global-json-file: global.json
 
     - name: Test
       run: dotnet test -c Release
-    
+
     - name: Test - Compiled
       run: dotnet test --configuration Release /p:Compiled=true
 
     - name: Pack
       run: |
-        PACKAGE_PATH="${GITHUB_WORKSPACE}/artifacts" 
+        PACKAGE_PATH="${GITHUB_WORKSPACE}/artifacts"
         dotnet pack --property:PackageOutputPath=$PACKAGE_PATH --configuration Release -p:PackageVersion=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=True
 
     - name: Publish on MyGet

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,14 +24,13 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: | 
-          6.0.x
+        dotnet-version: |
           8.0.x
         global-json-file: global.json
 
     - name: Version
       run: dotnet --version
-    
+
     - name: Test
       run: dotnet test -c Release
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   push:
-    tags: 
+    tags:
       - v*
 
 jobs:
@@ -17,8 +17,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: | 
-          6.0.x
+        dotnet-version: |
           8.0.x
         global-json-file: global.json
 
@@ -31,7 +30,7 @@ jobs:
         arrTag=(${GITHUB_REF//\// })
         VERSION="${arrTag[2]}"
         VERSION="${VERSION//v}"
-        PACKAGE_PATH="${GITHUB_WORKSPACE}/artifacts" 
+        PACKAGE_PATH="${GITHUB_WORKSPACE}/artifacts"
         echo "$VERSION"
         dotnet pack --property:PackageOutputPath=$PACKAGE_PATH --configuration Release -p:Version=$VERSION -p:ContinuousIntegrationBuild=True
 

--- a/Fluid.MvcViewEngine/Fluid.MvcViewEngine.csproj
+++ b/Fluid.MvcViewEngine/Fluid.MvcViewEngine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PackageIcon>logo_64x64.png</PackageIcon>
     <IsPackable>true</IsPackable>
@@ -18,10 +18,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Fluid\Fluid.csproj" />
     <ProjectReference Include="..\Fluid.ViewEngine\Fluid.ViewEngine.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">

--- a/Fluid.Tests/Fluid.Tests.csproj
+++ b/Fluid.Tests/Fluid.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <DefineConstants Condition="'$(Compiled)' == 'true'">$(DefineConstants);COMPILED</DefineConstants>
     <IsPackable>false</IsPackable>

--- a/Fluid.ViewEngine/Fluid.ViewEngine.csproj
+++ b/Fluid.ViewEngine/Fluid.ViewEngine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>true</IsPackable>
     <PackageIcon>logo_64x64.png</PackageIcon>

--- a/Fluid/Fluid.csproj
+++ b/Fluid/Fluid.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <IsPackable>true</IsPackable>
@@ -12,8 +12,6 @@
     <PackageIcon>logo_64x64.png</PackageIcon>
     <ImplicitUsings>true</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <!-- Ingore missing comments errors and obsolete TFMs -->
-    <NoWarn>$(NoWarn);CS1591;NETSDK1138</NoWarn>
 
     <AnalysisLevel>latest-Recommended</AnalysisLevel>
     <NoWarn>$(NoWarn);CA1016</NoWarn> <!-- CA1016: Mark assemblies with AssemblyVersionAttribute -->
@@ -40,15 +38,10 @@
     <PackageReference Include="TimeZoneConverter" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net8.0'))">
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="Microsoft.CSharp" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" />
-  </ItemGroup>
-
-  <!-- Keep specific targets since it removes some dependencies -->
-  <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">

--- a/Versions.props
+++ b/Versions.props
@@ -5,11 +5,6 @@
     <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>9.0.0</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <SystemTextJsonPackageVersion>8.0.5</SystemTextJsonPackageVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>9.0.0</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>9.0.0</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
   </PropertyGroup>


### PR DESCRIPTION
It's been obsolete a long time and possible core library users will just fall back to netstandard2.0. NET 6.0 has been flagged as unsupported target in newer runtime libs and causes warnings when used.