### PR TITLE
Implement ifchanged Liquid tag

### DIFF
--- a/Fluid.Tests/GoldendLiquidTests.cs
+++ b/Fluid.Tests/GoldendLiquidTests.cs
@@ -29,7 +29,6 @@ namespace Fluid.Tests
             ["id:filters_date_undefined_argument"] = "test expects error but Shopify parses date",
 
             ["tag:snippet tag"] = "snippet tag not implemented",
-            ["tag:ifchanged tag"] = "ifchanged tag not implemented",
             ["tag:strict2"] = "Fluid uses lenient parsing mode; strict2 mode not implemented",
 
             ["id:tags_liquid_single_line_comment_tag"] = "Skipping: `{% liquid %}` comment/endcomment special-case parsing not implemented",

--- a/Fluid.Tests/IfChangedStatementTests.cs
+++ b/Fluid.Tests/IfChangedStatementTests.cs
@@ -1,0 +1,130 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Fluid.Ast;
+using Fluid.Values;
+using Xunit;
+
+namespace Fluid.Tests
+{
+    public class IfChangedStatementTests
+    {
+        [Fact]
+        public async Task IfChangedOutputsOnFirstInvocation()
+        {
+            var statement = new IfChangedStatement(
+                [new OutputStatement(new LiteralExpression(new StringValue("hello")))]
+            );
+
+            var context = new TemplateContext();
+            var sw = new StringWriter();
+
+            await statement.WriteToAsync(sw, HtmlEncoder.Default, context);
+
+            Assert.Equal("hello", sw.ToString());
+        }
+
+        [Fact]
+        public async Task IfChangedDoesNotOutputOnSecondIdenticalInvocation()
+        {
+            var statement = new IfChangedStatement(
+                [new OutputStatement(new LiteralExpression(new StringValue("hello")))]
+            );
+
+            var context = new TemplateContext();
+            var sw = new StringWriter();
+
+            await statement.WriteToAsync(sw, HtmlEncoder.Default, context);
+            await statement.WriteToAsync(sw, HtmlEncoder.Default, context);
+
+            Assert.Equal("hello", sw.ToString());
+        }
+
+        [Fact]
+        public async Task IfChangedOutputsWhenContentChanges()
+        {
+            // We need to use parsed templates to test dynamic content
+            var parser = new FluidParser();
+            var template = parser.Parse("{% assign x = 'a' %}{% ifchanged %}{{ x }}{% endifchanged %}{% assign x = 'b' %}{% ifchanged %}{{ x }}{% endifchanged %}");
+
+            var context = new TemplateContext();
+            var result = await template.RenderAsync(context);
+
+            Assert.Equal("ab", result);
+        }
+
+        [Fact]
+        public async Task IfChangedEmptyBlockOutputsOnce()
+        {
+            var parser = new FluidParser();
+            var template = parser.Parse("{% ifchanged %}{% endifchanged %}{% ifchanged %}{% endifchanged %}");
+
+            var context = new TemplateContext();
+            var result = await template.RenderAsync(context);
+
+            Assert.Equal("", result);
+        }
+
+        [Fact]
+        public async Task IfChangedWorksWithinForLoop()
+        {
+            var parser = new FluidParser();
+            var template = parser.Parse("{% assign list = '1,1,2,2,3' | split: ',' %}{% for item in list %}{% ifchanged %}{{ item }}{% endifchanged %}{% endfor %}");
+
+            var context = new TemplateContext();
+            var result = await template.RenderAsync(context);
+
+            Assert.Equal("123", result);
+        }
+
+        [Fact]
+        public async Task IfChangedOutputsDifferentContent()
+        {
+            var parser = new FluidParser();
+            var template = parser.Parse("{% ifchanged %}a{% endifchanged %}{% ifchanged %}b{% endifchanged %}");
+
+            var context = new TemplateContext();
+            var result = await template.RenderAsync(context);
+
+            // Both output because content is different ("a" vs "b")
+            Assert.Equal("ab", result);
+        }
+
+        [Fact]
+        public async Task IfChangedRespectsWhitespaceTrimming()
+        {
+            var parser = new FluidParser();
+            var template = parser.Parse("X{%- ifchanged -%}Y{%- endifchanged -%}Z");
+
+            var context = new TemplateContext();
+            var result = await template.RenderAsync(context);
+
+            Assert.Equal("XYZ", result);
+        }
+
+        [Fact]
+        public async Task IfChangedHandlesNilValues()
+        {
+            var parser = new FluidParser();
+            var template = parser.Parse("{% ifchanged %}{{ undefined }}{% endifchanged %}{% ifchanged %}{{ undefined }}{% endifchanged %}");
+
+            var context = new TemplateContext();
+            var result = await template.RenderAsync(context);
+
+            // Both output empty string, but first invocation outputs (empty), second doesn't
+            Assert.Equal("", result);
+        }
+
+        [Fact]
+        public async Task IfChangedWithSortedList()
+        {
+            var parser = new FluidParser();
+            var template = parser.Parse("{% assign list = \"1,3,2,1,3,1,2\" | split: \",\" | sort %}{% for item in list -%}{%- ifchanged %} {{ item }}{% endifchanged -%}{%- endfor %}");
+
+            var context = new TemplateContext();
+            var result = await template.RenderAsync(context);
+
+            Assert.Equal(" 1 2 3", result);
+        }
+    }
+}

--- a/Fluid/Ast/AstRewriter.cs
+++ b/Fluid/Ast/AstRewriter.cs
@@ -461,6 +461,16 @@ namespace Fluid.Ast
             return ifStatement;
         }
 
+        protected internal override Statement VisitIfChangedStatement(IfChangedStatement ifChangedStatement)
+        {
+            if (TryRewriteStatements(ifChangedStatement.Statements, out var newStatements))
+            {
+                return new IfChangedStatement(newStatements.ToList());
+            }
+
+            return ifChangedStatement;
+        }
+
         protected internal override Statement VisitIncludeStatement(IncludeStatement includeStatement)
         {
             if (TryRewriteExpression(includeStatement.For, out var newFor) |

--- a/Fluid/Ast/AstVisitor.cs
+++ b/Fluid/Ast/AstVisitor.cs
@@ -361,6 +361,16 @@ namespace Fluid.Ast
             return ifStatement;
         }
 
+        protected internal virtual Statement VisitIfChangedStatement(IfChangedStatement ifChangedStatement)
+        {
+            foreach (var statement in ifChangedStatement.Statements)
+            {
+                Visit(statement);
+            }
+
+            return ifChangedStatement;
+        }
+
         protected internal virtual Statement VisitIncludeStatement(IncludeStatement includeStatement)
         {
             Visit(includeStatement.For);

--- a/Fluid/Ast/IfChangedStatement.cs
+++ b/Fluid/Ast/IfChangedStatement.cs
@@ -1,0 +1,50 @@
+using Fluid.Utils;
+using System.Text.Encodings.Web;
+
+namespace Fluid.Ast
+{
+    public sealed class IfChangedStatement : TagStatement
+    {
+        private const string IfChangedRegisterKey = "$$ifchanged$$";
+
+        public IfChangedStatement(IReadOnlyList<Statement> statements) : base(statements)
+        {
+        }
+
+        public override async ValueTask<Completion> WriteToAsync(IFluidOutput output, TextEncoder encoder, TemplateContext context)
+        {
+            context.IncrementSteps();
+
+            // Get the previous value (shared across all ifchanged blocks)
+            context.AmbientValues.TryGetValue(IfChangedRegisterKey, out var previousValueObj);
+            var previousValue = previousValueObj as string;
+
+            // Render inner statements to a buffer
+            using var captureOutput = new BufferFluidOutput();
+            var completion = Completion.Normal;
+
+            for (var i = 0; i < Statements.Count; i++)
+            {
+                completion = await Statements[i].WriteToAsync(captureOutput, encoder, context);
+
+                if (completion != Completion.Normal)
+                {
+                    break;
+                }
+            }
+
+            var currentValue = captureOutput.ToString();
+
+            // Output only if content has changed from the last ifchanged output
+            if (!string.Equals(previousValue, currentValue, StringComparison.Ordinal))
+            {
+                context.AmbientValues[IfChangedRegisterKey] = currentValue;
+                output.Write(currentValue);
+            }
+
+            return completion;
+        }
+
+        protected internal override Statement Accept(AstVisitor visitor) => visitor.VisitIfChangedStatement(this);
+    }
+}

--- a/Fluid/FluidParser.cs
+++ b/Fluid/FluidParser.cs
@@ -375,6 +375,14 @@ namespace Fluid
                         ;
             CycleTag.Name = "CycleTag";
 
+            var IfChangedTag = TagEnd
+                        .And(AnyTagsList)
+                        .AndSkip(CreateTag("endifchanged").ElseError($"'{{% endifchanged %}}' was expected"))
+                        .Then<Statement>(x => new IfChangedStatement(x.Item2))
+                        .ElseError("Invalid 'ifchanged' tag")
+                        ;
+            IfChangedTag.Name = "IfChangedTag";
+
             var DecrementTag = ZeroOrOne(VariableSignature).AndSkip(TagEnd)
                         .Then<Statement>(x => new DecrementStatement(x))
                         .ElseError("Invalid 'decrement' tag")
@@ -622,6 +630,7 @@ namespace Fluid
             RegisteredTags["capture"] = CaptureTag;
             RegisteredTags["cycle"] = CycleTag;
             RegisteredTags["decrement"] = DecrementTag;
+            RegisteredTags["ifchanged"] = IfChangedTag;
             RegisteredTags["include"] = IncludeTag;
             RegisteredTags["render"] = RenderTag;
             RegisteredTags["increment"] = IncrementTag;


### PR DESCRIPTION
## Summary

Implements the `{% ifchanged %}` Liquid tag, which outputs content only when it has changed from the previous invocation.

## Changes

- **`Fluid/Ast/IfChangedStatement.cs`** - New AST node that:
  - Renders inner statements to a buffer
  - Compares with the previous output stored in `context.AmbientValues`
  - Only outputs content if it differs from the last `ifchanged` output

- **`Fluid/FluidParser.cs`** - Registers the `ifchanged`/`endifchanged` block tag

- **`Fluid/Ast/AstVisitor.cs`** & **`AstRewriter.cs`** - Added visitor methods

- **`Fluid.Tests/GoldendLiquidTests.cs`** - Enabled golden liquid tests (removed skip entry)

- **`Fluid.Tests/IfChangedStatementTests.cs`** - 9 new unit tests

## Behavior

All `{% ifchanged %}` blocks share a single "previous value" in the render context. This matches Shopify Liquid's behavior:

```liquid
{% assign foo = 'hello' %}
{% ifchanged %}{{ foo }}{% endifchanged %}  {# outputs 'hello' #}
{% ifchanged %}{{ foo }}{% endifchanged %}  {# no output (unchanged) #}
{% assign foo = 'goodbye' %}
{% ifchanged %}{{ foo }}{% endifchanged %}  {# outputs 'goodbye' #}
```

Common use case - grouping in loops:
```liquid
{% for item in list | sort %}
  {% ifchanged %}{{ item }}{% endifchanged %}
{% endfor %}
```

## Tests

- All 5 golden liquid tests for `ifchanged tag` pass
- 9 new unit tests pass
- All 2415 existing tests pass (20 skipped for unrelated features)