### PR TITLE
Implemented GetHashCode in ArrayValue.cs and DictionaryValue.cs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonPackageVersion)" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
+    <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
 
     <!-- Common to all TFMs -->
     <PackageVersion Include="Parlot" Version="1.4.0" />

--- a/Fluid.Tests/ArrayFiltersTests.cs
+++ b/Fluid.Tests/ArrayFiltersTests.cs
@@ -372,6 +372,12 @@ namespace Fluid.Tests
                 new DictionaryValue(new FluidValueDictionaryFluidIndexable(
                     new Dictionary<string, FluidValue>()
                     {
+                        ["b"] = StringValue.Create("c"),
+                        ["a"] = StringValue.Create("b"),
+                    })),
+                new DictionaryValue(new FluidValueDictionaryFluidIndexable(
+                    new Dictionary<string, FluidValue>()
+                    {
                         ["a"] = StringValue.Create("b"),
                         ["c"] = StringValue.Create("c"),
                     })),

--- a/Fluid.Tests/ArrayFiltersTests.cs
+++ b/Fluid.Tests/ArrayFiltersTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Fluid.Values;
 using Fluid.Filters;
@@ -332,6 +333,62 @@ namespace Fluid.Tests
             var result = ArrayFilters.Uniq(input, arguments, context);
 
             Assert.Equal(2, result.Result.Enumerate(context).Count());
+        }
+
+        [Fact]
+        public void UniqWithArrays()
+        {
+            var input = new ArrayValue(new[] {
+                new ArrayValue([ StringValue.Create("a"), StringValue.Create("b") ]),
+                new ArrayValue([ StringValue.Create("a"), StringValue.Create("c") ]),
+                new ArrayValue([ StringValue.Create("a"), StringValue.Create("c") ]),
+                new ArrayValue([ StringValue.Create("b"), StringValue.Create("a") ]),
+            });
+
+            var arguments = new FilterArguments();
+            var context = new TemplateContext();
+
+            var result = ArrayFilters.Uniq(input, arguments, context);
+
+            Assert.Equal(3, result.Result.Enumerate(context).Count());
+        }
+
+        [Fact]
+        public void UniqWithDictionaries()
+        {
+            var input = new ArrayValue([
+                new DictionaryValue(new FluidValueDictionaryFluidIndexable(
+                    new Dictionary<string, FluidValue>()
+                    {
+                        ["a"] = StringValue.Create("b"),
+                        ["b"] = StringValue.Create("c"),
+                    })),
+                new DictionaryValue(new FluidValueDictionaryFluidIndexable(
+                    new Dictionary<string, FluidValue>()
+                    {
+                        ["a"] = StringValue.Create("b"),
+                        ["b"] = StringValue.Create("c"),
+                    })),
+                new DictionaryValue(new FluidValueDictionaryFluidIndexable(
+                    new Dictionary<string, FluidValue>()
+                    {
+                        ["a"] = StringValue.Create("b"),
+                        ["c"] = StringValue.Create("c"),
+                    })),
+                new DictionaryValue(new FluidValueDictionaryFluidIndexable(
+                    new Dictionary<string, FluidValue>()
+                    {
+                        ["a"] = StringValue.Create("c"),
+                        ["b"] = StringValue.Create("a"),
+                    }))
+            ]);
+
+            var arguments = new FilterArguments();
+            var context = new TemplateContext();
+
+            var result = ArrayFilters.Uniq(input, arguments, context);
+
+            Assert.Equal(3, result.Result.Enumerate(context).Count());
         }
 
         [Fact]

--- a/Fluid/Fluid.csproj
+++ b/Fluid/Fluid.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="Microsoft.CSharp" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">

--- a/Fluid/Shims.cs
+++ b/Fluid/Shims.cs
@@ -31,20 +31,4 @@ namespace Fluid
 #if !NET9_0_OR_GREATER
     internal sealed class Lock;
 #endif
-
-#if !NET8_0_OR_GREATER
-    internal sealed class HashCode
-    {
-        private int _hc = 19;
-
-        public void Add<T>(T value)
-        {
-            unchecked
-            {
-                _hc = _hc * 31 + (value?.GetHashCode() ?? 0);
-            }
-        }
-        public int ToHashCode() => _hc;
-    }
-#endif
 }

--- a/Fluid/Shims.cs
+++ b/Fluid/Shims.cs
@@ -37,11 +37,11 @@ namespace Fluid
     {
         private int _hc = 19;
 
-        public void Add(object o)
+        public void Add<T>(T value)
         {
             unchecked
             {
-                _hc = _hc * 31 + o.GetHashCode();
+                _hc = _hc * 31 + (value?.GetHashCode() ?? 0);
             }
         }
         public int ToHashCode() => _hc;

--- a/Fluid/Shims.cs
+++ b/Fluid/Shims.cs
@@ -31,4 +31,20 @@ namespace Fluid
 #if !NET9_0_OR_GREATER
     internal sealed class Lock;
 #endif
+
+#if !NET8_0_OR_GREATER
+    internal sealed class HashCode
+    {
+        private int _hc = 19;
+
+        public void Add(object o)
+        {
+            unchecked
+            {
+                _hc = _hc * 31 + o.GetHashCode();
+            }
+        }
+        public int ToHashCode() => _hc;
+    }
+#endif
 }

--- a/Fluid/Values/ArrayValue.cs
+++ b/Fluid/Values/ArrayValue.cs
@@ -155,9 +155,11 @@ namespace Fluid.Values
         {
             var hc = new HashCode();
 
-            foreach (var v in Values)
+            IReadOnlyList<FluidValue> values = Values;
+            int count = values.Count;
+            for (int i = 0; i < count; ++i)
             {
-                hc.Add(v);
+                hc.Add(values[i]);
             }
 
             return hc.ToHashCode();

--- a/Fluid/Values/ArrayValue.cs
+++ b/Fluid/Values/ArrayValue.cs
@@ -145,7 +145,7 @@ namespace Fluid.Values
             // The is operator will return false if null
             if (obj is ArrayValue otherValue)
             {
-                return Values.Equals(otherValue.Values);
+                return Equals(otherValue);
             }
 
             return false;
@@ -153,7 +153,14 @@ namespace Fluid.Values
 
         public override int GetHashCode()
         {
-            return Values.GetHashCode();
+            var hc = new HashCode();
+
+            foreach (var v in Values)
+            {
+                hc.Add(v);
+            }
+
+            return hc.ToHashCode();
         }
     }
 }

--- a/Fluid/Values/DictionaryValue.cs
+++ b/Fluid/Values/DictionaryValue.cs
@@ -137,7 +137,7 @@ namespace Fluid.Values
             // The is operator will return false if null
             if (obj is DictionaryValue otherValue)
             {
-                return _value.Equals(otherValue._value);
+                return Equals(otherValue);
             }
 
             return false;
@@ -145,7 +145,15 @@ namespace Fluid.Values
 
         public override int GetHashCode()
         {
-            return _value.GetHashCode();
+            var hc = new HashCode();
+            foreach (var key in _value.Keys.OrderBy(k => k))
+            {
+                hc.Add(key);
+                if (_value.TryGetValue(key, out var v))
+                    hc.Add(v);
+            }
+
+            return hc.ToHashCode();
         }
     }
 }


### PR DESCRIPTION
Currently Uniq filter doesn't work for arrays containing dictionaries or other arrays. This PR adds support for this by implementing GetHashCode in ArrayValue and DictionaryValue. 