### PR TITLE
Add `WithColorFilters` to `TemplateOptions` initialization

### DIFF
--- a/Fluid/TemplateOptions.cs
+++ b/Fluid/TemplateOptions.cs
@@ -120,7 +120,9 @@ namespace Fluid
             Filters.WithArrayFilters()
                 .WithStringFilters()
                 .WithNumberFilters()
-                .WithMiscFilters();
+                .WithMiscFilters()
+                .WithColorFilters();
         }
     }
 }
+


### PR DESCRIPTION
The color filters were implemented but never added to the TemplateOptions.
I tried to find a reason why it wasn’t done, but couldn’t find any mention of it, so I thought it was just forgotten.