### PR TITLE
Cache member accessors, filters and small scopes during rendering

### DIFF
--- a/Fluid.Benchmarks/Program.cs
+++ b/Fluid.Benchmarks/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using BenchmarkDotNet.Running;
 
 namespace Fluid.Benchmarks
@@ -7,15 +8,52 @@ namespace Fluid.Benchmarks
     {
         static void Main(string[] args)
         {
-            // var benchmark = new FluidBenchmarks();
-            // for (var i = 0; i < 100000 ;i++)
-            // {
-            //     var x = benchmark.Render();
+            // Steady-state loop for sampling profilers (for instance `ultra profile -- Fluid.Benchmarks.exe profile render 25`).
+            // BenchmarkDotNet spawns short-lived child processes, which a profiler can't follow.
+            if (args.Length > 0 && args[0].Equals("profile", StringComparison.OrdinalIgnoreCase))
+            {
+                RunProfileLoop(args);
+                return;
+            }
 
-            //     ArgumentNullException.ThrowIfNullOrEmpty(x);
-            // }
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        }
 
-             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        static void RunProfileLoop(string[] args)
+        {
+            var what = args.Length > 1 ? args[1] : "render";
+            var seconds = args.Length > 2 ? int.Parse(args[2]) : 25;
+
+            var benchmark = new FluidBenchmarks();
+
+            Func<object> work = what.ToLowerInvariant() switch
+            {
+                "render" => () => benchmark.Render(),
+                "parse" => () => benchmark.Parse(),
+                "parsebig" => () => benchmark.ParseBig(),
+                "parseandrender" => () => benchmark.ParseAndRender(),
+                _ => throw new ArgumentException("Unknown profile workload: " + what)
+            };
+
+            // Warm up so the capture isn't dominated by tiered JIT.
+            for (var i = 0; i < 200; i++)
+            {
+                if (work() is null) throw new InvalidOperationException("null result");
+            }
+
+            var sw = Stopwatch.StartNew();
+            long iterations = 0;
+            while (sw.Elapsed.TotalSeconds < seconds)
+            {
+                for (var i = 0; i < 50; i++)
+                {
+                    if (work() is null) throw new InvalidOperationException("null result");
+                }
+
+                iterations += 50;
+            }
+
+            Console.Error.WriteLine($"{what}: {iterations} iterations in {sw.Elapsed.TotalSeconds:F1}s ({iterations / sw.Elapsed.TotalSeconds:F0} ops/s)");
         }
     }
 }

--- a/Fluid.Benchmarks/RenderScenarioBenchmarks.cs
+++ b/Fluid.Benchmarks/RenderScenarioBenchmarks.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+
+namespace Fluid.Benchmarks
+{
+    /// <summary>
+    /// Rendering shapes that the product-catalog benchmark doesn't reach: heterogeneous collections,
+    /// deep scope chains, scopes wider than the inline slots, member names that need case conversion,
+    /// and numbers that can't be interned. These are the cases where per-call-site caching and the
+    /// inline scope slots are expected to cost rather than pay, so they belong next to the happy path.
+    /// </summary>
+    [MemoryDiagnoser]
+    public class RenderScenarioBenchmarks
+    {
+        private const int ItemCount = 100;
+
+        private readonly FluidParser _parser = new FluidParser();
+
+        private readonly TemplateOptions _ordinalOptions = new TemplateOptions();
+        private readonly TemplateOptions _camelCaseOptions = new TemplateOptions();
+
+        private readonly IFluidTemplate _polymorphicTemplate;
+        private readonly IFluidTemplate _monomorphicTemplate;
+        private readonly IFluidTemplate _deepScopeTemplate;
+        private readonly IFluidTemplate _nestedLoopTemplate;
+        private readonly IFluidTemplate _wideScopeTemplate;
+        private readonly IFluidTemplate _pascalCaseTemplate;
+        private readonly IFluidTemplate _decimalPriceTemplate;
+
+        private readonly List<object> _mixedItems = new(ItemCount);
+        private readonly List<object> _uniformItems = new(ItemCount);
+        private readonly List<PricedProduct> _pricedProducts = new(ItemCount);
+        private readonly List<int> _outer = new();
+        private readonly List<int> _inner = new();
+
+        public sealed class Alpha { public string Name { get; set; } }
+        public sealed class Beta { public string Name { get; set; } }
+        public sealed class Gamma { public string Name { get; set; } }
+        public sealed class Delta { public string Name { get; set; } }
+
+        public sealed class PricedProduct
+        {
+            public string Name { get; set; }
+            public decimal Price { get; set; }
+        }
+
+        public RenderScenarioBenchmarks()
+        {
+            _camelCaseOptions.ModelNamesComparer = StringComparers.CamelCase;
+
+            for (var i = 0; i < ItemCount; i++)
+            {
+                // Four runtime types in rotation: one call site, many shapes.
+                _mixedItems.Add((i % 4) switch
+                {
+                    0 => new Alpha { Name = "N" + i },
+                    1 => new Beta { Name = "N" + i },
+                    2 => new Gamma { Name = "N" + i },
+                    _ => new Delta { Name = "N" + i },
+                });
+
+                _uniformItems.Add(new Alpha { Name = "N" + i });
+
+                // Prices with a fractional part are never interned, unlike whole-number prices.
+                _pricedProducts.Add(new PricedProduct { Name = "N" + i, Price = 19.99m + i });
+            }
+
+            for (var i = 0; i < 10; i++)
+            {
+                _outer.Add(i);
+                _inner.Add(i);
+            }
+
+            _parser.TryParse("{% for item in items %}{{ item.Name }}{% endfor %}", out _polymorphicTemplate);
+            _parser.TryParse("{% for item in items %}{{ item.Name }}{% endfor %}", out _monomorphicTemplate);
+
+            // Six nested loops, then a read that misses at every level before resolving at the root.
+            _parser.TryParse(
+                "{% for a in outer %}{% for b in outer %}{% for c in outer %}" +
+                "{{ root }}" +
+                "{% endfor %}{% endfor %}{% endfor %}",
+                out _deepScopeTemplate);
+
+            // parentloop puts a third name in the loop scope.
+            _parser.TryParse(
+                "{% for a in outer %}{% for b in inner %}{{ forloop.parentloop.index }}{{ b }}{% endfor %}{% endfor %}",
+                out _nestedLoopTemplate);
+
+            // More names in one scope than the inline slots hold, forcing the dictionary path.
+            _parser.TryParse(
+                "{% assign a1 = 1 %}{% assign a2 = 2 %}{% assign a3 = 3 %}{% assign a4 = 4 %}" +
+                "{% assign a5 = 5 %}{% assign a6 = 6 %}" +
+                "{% for i in outer %}{{ a1 }}{{ a2 }}{{ a3 }}{{ a4 }}{{ a5 }}{{ a6 }}{% endfor %}",
+                out _wideScopeTemplate);
+
+            // PascalCase names under a camel-case comparer: every comparison has to convert.
+            _parser.TryParse("{% for item in Items %}{{ item.Name }}{% endfor %}", out _pascalCaseTemplate);
+
+            _parser.TryParse("{% for p in products %}{{ p.Price }}{% endfor %}", out _decimalPriceTemplate);
+
+            CheckAll();
+        }
+
+        private void CheckAll()
+        {
+            Verify(nameof(PolymorphicMembers), PolymorphicMembers(), "N0");
+            Verify(nameof(MonomorphicMembers), MonomorphicMembers(), "N0");
+            Verify(nameof(DeepScopeChain), DeepScopeChain(), "R");
+            Verify(nameof(NestedLoopsWithParentLoop), NestedLoopsWithParentLoop(), "1");
+            Verify(nameof(WideScope), WideScope(), "123456");
+            Verify(nameof(PascalCaseMemberNames), PascalCaseMemberNames(), "N0");
+            Verify(nameof(NonInternedNumbers), NonInternedNumbers(), "19.99");
+
+            static void Verify(string name, string result, string expected)
+            {
+                if (string.IsNullOrEmpty(result) || !result.Contains(expected))
+                {
+                    throw new InvalidOperationException($"{name} rendering failed: {result}");
+                }
+            }
+        }
+
+        /// <summary>One call site resolving members across four runtime types.</summary>
+        [Benchmark]
+        public string PolymorphicMembers()
+        {
+            var context = new TemplateContext(_ordinalOptions).SetValue("items", _mixedItems);
+            return _polymorphicTemplate.Render(context);
+        }
+
+        /// <summary>The same template over a single runtime type, as the comparison point.</summary>
+        [Benchmark]
+        public string MonomorphicMembers()
+        {
+            var context = new TemplateContext(_ordinalOptions).SetValue("items", _uniformItems);
+            return _monomorphicTemplate.Render(context);
+        }
+
+        /// <summary>A name that misses in every nested loop scope before resolving at the root.</summary>
+        [Benchmark]
+        public string DeepScopeChain()
+        {
+            var context = new TemplateContext(_ordinalOptions)
+                .SetValue("outer", _outer)
+                .SetValue("root", "R");
+            return _deepScopeTemplate.Render(context);
+        }
+
+        /// <summary>Nested loops, so the loop scope also holds parentloop.</summary>
+        [Benchmark]
+        public string NestedLoopsWithParentLoop()
+        {
+            var context = new TemplateContext(_ordinalOptions)
+                .SetValue("outer", _outer)
+                .SetValue("inner", _inner);
+            return _nestedLoopTemplate.Render(context);
+        }
+
+        /// <summary>More names in a scope than the inline slots hold.</summary>
+        [Benchmark]
+        public string WideScope()
+        {
+            var context = new TemplateContext(_ordinalOptions).SetValue("outer", _outer);
+            return _wideScopeTemplate.Render(context);
+        }
+
+        /// <summary>PascalCase names resolved through the camel-case comparer.</summary>
+        [Benchmark]
+        public string PascalCaseMemberNames()
+        {
+            var context = new TemplateContext(_camelCaseOptions).SetValue("Items", _uniformItems);
+            return _pascalCaseTemplate.Render(context);
+        }
+
+        /// <summary>Prices with a fractional part, which the small-integer interning never covers.</summary>
+        [Benchmark]
+        public string NonInternedNumbers()
+        {
+            var context = new TemplateContext(_ordinalOptions).SetValue("products", _pricedProducts);
+            return _decimalPriceTemplate.Render(context);
+        }
+    }
+}

--- a/Fluid.Tests/RenderCacheInvalidationTests.cs
+++ b/Fluid.Tests/RenderCacheInvalidationTests.cs
@@ -1,4 +1,5 @@
 using Fluid.Accessors;
+using Fluid.Ast;
 using Fluid.Values;
 using System;
 using System.Collections.Generic;
@@ -30,6 +31,14 @@ namespace Fluid.Tests
         private sealed class Other
         {
             public string Name { get; set; }
+        }
+
+        private sealed class ThrowingExpression : Expression
+        {
+            public override ValueTask<FluidValue> EvaluateAsync(TemplateContext context)
+            {
+                throw new InvalidOperationException("input");
+            }
         }
 
         [Fact]
@@ -294,6 +303,17 @@ namespace Fluid.Tests
         }
 
         [Fact]
+        public void DeletingANullNameFromAnInitializedScopeThrows()
+        {
+            var scope = new Scope();
+            scope.SetOwnValue("name", StringValue.Empty);
+            scope.DeleteOwn("name");
+
+            Assert.Throws<ArgumentNullException>(() => scope.DeleteOwn(null));
+            Assert.Throws<ArgumentNullException>(() => scope.Delete(null));
+        }
+
+        [Fact]
         public async Task UndefinedFilterUnderStrictFiltersFaultsTheTaskRatherThanThrowingSynchronously()
         {
             // Callers may start a render and await it later; the error has to arrive on the task.
@@ -324,6 +344,24 @@ namespace Fluid.Tests
                 var task = template.RenderAsync(new TemplateContext(options));
                 await Assert.ThrowsAsync<InvalidOperationException>(async () => await task);
             }
+        }
+
+        [Fact]
+        public async Task FilterInputThrowingSynchronouslyFaultsTheTask()
+        {
+            var expression = new FilterExpression(new ThrowingExpression(), "identity", []);
+            var options = new TemplateOptions();
+            options.Filters.AddFilter("identity", (input, args, ctx) => input);
+            var context = new TemplateContext(options);
+
+            // The first evaluation populates the literal-argument cache through the async path.
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await expression.EvaluateAsync(context));
+
+            ValueTask<FluidValue> task = default;
+            var exception = Record.Exception(() => task = expression.EvaluateAsync(context));
+
+            Assert.Null(exception);
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await task);
         }
 
         [Fact]

--- a/Fluid.Tests/RenderCacheInvalidationTests.cs
+++ b/Fluid.Tests/RenderCacheInvalidationTests.cs
@@ -1,0 +1,232 @@
+using Fluid.Accessors;
+using Fluid.Values;
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Fluid.Tests
+{
+    /// <summary>
+    /// Rendering caches member accessors and filter delegates per call site, keyed on the options they
+    /// were resolved from. These tests pin the invalidation: a template parsed once and rendered many
+    /// times must observe registrations made between renders, and must not leak a resolution from one
+    /// set of options into another.
+    /// </summary>
+    public class RenderCacheInvalidationTests
+    {
+#if COMPILED
+        private static readonly FluidParser _parser = new FluidParser().Compile();
+#else
+        private static readonly FluidParser _parser = new FluidParser();
+#endif
+
+        private sealed class Model
+        {
+            public string Name { get; set; }
+        }
+
+        private sealed class Other
+        {
+            public string Name { get; set; }
+        }
+
+        [Fact]
+        public async Task AccessorRegisteredBetweenRendersIsPickedUp()
+        {
+            _parser.TryParse("{{ p.Name }}", out var template, out var error);
+            Assert.Null(error);
+
+            var options = new TemplateOptions();
+            options.MemberAccessStrategy.Register(typeof(Model), "Name", new DelegateAccessor((o, n) => "first"));
+
+            var context = new TemplateContext(options).SetValue("p", new Model { Name = "ignored" });
+            Assert.Equal("first", await template.RenderAsync(context));
+
+            // Re-registering must invalidate whatever the first render cached for this call site.
+            options.MemberAccessStrategy.Register(typeof(Model), "Name", new DelegateAccessor((o, n) => "second"));
+
+            context = new TemplateContext(options).SetValue("p", new Model { Name = "ignored" });
+            Assert.Equal("second", await template.RenderAsync(context));
+        }
+
+        [Fact]
+        public async Task DerivedStrategyOverridingGetAccessorIsNeverCached()
+        {
+            // A subclass may resolve accessors from a source this library can't see, so it must be
+            // consulted on every access rather than have its first answer cached forever.
+            _parser.TryParse("{{ p.Name }}", out var template, out var error);
+            Assert.Null(error);
+
+            var strategy = new ToggleStrategy();
+            var options = new TemplateOptions { MemberAccessStrategy = strategy };
+
+            var context = new TemplateContext(options).SetValue("p", new Model());
+            Assert.Equal("A", await template.RenderAsync(context));
+
+            strategy.Flip = true;
+
+            context = new TemplateContext(options).SetValue("p", new Model());
+            Assert.Equal("B", await template.RenderAsync(context));
+        }
+
+        private sealed class ToggleStrategy : DefaultMemberAccessStrategy
+        {
+            public bool Flip;
+
+            public override IMemberAccessor GetAccessor(Type type, string name, StringComparer stringComparer)
+            {
+                return new DelegateAccessor((o, n) => Flip ? "B" : "A");
+            }
+        }
+
+        [Fact]
+        public async Task SameTemplateAlternatingBetweenOptionsResolvesEachIndependently()
+        {
+            _parser.TryParse("{{ p.Name }}", out var template, out var error);
+            Assert.Null(error);
+
+            var first = new TemplateOptions();
+            first.MemberAccessStrategy.Register(typeof(Model), "Name", new DelegateAccessor((o, n) => "one"));
+
+            var second = new TemplateOptions();
+            second.MemberAccessStrategy.Register(typeof(Model), "Name", new DelegateAccessor((o, n) => "two"));
+
+            for (var i = 0; i < 3; i++)
+            {
+                Assert.Equal("one", await template.RenderAsync(new TemplateContext(first).SetValue("p", new Model())));
+                Assert.Equal("two", await template.RenderAsync(new TemplateContext(second).SetValue("p", new Model())));
+            }
+        }
+
+        [Fact]
+        public async Task SameCallSiteHandlesAlternatingRuntimeTypes()
+        {
+            // One call site seeing a polymorphic collection must re-resolve per type, not reuse the
+            // accessor of whichever type it happened to see first.
+            _parser.TryParse("{% for p in items %}{{ p.Name }};{% endfor %}", out var template, out var error);
+            Assert.Null(error);
+
+            var options = new TemplateOptions();
+            var context = new TemplateContext(options)
+                .SetValue("items", new object[]
+                {
+                    new Model { Name = "m1" },
+                    new Other { Name = "o1" },
+                    new Model { Name = "m2" },
+                    new Other { Name = "o2" },
+                });
+
+            Assert.Equal("m1;o1;m2;o2;", await template.RenderAsync(context));
+        }
+
+        [Fact]
+        public async Task FilterRegisteredBetweenRendersIsPickedUp()
+        {
+            _parser.TryParse("{{ 'x' | mark }}", out var template, out var error);
+            Assert.Null(error);
+
+            var options = new TemplateOptions();
+
+            // Not registered yet: non-strict filters pass the input through.
+            Assert.Equal("x", await template.RenderAsync(new TemplateContext(options)));
+
+            options.Filters.AddFilter("mark", (input, args, ctx) => new StringValue(input.ToStringValue() + "!"));
+            Assert.Equal("x!", await template.RenderAsync(new TemplateContext(options)));
+
+            // Replacing the delegate must also invalidate.
+            options.Filters.AddFilter("mark", (input, args, ctx) => new StringValue(input.ToStringValue() + "?"));
+            Assert.Equal("x?", await template.RenderAsync(new TemplateContext(options)));
+
+            options.Filters.Remove("mark");
+            Assert.Equal("x", await template.RenderAsync(new TemplateContext(options)));
+        }
+
+        [Fact]
+        public async Task StrictFiltersStillThrowsAfterAFilterIsRemoved()
+        {
+            _parser.TryParse("{{ 'x' | mark }}", out var template, out var error);
+            Assert.Null(error);
+
+            var options = new TemplateOptions { StrictFilters = true };
+            options.Filters.AddFilter("mark", (input, args, ctx) => new StringValue("ok"));
+
+            Assert.Equal("ok", await template.RenderAsync(new TemplateContext(options)));
+
+            options.Filters.Remove("mark");
+
+            await Assert.ThrowsAsync<FluidException>(() => template.RenderAsync(new TemplateContext(options)).AsTask());
+        }
+
+        [Fact]
+        public async Task SameTemplateAlternatingBetweenFilterCollections()
+        {
+            _parser.TryParse("{{ 'x' | mark }}", out var template, out var error);
+            Assert.Null(error);
+
+            var first = new TemplateOptions();
+            first.Filters.AddFilter("mark", (input, args, ctx) => new StringValue("one"));
+
+            var second = new TemplateOptions();
+            second.Filters.AddFilter("mark", (input, args, ctx) => new StringValue("two"));
+
+            for (var i = 0; i < 3; i++)
+            {
+                Assert.Equal("one", await template.RenderAsync(new TemplateContext(first)));
+                Assert.Equal("two", await template.RenderAsync(new TemplateContext(second)));
+            }
+        }
+
+        [Theory]
+        [InlineData("ar-SA")]
+        [InlineData("fa-IR")]
+        [InlineData("hi-IN")]
+        [InlineData("de-DE")]
+        public async Task InternedNumbersRenderIdenticallyAcrossCultures(string culture)
+        {
+            // Small non-negative integers render from precomputed text instead of formatting the
+            // decimal, which is only sound if that text is what every culture would have produced.
+            // 1023 is the last interned value and 1024 the first non-interned one, so they must agree.
+            _parser.TryParse("{{ a }}|{{ b }}|{{ c }}", out var template, out var error);
+            Assert.Null(error);
+
+            var cultureInfo = CultureInfo.GetCultureInfo(culture);
+            var options = new TemplateOptions { CultureInfo = cultureInfo };
+            var context = new TemplateContext(options)
+                .SetValue("a", NumberValue.Create(0m))
+                .SetValue("b", NumberValue.Create(1023m))
+                .SetValue("c", NumberValue.Create(1024m));
+
+            Assert.Equal("0|1023|1024", await template.RenderAsync(context));
+        }
+
+        [Theory]
+        [InlineData("ar-SA")]
+        [InlineData("fa-IR")]
+        [InlineData("de-DE")]
+        public async Task NegativeNumbersStillFormatPerCulture(string culture)
+        {
+            // Interning only covers non-negative whole numbers, so negatives must keep going through
+            // culture-aware formatting (Arabic locales use their own minus sign and direction marks).
+            _parser.TryParse("{{ a }}", out var template, out var error);
+            Assert.Null(error);
+
+            var cultureInfo = CultureInfo.GetCultureInfo(culture);
+            var options = new TemplateOptions { CultureInfo = cultureInfo };
+            var context = new TemplateContext(options).SetValue("a", NumberValue.Create(-1m));
+
+            Assert.Equal((-1m).ToString(cultureInfo), await template.RenderAsync(context));
+        }
+
+        [Fact]
+        public void InterningPreservesDecimalScale()
+        {
+            // Liquid keeps the scale of a number as part of its identity (1.0 * 2.0 == 2.00), so a
+            // scaled value must never be replaced by an interned whole number.
+            Assert.Equal("5", NumberValue.Create(5m).ToStringValue());
+            Assert.Equal("5.0", NumberValue.Create(5.0m).ToStringValue());
+            Assert.Equal("0.0", NumberValue.Create(0.0m).ToStringValue());
+            Assert.Equal("1023.00", NumberValue.Create(1023.00m).ToStringValue());
+        }
+    }
+}

--- a/Fluid.Tests/RenderCacheInvalidationTests.cs
+++ b/Fluid.Tests/RenderCacheInvalidationTests.cs
@@ -1,6 +1,7 @@
 using Fluid.Accessors;
 using Fluid.Values;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
 using Xunit;
@@ -68,15 +69,27 @@ namespace Fluid.Tests
 
             context = new TemplateContext(options).SetValue("p", new Model());
             Assert.Equal("B", await template.RenderAsync(context));
+
+            // The strategy must be consulted afresh for each render rather than answered from a cache.
+            Assert.Equal(2, strategy.GetAccessorCalls);
         }
 
         private sealed class ToggleStrategy : DefaultMemberAccessStrategy
         {
             public bool Flip;
 
+            public int GetAccessorCalls;
+
             public override IMemberAccessor GetAccessor(Type type, string name, StringComparer stringComparer)
             {
-                return new DelegateAccessor((o, n) => Flip ? "B" : "A");
+                GetAccessorCalls++;
+
+                // The two accessors must be distinct instances that capture the answer at resolution
+                // time. A single accessor reading a mutable field would return the new value even when
+                // the accessor itself was cached, so the test would pass with the opt-out removed.
+                return Flip
+                    ? new DelegateAccessor((o, n) => "B")
+                    : new DelegateAccessor((o, n) => "A");
             }
         }
 
@@ -216,6 +229,101 @@ namespace Fluid.Tests
             var context = new TemplateContext(options).SetValue("a", NumberValue.Create(-1m));
 
             Assert.Equal((-1m).ToString(cultureInfo), await template.RenderAsync(context));
+        }
+
+        [Fact]
+        public async Task AlternatingOptionsStopsAllocatingCacheEntries()
+        {
+            // A template rendered against two sets of options misses its per-call-site caches every
+            // time. Rather than allocate a replacement entry per access forever, both caches give up
+            // and fall back to resolving directly -- so a long run must not keep growing the heap.
+            _parser.TryParse("{% for p in items %}{{ p.Name }}{{ 'x' | mark }};{% endfor %}", out var template, out var error);
+            Assert.Null(error);
+
+            var first = new TemplateOptions();
+            first.Filters.AddFilter("mark", (input, args, ctx) => new StringValue("1"));
+
+            var second = new TemplateOptions();
+            second.Filters.AddFilter("mark", (input, args, ctx) => new StringValue("2"));
+
+            var items = new List<Model>();
+            for (var i = 0; i < 50; i++)
+            {
+                items.Add(new Model { Name = "n" });
+            }
+
+            async Task RenderBoth()
+            {
+                await template.RenderAsync(new TemplateContext(first).SetValue("items", items));
+                await template.RenderAsync(new TemplateContext(second).SetValue("items", items));
+            }
+
+            // Warm up past the give-up threshold, then measure.
+            for (var i = 0; i < 20; i++)
+            {
+                await RenderBoth();
+            }
+
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            for (var i = 0; i < 20; i++)
+            {
+                await RenderBoth();
+            }
+            var settled = GC.GetAllocatedBytesForCurrentThread() - before;
+
+            before = GC.GetAllocatedBytesForCurrentThread();
+            for (var i = 0; i < 40; i++)
+            {
+                await RenderBoth();
+            }
+            var doubled = GC.GetAllocatedBytesForCurrentThread() - before;
+
+            // Allocation should track the render count, not grow per access from cache churn.
+            Assert.InRange((double)doubled / settled, 1.5, 2.5);
+        }
+
+        [Fact]
+        public void SettingANullNameThrowsAtTheOffendingCall()
+        {
+            // The dictionary this replaced rejected a null key; losing that deferred the failure to an
+            // unrelated later call.
+            var scope = new Scope();
+
+            Assert.Throws<ArgumentNullException>(() => scope.SetOwnValue(null, StringValue.Empty));
+            Assert.Throws<ArgumentNullException>(() => scope.SetValue(null, StringValue.Empty));
+        }
+
+        [Fact]
+        public async Task UndefinedFilterUnderStrictFiltersFaultsTheTaskRatherThanThrowingSynchronously()
+        {
+            // Callers may start a render and await it later; the error has to arrive on the task.
+            _parser.TryParse("{{ 'x' | nope }}", out var template, out var error);
+            Assert.Null(error);
+
+            var options = new TemplateOptions { StrictFilters = true };
+
+            // Second evaluation takes the cached fast path, which is where the throw would escape.
+            for (var i = 0; i < 2; i++)
+            {
+                var task = template.RenderAsync(new TemplateContext(options));
+                await Assert.ThrowsAsync<FluidException>(async () => await task);
+            }
+        }
+
+        [Fact]
+        public async Task FilterThrowingSynchronouslyFaultsTheTask()
+        {
+            _parser.TryParse("{{ 'x' | boom }}", out var template, out var error);
+            Assert.Null(error);
+
+            var options = new TemplateOptions();
+            options.Filters.AddFilter("boom", (input, args, ctx) => throw new InvalidOperationException("boom"));
+
+            for (var i = 0; i < 2; i++)
+            {
+                var task = template.RenderAsync(new TemplateContext(options));
+                await Assert.ThrowsAsync<InvalidOperationException>(async () => await task);
+            }
         }
 
         [Fact]

--- a/Fluid/Ast/FilterExpression.cs
+++ b/Fluid/Ast/FilterExpression.cs
@@ -19,35 +19,90 @@ namespace Fluid.Ast
         private volatile bool _canBeCached = true;
         private volatile FilterArguments _cachedArguments;
 
-        public override async ValueTask<FluidValue> EvaluateAsync(TemplateContext context)
+        // Monomorphic inline cache of the resolved filter. Filters are looked up by name in a dictionary
+        // shared by every call site, so a template that invokes the same filter in a loop pays for the
+        // string hashing once instead of once per iteration. The cache is invalidated when the collection
+        // instance or its version changes, so filters registered after the first render are still picked up.
+        private sealed class FilterCacheEntry
         {
-            FilterArguments arguments;
+            public FilterCollection Collection;
+            public int Version;
+            public FilterDelegate Filter;
+        }
 
-            // The arguments can be cached if all the parameters are LiteralExpression
-            if (_cachedArguments == null)
+        private volatile FilterCacheEntry _filterCache;
+
+        public override ValueTask<FluidValue> EvaluateAsync(TemplateContext context)
+        {
+            var arguments = _cachedArguments;
+
+            if (arguments is null)
             {
-                arguments = new FilterArguments();
-
-                foreach (var parameter in Parameters)
-                {
-                    _canBeCached = _canBeCached && parameter.Expression is LiteralExpression;
-                    arguments.Add(parameter.Name, await parameter.Expression.EvaluateAsync(context));
-                }
-
-                // Can we cache it?
-                if (_canBeCached)
-                {
-                    _cachedArguments = arguments;
-                }
+                // First evaluation, or arguments that can't be cached because they aren't all literals.
+                return EvaluateWithArgumentsAsync(context);
             }
-            else
+
+            var inputTask = Input.EvaluateAsync(context);
+
+            if (!inputTask.IsCompletedSuccessfully)
             {
-                arguments = _cachedArguments;
+                return AwaitedInput(inputTask, arguments, context);
+            }
+
+            // Nothing was awaited: invoke the filter directly and forward its ValueTask, so a synchronous
+            // filter (the vast majority) doesn't allocate an async state machine.
+            return InvokeFilter(inputTask.Result, arguments, context);
+        }
+
+        private async ValueTask<FluidValue> EvaluateWithArgumentsAsync(TemplateContext context)
+        {
+            // The arguments can be cached if all the parameters are LiteralExpression
+            var arguments = new FilterArguments();
+
+            foreach (var parameter in Parameters)
+            {
+                _canBeCached = _canBeCached && parameter.Expression is LiteralExpression;
+                arguments.Add(parameter.Name, await parameter.Expression.EvaluateAsync(context));
+            }
+
+            // Can we cache it?
+            if (_canBeCached)
+            {
+                _cachedArguments = arguments;
             }
 
             var input = await Input.EvaluateAsync(context);
 
-            if (!context.Options.Filters.TryGetValue(Name, out var filter))
+            return await InvokeFilter(input, arguments, context);
+        }
+
+        private async ValueTask<FluidValue> AwaitedInput(ValueTask<FluidValue> inputTask, FilterArguments arguments, TemplateContext context)
+        {
+            var input = await inputTask;
+            return await InvokeFilter(input, arguments, context);
+        }
+
+        private ValueTask<FluidValue> InvokeFilter(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            var filters = context.Options.Filters;
+            var cache = _filterCache;
+
+            FilterDelegate filter;
+
+            if (cache is not null && ReferenceEquals(cache.Collection, filters) && cache.Version == filters.Version)
+            {
+                filter = cache.Filter;
+            }
+            else
+            {
+                // Read the version before the lookup so a concurrent mutation invalidates the entry
+                // on the next evaluation instead of being silently baked in.
+                var version = filters.Version;
+                filters.TryGetValue(Name, out filter);
+                _filterCache = new FilterCacheEntry { Collection = filters, Version = version, Filter = filter };
+            }
+
+            if (filter is null)
             {
                 // When a filter is not defined, return the input unless strict filters are enabled
                 if (context.Options.StrictFilters)
@@ -55,10 +110,10 @@ namespace Fluid.Ast
                     throw new FluidException($"Undefined filter '{Name}'");
                 }
 
-                return input;
+                return new ValueTask<FluidValue>(input);
             }
 
-            return await filter(input, arguments, context);
+            return filter(input, arguments, context);
         }
 
         protected internal override Expression Accept(AstVisitor visitor) => visitor.VisitFilterExpression(this);

--- a/Fluid/Ast/FilterExpression.cs
+++ b/Fluid/Ast/FilterExpression.cs
@@ -25,10 +25,23 @@ namespace Fluid.Ast
         // instance or its version changes, so filters registered after the first render are still picked up.
         private sealed class FilterCacheEntry
         {
+            /// <summary>
+            /// Marks a call site that misses too often to be worth caching -- typically one template
+            /// rendered against several sets of options. Without it such a site would allocate a
+            /// replacement entry on every filter invocation.
+            /// </summary>
+            public static readonly FilterCacheEntry Disabled = new();
+
             public FilterCollection Collection;
             public int Version;
             public FilterDelegate Filter;
+            public int Misses;
         }
+
+        /// <summary>
+        /// How many times a call site may re-resolve its filter before it stops caching.
+        /// </summary>
+        private const int MaxMisses = 4;
 
         private volatile FilterCacheEntry _filterCache;
 
@@ -89,7 +102,11 @@ namespace Fluid.Ast
 
             FilterDelegate filter;
 
-            if (cache is not null && ReferenceEquals(cache.Collection, filters) && cache.Version == filters.Version)
+            if (ReferenceEquals(cache, FilterCacheEntry.Disabled))
+            {
+                filters.TryGetValue(Name, out filter);
+            }
+            else if (cache is not null && ReferenceEquals(cache.Collection, filters) && cache.Version == filters.Version)
             {
                 filter = cache.Filter;
             }
@@ -99,7 +116,12 @@ namespace Fluid.Ast
                 // on the next evaluation instead of being silently baked in.
                 var version = filters.Version;
                 filters.TryGetValue(Name, out filter);
-                _filterCache = new FilterCacheEntry { Collection = filters, Version = version, Filter = filter };
+
+                var misses = (cache?.Misses ?? 0) + 1;
+
+                _filterCache = misses > MaxMisses
+                    ? FilterCacheEntry.Disabled
+                    : new FilterCacheEntry { Collection = filters, Version = version, Filter = filter, Misses = misses };
             }
 
             if (filter is null)
@@ -107,13 +129,28 @@ namespace Fluid.Ast
                 // When a filter is not defined, return the input unless strict filters are enabled
                 if (context.Options.StrictFilters)
                 {
-                    throw new FluidException($"Undefined filter '{Name}'");
+                    // Faulted rather than thrown: this method is no longer async, and callers that start
+                    // a render and await it later would otherwise see the throw escape at the call site.
+                    return Faulted(new FluidException($"Undefined filter '{Name}'"));
                 }
 
                 return new ValueTask<FluidValue>(input);
             }
 
-            return filter(input, arguments, context);
+            try
+            {
+                return filter(input, arguments, context);
+            }
+            catch (Exception e)
+            {
+                // Same reason: a filter that throws before its first await used to fault the task.
+                return Faulted(e);
+            }
+        }
+
+        private static ValueTask<FluidValue> Faulted(Exception exception)
+        {
+            return new ValueTask<FluidValue>(Task.FromException<FluidValue>(exception));
         }
 
         protected internal override Expression Accept(AstVisitor visitor) => visitor.VisitFilterExpression(this);

--- a/Fluid/Ast/FilterExpression.cs
+++ b/Fluid/Ast/FilterExpression.cs
@@ -55,7 +55,17 @@ namespace Fluid.Ast
                 return EvaluateWithArgumentsAsync(context);
             }
 
-            var inputTask = Input.EvaluateAsync(context);
+            ValueTask<FluidValue> inputTask;
+
+            try
+            {
+                inputTask = Input.EvaluateAsync(context);
+            }
+            catch (Exception e)
+            {
+                // EvaluateAsync used to be async, so even a synchronous input failure faulted its task.
+                return Faulted(e);
+            }
 
             if (!inputTask.IsCompletedSuccessfully)
             {

--- a/Fluid/Ast/ForStatement.cs
+++ b/Fluid/Ast/ForStatement.cs
@@ -1,5 +1,6 @@
 ﻿using Fluid.Values;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text.Encodings.Web;
 
 namespace Fluid.Ast
@@ -7,6 +8,15 @@ namespace Fluid.Ast
     public sealed class ForStatement : TagStatement
     {
         private readonly string _continueSourceLiteral;
+
+        // Precomputed for every source shape but a range. Both `forloop.name` and the `offset: continue`
+        // key are then constant for the lifetime of the statement, so they don't need to be rebuilt
+        // (with LINQ and string.Join) on every execution of the loop.
+        private readonly string _staticContinueOffsetLiteral;
+
+        // Statements never change after construction, and PrepareBuffer can only shrink a TextSpanStatement
+        // by trimming whitespace, so a whitespace-only body stays whitespace-only.
+        private readonly bool _suppressWhitespaceBody;
 
         public ForStatement(
             IReadOnlyList<Statement> statements,
@@ -29,6 +39,18 @@ namespace Fluid.Ast
             _continueSourceLiteral = source is MemberExpression m
                 ? string.Join(".", m.Segments.Select(s => (s as IdentifierSegment)?.Identifier).Where(s => s != null))
                 : null;
+
+            if (!string.IsNullOrEmpty(_continueSourceLiteral))
+            {
+                _staticContinueOffsetLiteral = $"for_continue_{Identifier}-{_continueSourceLiteral}";
+            }
+            else if (source is not RangeExpression)
+            {
+                // Fallback: stable within the current render (statement instance).
+                _staticContinueOffsetLiteral = $"for_continue_{Identifier}-stmt_" + RuntimeHelpers.GetHashCode(this).ToString(CultureInfo.InvariantCulture);
+            }
+
+            _suppressWhitespaceBody = Statements.Count == 1 && Statements[0] is TextSpanStatement t && t.IsWhitespaceOrCommentOnly;
         }
 
         public string Identifier { get; }
@@ -47,7 +69,7 @@ namespace Fluid.Ast
             // The `offset: continue` feature uses a per-source key to store the absolute index
             // of the next item to render. In Liquid, this state is updated by every `for` loop
             // over the same source, even if the loop itself doesn't specify `offset: continue`.
-            var continueOffsetLiteral = await BuildContinueOffsetLiteralAsync(context);
+            var continueOffsetLiteral = _staticContinueOffsetLiteral ?? await BuildRangeContinueOffsetLiteralAsync((RangeExpression)Source, context);
 
             // Golden Liquid: empty strings are treated as empty collections
             if (evaluatedSource.Type == FluidValues.String && string.IsNullOrEmpty(evaluatedSource.ToStringValue()))
@@ -65,14 +87,6 @@ namespace Fluid.Ast
             IReadOnlyList<FluidValue> source = evaluatedSource is ArrayValue array
                 ? array.Values
                 : await evaluatedSource.EnumerateAsync(context).ToListAsync();
-
-            var suppressWhitespaceBody = Statements.Count == 1
-                && Statements[0] is TextSpanStatement t
-#if NET6_0_OR_GREATER
-                && t.Text.Span.IsWhiteSpace();
-#else
-                && string.IsNullOrWhiteSpace(t.Text.ToString());
-#endif
 
             if (source.Count == 0)
             {
@@ -138,8 +152,8 @@ namespace Fluid.Ast
                 var forloop = new ForLoopValue
                 {
                     Identifier = Identifier,
-                    Source = Source is MemberExpression m
-                        ? string.Join(".", m.Segments.Select(s => (s as IdentifierSegment)?.Identifier).Where(s => s != null))
+                    Source = _continueSourceLiteral is not null
+                        ? _continueSourceLiteral
                         : Source is RangeExpression r
                             ? $"({Convert.ToInt32((await r.From.EvaluateAsync(context)).ToNumberValue())}..{Convert.ToInt32((await r.To.EvaluateAsync(context)).ToNumberValue())})"
                             : null
@@ -179,7 +193,7 @@ namespace Fluid.Ast
 
                     var completion = Completion.Normal;
 
-                    if (!suppressWhitespaceBody)
+                    if (!_suppressWhitespaceBody)
                     {
                         for (var index = 0; index < Statements.Count; index++)
                         {
@@ -225,30 +239,17 @@ namespace Fluid.Ast
             return Completion.Normal;
         }
 
-        private async ValueTask<string> BuildContinueOffsetLiteralAsync(TemplateContext context)
+        /// <summary>
+        /// Builds the key holding the `offset: continue` cursor for a range source, the only shape whose
+        /// `forloop.name` isn't known until the loop runs. Every other shape is precomputed in the constructor.
+        /// </summary>
+        private async ValueTask<string> BuildRangeContinueOffsetLiteralAsync(RangeExpression r, TemplateContext context)
         {
             // Key is based on Liquid's `forloop.name`: "{identifier}-{source}".
             // This means changing the loop variable changes the key.
-
-            string source;
-
-            if (!string.IsNullOrEmpty(_continueSourceLiteral))
-            {
-                source = _continueSourceLiteral;
-            }
-            else if (Source is RangeExpression r)
-            {
-                var from = Convert.ToInt32((await r.From.EvaluateAsync(context)).ToNumberValue());
-                var to = Convert.ToInt32((await r.To.EvaluateAsync(context)).ToNumberValue());
-                source = $"({from}..{to})";
-            }
-            else
-            {
-                // Fallback: stable within the current render (statement instance).
-                source = "stmt_" + System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(this).ToString(CultureInfo.InvariantCulture);
-            }
-
-            return $"for_continue_{Identifier}-{source}";
+            var from = Convert.ToInt32((await r.From.EvaluateAsync(context)).ToNumberValue());
+            var to = Convert.ToInt32((await r.To.EvaluateAsync(context)).ToNumberValue());
+            return $"for_continue_{Identifier}-({from}..{to})";
         }
 
         private static async ValueTask<int> EvaluateIntegerArgumentAsync(string name, Expression expression, TemplateContext context)

--- a/Fluid/Ast/IdentifierSegment.cs
+++ b/Fluid/Ast/IdentifierSegment.cs
@@ -6,15 +6,38 @@ namespace Fluid.Ast
     [DebuggerDisplay("{Identifier,nq}")]
     public sealed class IdentifierSegment : MemberSegment
     {
+        // The parser never produces a dotted identifier -- `a.b` becomes two segments -- but a segment
+        // built directly by user code can be dotted, and then resolution has to walk the parts.
+        private readonly bool _identifierHasDot;
+
+        // Only needed when the identifier isn't found in scope, which is the uncommon case, so it is
+        // built on demand rather than for every segment of every parsed template.
+        private string _incrementIdentifier;
+
+        // Per-call-site accessor cache. A given `a.b` in a template overwhelmingly resolves against the
+        // same runtime type on every evaluation, so remembering the last resolution turns the member
+        // lookup into a few reference comparisons instead of a dictionary probe with string hashing.
+        // Entries are immutable and published by a single reference assignment, so a racing reader
+        // either sees the previous entry or a fully initialized new one.
+        private ObjectValueBase.AccessorCacheEntry _accessorCache;
+
         public IdentifierSegment(string identifier)
         {
             Identifier = identifier;
+            _identifierHasDot = identifier is not null && identifier.Contains('.');
         }
 
         public string Identifier { get; }
 
         public override ValueTask<FluidValue> ResolveAsync(FluidValue value, TemplateContext context)
         {
+            // ObjectValue is sealed and doesn't override GetValueAsync, so the cached path is
+            // observationally identical. Any other value type goes through the virtual member.
+            if (value is ObjectValue objectValue)
+            {
+                return objectValue.GetValueAsync(Identifier, context, _identifierHasDot, ref _accessorCache);
+            }
+
             return value.GetValueAsync(Identifier, context);
         }
 
@@ -26,7 +49,7 @@ namespace Fluid.Ast
             if (value.IsNil())
             {
                 // Check if there's an increment/decrement counter with this name
-                var incDecValue = context.LocalScope.GetValue(IncrementStatement.Prefix + Identifier);
+                var incDecValue = context.LocalScope.GetValue(_incrementIdentifier ??= IncrementStatement.Prefix + Identifier);
                 if (!incDecValue.IsNil())
                 {
                     return new ValueTask<(FluidValue, bool)>((incDecValue, false));

--- a/Fluid/DefaultMemberAccessStrategy.cs
+++ b/Fluid/DefaultMemberAccessStrategy.cs
@@ -10,11 +10,13 @@ namespace Fluid
 
         private static readonly bool _dynamicCodeSupported = IsDynamicCodeSupported();
 
-        // Volatile so that reading it as the cache token is an acquire, which keeps the map read that
-        // follows in GetAccessor from being reordered before it. Without that, a call site could pair a
-        // token from after a registration with an accessor resolved from the map before it, and then
-        // never re-resolve.
         private volatile Dictionary<AccessorKey, IMemberAccessor> _map = [];
+
+        // A standalone token rather than the map itself. Using the map would mean every cached accessor
+        // pinned the superseded copy it was resolved against, and would churn on every cold resolution,
+        // because GetAccessor registers what it resolves. Volatile so reading it is an acquire, keeping
+        // the map read that follows from being reordered before it.
+        private volatile object _accessorCacheToken = new();
 
         // Only the exact type opts in. A derived strategy may override GetAccessor to resolve from its
         // own source, which this map -- and therefore the token -- would not reflect; it would then serve
@@ -26,18 +28,16 @@ namespace Fluid
             _accessorCachingSupported = GetType() == typeof(DefaultMemberAccessStrategy);
         }
 
-        /// <summary>
-        /// The map itself is the token: <see cref="Register"/> replaces it with a new instance on every
-        /// mutation, so it invalidates cached accessors without a separate version counter to maintain.
-        /// </summary>
-        protected internal override object AccessorCacheToken => _accessorCachingSupported ? _map : null;
+        protected internal override object AccessorCacheToken => _accessorCachingSupported ? _accessorCacheToken : null;
 
         public override IMemberAccessor GetAccessor(Type type, string name, StringComparer stringComparer)
         {
             if (!TryGetAccessor(type, name, stringComparer, out var accessor))
             {
-                Register(type, name, accessor = GetMemberAccessor(type, name, stringComparer) ?? GetAccessorUnlikely(type, name, stringComparer));
-            }            
+                // Memoize what was resolved, but without invalidating cached accessors: this only fills
+                // in a pair that had no entry, so it cannot change what any other pair resolves to.
+                AddToMap(type, name, accessor = GetMemberAccessor(type, name, stringComparer) ?? GetAccessorUnlikely(type, name, stringComparer));
+            }
 
             return accessor;
         }
@@ -175,11 +175,17 @@ namespace Fluid
 
         public override void Register(Type type, string name, IMemberAccessor accessor)
         {
+            AddToMap(type, name, accessor);
+
+            // A registration can replace what an already-resolved pair maps to, so retire the token and
+            // make every call site re-resolve.
+            _accessorCacheToken = new object();
+        }
+
+        private void AddToMap(Type type, string name, IMemberAccessor accessor)
+        {
             var map = new Dictionary<AccessorKey, IMemberAccessor>(_map);
             map[new AccessorKey(type, name)] = accessor;
-
-            // Publishing the new map also invalidates every accessor cached by a call site, since the
-            // map doubles as the cache token.
             _map = map;
         }
     }

--- a/Fluid/DefaultMemberAccessStrategy.cs
+++ b/Fluid/DefaultMemberAccessStrategy.cs
@@ -10,7 +10,27 @@ namespace Fluid
 
         private static readonly bool _dynamicCodeSupported = IsDynamicCodeSupported();
 
-        private Dictionary<AccessorKey, IMemberAccessor> _map = [];
+        // Volatile so that reading it as the cache token is an acquire, which keeps the map read that
+        // follows in GetAccessor from being reordered before it. Without that, a call site could pair a
+        // token from after a registration with an accessor resolved from the map before it, and then
+        // never re-resolve.
+        private volatile Dictionary<AccessorKey, IMemberAccessor> _map = [];
+
+        // Only the exact type opts in. A derived strategy may override GetAccessor to resolve from its
+        // own source, which this map -- and therefore the token -- would not reflect; it would then serve
+        // a stale accessor forever. Subclasses give up the caching, not correctness.
+        private readonly bool _accessorCachingSupported;
+
+        public DefaultMemberAccessStrategy()
+        {
+            _accessorCachingSupported = GetType() == typeof(DefaultMemberAccessStrategy);
+        }
+
+        /// <summary>
+        /// The map itself is the token: <see cref="Register"/> replaces it with a new instance on every
+        /// mutation, so it invalidates cached accessors without a separate version counter to maintain.
+        /// </summary>
+        protected internal override object AccessorCacheToken => _accessorCachingSupported ? _map : null;
 
         public override IMemberAccessor GetAccessor(Type type, string name, StringComparer stringComparer)
         {
@@ -157,6 +177,9 @@ namespace Fluid
         {
             var map = new Dictionary<AccessorKey, IMemberAccessor>(_map);
             map[new AccessorKey(type, name)] = accessor;
+
+            // Publishing the new map also invalidates every accessor cached by a call site, since the
+            // map doubles as the cache token.
             _map = map;
         }
     }

--- a/Fluid/FiltersCollection.cs
+++ b/Fluid/FiltersCollection.cs
@@ -14,6 +14,21 @@ namespace Fluid
             }
         }
 
+        private int _version;
+
+        /// <summary>
+        /// Changes whenever the content of the collection changes, so that call sites can cache a
+        /// resolved <see cref="FilterDelegate"/> and detect when the cached value became stale.
+        /// </summary>
+        /// <remarks>
+        /// Read as an acquire so the dictionary probe that follows can't be reordered ahead of it, and
+        /// incremented atomically so a preempted writer can't roll the counter back onto a value a call
+        /// site has already cached. Note this only orders the version itself: mutating the collection
+        /// while templates render concurrently is still unsupported, because the backing dictionary is
+        /// not thread-safe.
+        /// </remarks>
+        internal int Version => Volatile.Read(ref _version);
+
         public int Count => _filters == null ? 0 : _filters.Count;
 
         public void AddFilter(string name, FilterDelegate d)
@@ -21,6 +36,7 @@ namespace Fluid
             _filters ??= new Dictionary<string, FilterDelegate>();
 
             _filters[name] = d;
+            Interlocked.Increment(ref _version);
         }
 
         public bool TryGetValue(string name, out FilterDelegate filter)
@@ -35,6 +51,7 @@ namespace Fluid
             if (_filters != null)
             {
                 _filters.Remove(name);
+                Interlocked.Increment(ref _version);
             }
         }
 
@@ -43,6 +60,7 @@ namespace Fluid
             if (_filters != null)
             {
                 _filters.Clear();
+                Interlocked.Increment(ref _version);
             }
         }
 

--- a/Fluid/MemberAccessStrategy.cs
+++ b/Fluid/MemberAccessStrategy.cs
@@ -5,5 +5,30 @@ namespace Fluid
         public abstract IMemberAccessor GetAccessor(Type type, string name, StringComparer stringComparer);
 
         public abstract void Register(Type type, string name, IMemberAccessor accessor);
+
+        /// <summary>
+        /// Gets a token identifying the current set of accessors this strategy would return, or
+        /// <c>null</c> to disable caching. Call sites may remember the <see cref="IMemberAccessor"/>
+        /// resolved for a type and name, and re-resolve it only once this token changes.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Defaults to <c>null</c>, so a custom strategy is consulted on every member access and never
+        /// serves a stale accessor.
+        /// </para>
+        /// <para>
+        /// An implementation that opts in must return a token that is not equal (by reference) to any
+        /// previous token whenever the accessor it would return for <em>any</em> type and name changes,
+        /// including changes originating from a source other than <see cref="Register"/>. Returning a
+        /// token that fails to change leaves call sites bound to a superseded accessor indefinitely,
+        /// with no error. The simplest correct implementation is to return the immutable map the
+        /// accessors are resolved from, replacing it on every mutation.
+        /// </para>
+        /// <para>
+        /// The token must be published such that it is visible to threads that render templates
+        /// concurrently; assigning a freshly built map to a field satisfies this.
+        /// </para>
+        /// </remarks>
+        protected internal virtual object AccessorCacheToken => null;
     }
 }

--- a/Fluid/MemberNameStrategies.cs
+++ b/Fluid/MemberNameStrategies.cs
@@ -19,6 +19,29 @@ namespace Fluid
 
         public override bool Equals(string x, string y)
         {
+            // Converting a name allocates whenever it isn't already camel-cased, and two names that are
+            // ordinally equal always convert to the same result, so settle those without converting.
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (x is null || y is null)
+            {
+                return false;
+            }
+
+            if (string.Equals(x, y, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            // Camel-casing never changes the length of a name.
+            if (x.Length != y.Length)
+            {
+                return false;
+            }
+
             var cx = JsonNamingPolicy.CamelCase.ConvertName(x);
             var cy = JsonNamingPolicy.CamelCase.ConvertName(y);
             return string.Equals(cx, cy, StringComparison.Ordinal);
@@ -41,6 +64,23 @@ namespace Fluid
 
         public override bool Equals(string x, string y)
         {
+            // Two ordinally equal names always convert to the same result, so skip the conversion,
+            // which allocates.
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (x is null || y is null)
+            {
+                return false;
+            }
+
+            if (string.Equals(x, y, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
             var cx = JsonNamingPolicy.SnakeCaseLower.ConvertName(x);
             var cy = JsonNamingPolicy.SnakeCaseLower.ConvertName(y);
             return string.Equals(cx, cy, StringComparison.Ordinal);

--- a/Fluid/Scope.cs
+++ b/Fluid/Scope.cs
@@ -5,7 +5,31 @@ namespace Fluid
 {
     public sealed class Scope
     {
+        // Most scopes created while rendering hold only a handful of names: a for loop scope holds the
+        // loop variable, `forloop` and optionally `parentloop`. Keeping those in inline slots avoids
+        // allocating a Dictionary per scope, and replaces hashing the name on every read with a short
+        // scan that usually resolves on the first reference comparison, because the name comes from the
+        // same AST node every time. The Dictionary is only materialized once the slots overflow.
+        // Three, because that is what the motivating case holds: the loop variable, `forloop`, and
+        // `parentloop` when loops nest. Slots only cost on a miss -- every occupied one is a comparison
+        // before falling through to the parent -- so there is no reason to carry more than that.
+        private const int InlineCapacity = 3;
+
+        private string _name0, _name1, _name2;
+        private FluidValue _value0, _value1, _value2;
+        private int _inlineCount;
+
         private Dictionary<string, FluidValue> _properties;
+
+        // The comparer this scope's storage uses, or null while the scope is still empty. Mirrors the
+        // previous behaviour of creating the dictionary with the parent's comparer when it has one.
+        private StringComparer _storageComparer;
+
+        // Ordinal is the default for every scope whose chain never reaches a custom ModelNamesComparer.
+        // Calling string.Equals directly for it keeps the slot scan free of a virtual call, which matters
+        // most on a miss, where every occupied slot is compared before moving to the parent scope.
+        private bool _storageComparerIsOrdinal;
+
         private readonly bool _forLoopScope;
         private readonly StringComparer _stringComparer;
 
@@ -34,7 +58,35 @@ namespace Fluid
         /// <summary>
         /// Gets the own properties of the scope
         /// </summary>
-        public IEnumerable<string> Properties => _properties == null ? Array.Empty<string>() : _properties.Keys;
+        /// <remarks>
+        /// A snapshot, so that enumerating it behaves the same whether the scope is small enough to use
+        /// the inline slots or has spilled into a dictionary.
+        /// </remarks>
+        public IEnumerable<string> Properties
+        {
+            get
+            {
+                if (_properties != null)
+                {
+                    var keys = new string[_properties.Count];
+                    _properties.Keys.CopyTo(keys, 0);
+                    return keys;
+                }
+
+                if (_inlineCount == 0)
+                {
+                    return Array.Empty<string>();
+                }
+
+                var names = new string[_inlineCount];
+                for (var i = 0; i < names.Length; i++)
+                {
+                    names[i] = GetInlineName(i);
+                }
+
+                return names;
+            }
+        }
 
         /// <summary>
         /// Gets the parent scope if any.
@@ -46,19 +98,48 @@ namespace Fluid
         /// if it doesn't exist.
         /// </summary>
         /// <param name="name">The name of the value to return.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public FluidValue GetValue(string name)
         {
             ArgumentNullException.ThrowIfNull(name);
-    
-            if (_properties != null && _properties.TryGetValue(name, out var result))
+
+            var scope = this;
+
+            do
             {
-                return result;
+                if (scope.TryGetOwnValue(name, out var result))
+                {
+                    return result;
+                }
+
+                scope = scope.Parent;
+            }
+            while (scope != null);
+
+            return UndefinedValue.Instance;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool TryGetOwnValue(string name, out FluidValue value)
+        {
+            var count = _inlineCount;
+
+            if (count != 0)
+            {
+                if (NameEquals(name, _name0)) { value = _value0; return true; }
+                if (count > 1 && NameEquals(name, _name1)) { value = _value1; return true; }
+                if (count > 2 && NameEquals(name, _name2)) { value = _value2; return true; }
+
+                value = null;
+                return false;
             }
 
-            return Parent != null
-                ? Parent.GetValue(name)
-                : UndefinedValue.Instance;
+            if (_properties != null)
+            {
+                return _properties.TryGetValue(name, out value);
+            }
+
+            value = null;
+            return false;
         }
 
         /// <summary>
@@ -81,12 +162,30 @@ namespace Fluid
         /// Deletes the value with the specified name in the current scopes.
         /// </summary>
         /// <param name="name">The name of the value to delete.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void DeleteOwn(string name)
         {
             if (_properties != null)
             {
                 _properties.Remove(name);
+                return;
+            }
+
+            for (var i = 0; i < _inlineCount; i++)
+            {
+                var slotName = GetInlineName(i);
+
+                if (NameEquals(name, slotName))
+                {
+                    // Compact the slots so the scan in TryGetOwnValue can stop at _inlineCount.
+                    for (var j = i; j < _inlineCount - 1; j++)
+                    {
+                        SetInline(j, GetInlineName(j + 1), GetInlineValue(j + 1));
+                    }
+
+                    SetInline(_inlineCount - 1, null, null);
+                    _inlineCount--;
+                    return;
+                }
             }
         }
 
@@ -109,11 +208,55 @@ namespace Fluid
         /// <summary>
         /// Sets the value with the specified name in the current scope.
         /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetOwnValue(string name, FluidValue value)
         {
-            _properties ??= new Dictionary<string, FluidValue>(Parent?._properties?.Comparer ?? _stringComparer);
-            _properties[name] = value ?? NilValue.Instance;
+            value ??= NilValue.Instance;
+
+            if (_properties != null)
+            {
+                _properties[name] = value;
+                return;
+            }
+
+            var comparer = _storageComparer;
+
+            if (comparer is null)
+            {
+                _storageComparer = comparer = Parent?._storageComparer ?? _stringComparer;
+                _storageComparerIsOrdinal = ReferenceEquals(comparer, StringComparer.Ordinal);
+            }
+
+            for (var i = 0; i < _inlineCount; i++)
+            {
+                var slotName = GetInlineName(i);
+
+                if (NameEquals(name, slotName))
+                {
+                    SetInline(i, slotName, value);
+                    return;
+                }
+            }
+
+            if (_inlineCount < InlineCapacity)
+            {
+                SetInline(_inlineCount, name, value);
+                _inlineCount++;
+                return;
+            }
+
+            // Overflow: switch to a dictionary and keep using it from now on.
+            var properties = new Dictionary<string, FluidValue>(comparer);
+            for (var i = 0; i < _inlineCount; i++)
+            {
+                properties[GetInlineName(i)] = GetInlineValue(i);
+            }
+
+            properties[name] = value;
+
+            _properties = properties;
+            _inlineCount = 0;
+            _name0 = _name1 = _name2 = null;
+            _value0 = _value1 = _value2 = null;
         }
 
         /// <summary>
@@ -127,6 +270,64 @@ namespace Fluid
                 {
                     scope.SetValue(property.Key, property.Value);
                 }
+
+                return;
+            }
+
+            for (var i = 0; i < _inlineCount; i++)
+            {
+                scope.SetValue(GetInlineName(i), GetInlineValue(i));
+            }
+        }
+
+        /// <summary>
+        /// Compares a looked-up name against the name held in a slot, under this scope's comparer.
+        /// Reference equality short-circuits only when the caller happens to pass the very string the
+        /// value was stored with; the parser allocates a separate string per identifier occurrence, so
+        /// reading a loop variable in the body does not hit that and falls through to the comparison.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool NameEquals(string name, string slotName)
+        {
+            if (ReferenceEquals(name, slotName))
+            {
+                return true;
+            }
+
+            if (slotName is null)
+            {
+                return false;
+            }
+
+            return _storageComparerIsOrdinal
+                ? string.Equals(name, slotName, StringComparison.Ordinal)
+                : _storageComparer.Equals(name, slotName);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private string GetInlineName(int index) => index switch
+        {
+            0 => _name0,
+            1 => _name1,
+            _ => _name2,
+        };
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private FluidValue GetInlineValue(int index) => index switch
+        {
+            0 => _value0,
+            1 => _value1,
+            _ => _value2,
+        };
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void SetInline(int index, string name, FluidValue value)
+        {
+            switch (index)
+            {
+                case 0: _name0 = name; _value0 = value; break;
+                case 1: _name1 = name; _value1 = value; break;
+                default: _name2 = name; _value2 = value; break;
             }
         }
     }

--- a/Fluid/Scope.cs
+++ b/Fluid/Scope.cs
@@ -172,6 +172,13 @@ namespace Fluid
                 return;
             }
 
+            if (_storageComparer != null)
+            {
+                // Once initialized, the dictionary-backed implementation rejected null keys even when
+                // the scope was empty after deleting its last value.
+                ArgumentNullException.ThrowIfNull(name);
+            }
+
             for (var i = 0; i < _inlineCount; i++)
             {
                 var slotName = GetInlineName(i);

--- a/Fluid/Scope.cs
+++ b/Fluid/Scope.cs
@@ -25,10 +25,12 @@ namespace Fluid
         // previous behaviour of creating the dictionary with the parent's comparer when it has one.
         private StringComparer _storageComparer;
 
-        // Ordinal is the default for every scope whose chain never reaches a custom ModelNamesComparer.
-        // Calling string.Equals directly for it keeps the slot scan free of a virtual call, which matters
-        // most on a miss, where every occupied slot is compared before moving to the parent scope.
-        private bool _storageComparerIsOrdinal;
+        // Both built-in comparers can be compared without a virtual call, which matters most on a miss,
+        // where every occupied slot is compared before moving to the parent scope. OrdinalIgnoreCase is
+        // what TemplateOptions.ModelNamesComparer defaults to, and Ordinal is what a scope falls back to
+        // when nothing in its chain sets one, so between them they cover the common configurations.
+        private StringComparison _storageComparison;
+        private bool _storageComparisonIsDirect;
 
         private readonly bool _forLoopScope;
         private readonly StringComparer _stringComparer;
@@ -210,6 +212,10 @@ namespace Fluid
         /// </summary>
         public void SetOwnValue(string name, FluidValue value)
         {
+            // The Dictionary this used to delegate to rejected a null key, and callers relied on being
+            // told at the offending call rather than when the name later surfaced somewhere else.
+            ArgumentNullException.ThrowIfNull(name);
+
             value ??= NilValue.Instance;
 
             if (_properties != null)
@@ -223,16 +229,25 @@ namespace Fluid
             if (comparer is null)
             {
                 _storageComparer = comparer = Parent?._storageComparer ?? _stringComparer;
-                _storageComparerIsOrdinal = ReferenceEquals(comparer, StringComparer.Ordinal);
+
+                if (ReferenceEquals(comparer, StringComparer.Ordinal))
+                {
+                    _storageComparison = StringComparison.Ordinal;
+                    _storageComparisonIsDirect = true;
+                }
+                else if (ReferenceEquals(comparer, StringComparer.OrdinalIgnoreCase))
+                {
+                    _storageComparison = StringComparison.OrdinalIgnoreCase;
+                    _storageComparisonIsDirect = true;
+                }
             }
 
             for (var i = 0; i < _inlineCount; i++)
             {
-                var slotName = GetInlineName(i);
-
-                if (NameEquals(name, slotName))
+                if (NameEquals(name, GetInlineName(i)))
                 {
-                    SetInline(i, slotName, value);
+                    // Only the value changes; the slot already holds an equal name.
+                    SetInlineValue(i, value);
                     return;
                 }
             }
@@ -244,7 +259,10 @@ namespace Fluid
                 return;
             }
 
-            // Overflow: switch to a dictionary and keep using it from now on.
+            // Overflow: switch to a dictionary and keep using it from now on. Publish the dictionary
+            // before retiring the slots, and leave the slot fields populated -- a reader that still sees
+            // the old _inlineCount then resolves from slots that are still valid, instead of finding
+            // neither store and reporting a name that is present as undefined.
             var properties = new Dictionary<string, FluidValue>(comparer);
             for (var i = 0; i < _inlineCount; i++)
             {
@@ -255,8 +273,6 @@ namespace Fluid
 
             _properties = properties;
             _inlineCount = 0;
-            _name0 = _name1 = _name2 = null;
-            _value0 = _value1 = _value2 = null;
         }
 
         /// <summary>
@@ -299,8 +315,8 @@ namespace Fluid
                 return false;
             }
 
-            return _storageComparerIsOrdinal
-                ? string.Equals(name, slotName, StringComparison.Ordinal)
+            return _storageComparisonIsDirect
+                ? string.Equals(name, slotName, _storageComparison)
                 : _storageComparer.Equals(name, slotName);
         }
 
@@ -328,6 +344,21 @@ namespace Fluid
                 case 0: _name0 = name; _value0 = value; break;
                 case 1: _name1 = name; _value1 = value; break;
                 default: _name2 = name; _value2 = value; break;
+            }
+        }
+
+        /// <summary>
+        /// Overwrites the value of an occupied slot. The loop variable is rewritten once per iteration,
+        /// so this avoids re-storing a name the slot already holds.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void SetInlineValue(int index, FluidValue value)
+        {
+            switch (index)
+            {
+                case 0: _value0 = value; break;
+                case 1: _value1 = value; break;
+                default: _value2 = value; break;
             }
         }
     }

--- a/Fluid/Values/FluidValue.cs
+++ b/Fluid/Values/FluidValue.cs
@@ -159,12 +159,6 @@ namespace Fluid.Values
 
             var typeOfValue = value.GetType();
 
-            // A type already known to be none of the special cases below goes straight to the wrapper.
-            if (_plainObjectTypeCache.Contains(typeOfValue))
-            {
-                return new ObjectValue(value);
-            }
-
             // Check if the value is an enum and convert to string
             if (typeOfValue.IsEnum)
             {
@@ -200,6 +194,13 @@ namespace Fluid.Values
                 case TypeCode.Empty:
                     return NilValue.Instance;
                 case TypeCode.Object:
+
+                    // Only object-typed values ever reach the fallback, so the memo is probed here
+                    // rather than up front, where every string and number would pay for it and miss.
+                    if (_plainObjectTypeCache.Contains(typeOfValue))
+                    {
+                        return new ObjectValue(value);
+                    }
 
                     switch (value)
                     {

--- a/Fluid/Values/FluidValue.cs
+++ b/Fluid/Values/FluidValue.cs
@@ -18,6 +18,14 @@ namespace Fluid.Values
 
         private static Dictionary<Type, Type> _genericDictionaryTypeCache = new();
 
+        /// <summary>
+        /// Types that <see cref="Create(object, TemplateOptions)"/> has already found to be plain objects.
+        /// Converting a model means running the same enum check, type code lookup and dozen-odd pattern
+        /// matches for every item of a list; remembering the outcome per type reduces that to one lookup.
+        /// Replaced wholesale rather than mutated, so readers never see a partially updated table.
+        /// </summary>
+        private static HashSet<Type> _plainObjectTypeCache = [];
+
         [Conditional("DEBUG")]
         protected static void AssertWriteToParameters(IFluidOutput output, TextEncoder encoder, CultureInfo cultureInfo)
         {
@@ -150,6 +158,12 @@ namespace Fluid.Values
             }
 
             var typeOfValue = value.GetType();
+
+            // A type already known to be none of the special cases below goes straight to the wrapper.
+            if (_plainObjectTypeCache.Contains(typeOfValue))
+            {
+                return new ObjectValue(value);
+            }
 
             // Check if the value is an enum and convert to string
             if (typeOfValue.IsEnum)
@@ -305,6 +319,16 @@ namespace Fluid.Values
                             return fluidValues != null
                                 ? new ArrayValue(fluidValues)
                                 : ArrayValue.Empty;
+                    }
+
+                    // Nothing above matched, so every value of this type is a plain object. Swap in a
+                    // copy with the type added, unless another thread got there first -- in which case
+                    // its table is just as valid and this one is dropped.
+                    var plainTypes = _plainObjectTypeCache;
+
+                    if (!plainTypes.Contains(typeOfValue))
+                    {
+                        Interlocked.CompareExchange(ref _plainObjectTypeCache, new HashSet<Type>(plainTypes) { typeOfValue }, plainTypes);
                     }
 
                     return new ObjectValue(value);

--- a/Fluid/Values/NumberValue.cs
+++ b/Fluid/Values/NumberValue.cs
@@ -12,23 +12,44 @@ namespace Fluid.Values
     /// 1.0 * 2.0 = 2.00
     public sealed class NumberValue : FluidValue, IEquatable<NumberValue>
     {
-        public static readonly NumberValue Zero = new NumberValue(0M);
+        /// <summary>
+        /// The largest value (exclusive) kept as a shared instance with precomputed text.
+        /// </summary>
+        private const int InternedLimit = 1024;
 
-        private static readonly NumberValue[] IntToString = new NumberValue[1024];
+        public static readonly NumberValue Zero;
+
+        private static readonly NumberValue[] IntToString = new NumberValue[InternedLimit];
 
         private readonly decimal _value;
+
+        /// <summary>
+        /// The rendered form of the value, when it is known to be culture-independent. Non-negative
+        /// integers below <see cref="IntToString"/>'s length format as plain ASCII digits in every
+        /// culture, so their text can be precomputed and written without formatting the decimal.
+        /// </summary>
+        private readonly string _text;
 
         static NumberValue()
         {
             for (var i = 0; i < IntToString.Length; ++i)
             {
-                IntToString[i] = new NumberValue(i);
+                IntToString[i] = new NumberValue(i, i.ToString(CultureInfo.InvariantCulture));
             }
+
+            // Share the instance Create(0) hands out, so there is only ever one canonical zero.
+            Zero = IntToString[0];
         }
 
         private NumberValue(decimal value)
         {
             _value = value;
+        }
+
+        private NumberValue(int value, string text)
+        {
+            _value = value;
+            _text = text;
         }
 
         public override FluidValues Type => FluidValues.Number;
@@ -101,12 +122,18 @@ namespace Fluid.Values
 
         public override string ToStringValue()
         {
-            return _value.ToString(CultureInfo.InvariantCulture);
+            return _text ?? _value.ToString(CultureInfo.InvariantCulture);
         }
 
         public override ValueTask WriteToAsync(IFluidOutput output, TextEncoder encoder, CultureInfo cultureInfo)
         {
             AssertWriteToParameters(output, encoder, cultureInfo);
+
+            if (_text is not null)
+            {
+                output.Write(encoder, _text);
+                return default;
+            }
 
             var scale = GetScale(_value);
 
@@ -230,6 +257,15 @@ namespace Fluid.Values
 
         public static NumberValue Create(decimal value)
         {
+            // Reuse the interned instances for small non-negative whole numbers. That is by far the most
+            // common shape of number flowing through a template (loop counters, sizes, quantities, prices)
+            // and lets them render from precomputed text instead of formatting a decimal.
+            // The scale is part of a number's identity in Liquid (1.0 * 2.0 == 2.00), so only scale 0 qualifies.
+            if (GetScale(value) == 0 && value >= 0m && value < InternedLimit)
+            {
+                return IntToString[(int)value];
+            }
+
             return new NumberValue(value);
         }
 

--- a/Fluid/Values/NumberValue.cs
+++ b/Fluid/Values/NumberValue.cs
@@ -261,10 +261,15 @@ namespace Fluid.Values
             // common shape of number flowing through a template (loop counters, sizes, quantities, prices)
             // and lets them render from precomputed text instead of formatting a decimal.
             // The scale is part of a number's identity in Liquid (1.0 * 2.0 == 2.00), so only scale 0 qualifies.
-            if (GetScale(value) == 0 && value >= 0m && value < InternedLimit)
+#if NET8_0_OR_GREATER
+            // Range first, because it is a pair of comparisons; the scale read is free on this target.
+            // Not done on netstandard2.0, where GetScale goes through decimal.GetBits and allocates an
+            // int[4] per call -- that would cost more than the allocation interning saves.
+            if (value >= 0m && value < InternedLimit && GetScale(value) == 0)
             {
                 return IntToString[(int)value];
             }
+#endif
 
             return new NumberValue(value);
         }

--- a/Fluid/Values/ObjectValueBase.cs
+++ b/Fluid/Values/ObjectValueBase.cs
@@ -51,19 +51,20 @@ namespace Fluid.Values
         internal sealed class AccessorCacheEntry
         {
             /// <summary>
-            /// Marks a call site that has seen too many distinct types to be worth caching, such as a
-            /// loop over a heterogeneous collection. Without it such a site would miss every time and
-            /// allocate a replacement entry per access, which is worse than not caching at all.
+            /// Marks a call site that misses too often to be worth caching -- a loop over a
+            /// heterogeneous collection, or a template rendered against several sets of options.
+            /// Without it such a site would allocate a replacement entry on every access, which is
+            /// worse than not caching at all.
             /// </summary>
             public static readonly AccessorCacheEntry Disabled = new(null, null, null, null, 0);
 
-            public AccessorCacheEntry(object token, Type type, StringComparer comparer, IMemberAccessor accessor, int shapeMisses)
+            public AccessorCacheEntry(object token, Type type, StringComparer comparer, IMemberAccessor accessor, int misses)
             {
                 Token = token;
                 Type = type;
                 Comparer = comparer;
                 Accessor = accessor;
-                ShapeMisses = shapeMisses;
+                Misses = misses;
             }
 
             public readonly object Token;
@@ -72,18 +73,18 @@ namespace Fluid.Values
             public readonly IMemberAccessor Accessor;
 
             /// <summary>
-            /// How often this site resolved against a different type or comparer. Counted on the entry
-            /// rather than the segment so that tracking it costs no extra field per parsed segment.
+            /// How often this site had to re-resolve. Counted on the entry rather than the segment so
+            /// that tracking it costs no extra field per parsed segment.
             /// </summary>
-            public readonly int ShapeMisses;
+            public readonly int Misses;
         }
 
         /// <summary>
-        /// How many times a call site may change shape before it stops caching. A monomorphic site
-        /// misses once when cold, so this only has to stay clear of the handful of misses that
-        /// registering accessors for new types causes while an application warms up.
+        /// How many times a call site may re-resolve before it stops caching. A site that settles misses
+        /// only while warming up, so this only has to clear the handful of misses that resolving the
+        /// first accessors for a model type costs.
         /// </summary>
-        private const int MaxShapeMisses = 4;
+        private const int MaxMisses = 4;
 
         public override ValueTask<FluidValue> GetValueAsync(string name, TemplateContext context)
         {
@@ -131,16 +132,15 @@ namespace Fluid.Values
                 return accessor;
             }
 
-            // Only a change of shape counts towards the budget. Missing because the strategy registered
-            // an accessor elsewhere says nothing about how many types this site sees, and would
-            // otherwise disable caching everywhere during warm-up.
-            var shapeMisses = entry is null || (ReferenceEquals(entry.Type, type) && ReferenceEquals(entry.Comparer, comparer))
-                ? entry?.ShapeMisses ?? 0
-                : entry.ShapeMisses + 1;
+            // Every miss counts, whatever the cause. A site that keeps missing is one whose entry never
+            // pays for itself, and it would otherwise allocate a replacement on every single access --
+            // which is what a template rendered alternately against two TemplateOptions does, since the
+            // type and comparer match every time and only the token differs.
+            var misses = (entry?.Misses ?? 0) + 1;
 
-            cache = shapeMisses > MaxShapeMisses
+            cache = misses > MaxMisses
                 ? AccessorCacheEntry.Disabled
-                : new AccessorCacheEntry(token, type, comparer, accessor, shapeMisses);
+                : new AccessorCacheEntry(token, type, comparer, accessor, misses);
 
             return accessor;
         }

--- a/Fluid/Values/ObjectValueBase.cs
+++ b/Fluid/Values/ObjectValueBase.cs
@@ -38,11 +38,116 @@ namespace Fluid.Values
             return other is ObjectValueBase otherObject && Value.Equals(otherObject.Value);
         }
 
+        /// <summary>
+        /// A resolved <see cref="IMemberAccessor"/> remembered by a single call site, so that repeatedly
+        /// reading the same member off the same type (a loop body, typically) doesn't hash the member
+        /// name into the strategy's dictionary on every iteration.
+        /// </summary>
+        /// <remarks>
+        /// Immutable, and published by a single reference assignment. Under the .NET runtime memory model
+        /// that assignment is a release store, so a thread that reads the entry either sees the previous
+        /// one or this one fully initialized -- never a half-built entry.
+        /// </remarks>
+        internal sealed class AccessorCacheEntry
+        {
+            /// <summary>
+            /// Marks a call site that has seen too many distinct types to be worth caching, such as a
+            /// loop over a heterogeneous collection. Without it such a site would miss every time and
+            /// allocate a replacement entry per access, which is worse than not caching at all.
+            /// </summary>
+            public static readonly AccessorCacheEntry Disabled = new(null, null, null, null, 0);
+
+            public AccessorCacheEntry(object token, Type type, StringComparer comparer, IMemberAccessor accessor, int shapeMisses)
+            {
+                Token = token;
+                Type = type;
+                Comparer = comparer;
+                Accessor = accessor;
+                ShapeMisses = shapeMisses;
+            }
+
+            public readonly object Token;
+            public readonly Type Type;
+            public readonly StringComparer Comparer;
+            public readonly IMemberAccessor Accessor;
+
+            /// <summary>
+            /// How often this site resolved against a different type or comparer. Counted on the entry
+            /// rather than the segment so that tracking it costs no extra field per parsed segment.
+            /// </summary>
+            public readonly int ShapeMisses;
+        }
+
+        /// <summary>
+        /// How many times a call site may change shape before it stops caching. A monomorphic site
+        /// misses once when cold, so this only has to stay clear of the handful of misses that
+        /// registering accessors for new types causes while an application warms up.
+        /// </summary>
+        private const int MaxShapeMisses = 4;
+
         public override ValueTask<FluidValue> GetValueAsync(string name, TemplateContext context)
         {
             var accessor = context.Options.MemberAccessStrategy.GetAccessor(Value.GetType(), name, context.Options.ModelNamesComparer);
+            return GetValueAsync(name, context, name.Contains('.'), accessor);
+        }
 
-            if (name.Contains('.'))
+        internal ValueTask<FluidValue> GetValueAsync(string name, TemplateContext context, bool nameHasDot, ref AccessorCacheEntry cache)
+        {
+            return GetValueAsync(name, context, nameHasDot, GetAccessorCached(name, context, ref cache));
+        }
+
+        private IMemberAccessor GetAccessorCached(string name, TemplateContext context, ref AccessorCacheEntry cache)
+        {
+            var type = Value.GetType();
+            var strategy = context.Options.MemberAccessStrategy;
+            var comparer = context.Options.ModelNamesComparer;
+
+            // A single read of the field; the entry is immutable once published.
+            var entry = cache;
+
+            if (ReferenceEquals(entry, AccessorCacheEntry.Disabled))
+            {
+                return strategy.GetAccessor(type, name, comparer);
+            }
+
+            // Read the token before resolving. A registration racing with this lookup then leaves the
+            // entry stamped with the superseded token, so it is re-resolved on the next access instead
+            // of being baked in.
+            var token = strategy.AccessorCacheToken;
+
+            if (entry is not null
+                && ReferenceEquals(entry.Token, token)
+                && ReferenceEquals(entry.Type, type)
+                && ReferenceEquals(entry.Comparer, comparer))
+            {
+                return entry.Accessor;
+            }
+
+            var accessor = strategy.GetAccessor(type, name, comparer);
+
+            // A null token means the strategy doesn't support caching.
+            if (token is null)
+            {
+                return accessor;
+            }
+
+            // Only a change of shape counts towards the budget. Missing because the strategy registered
+            // an accessor elsewhere says nothing about how many types this site sees, and would
+            // otherwise disable caching everywhere during warm-up.
+            var shapeMisses = entry is null || (ReferenceEquals(entry.Type, type) && ReferenceEquals(entry.Comparer, comparer))
+                ? entry?.ShapeMisses ?? 0
+                : entry.ShapeMisses + 1;
+
+            cache = shapeMisses > MaxShapeMisses
+                ? AccessorCacheEntry.Disabled
+                : new AccessorCacheEntry(token, type, comparer, accessor, shapeMisses);
+
+            return accessor;
+        }
+
+        private ValueTask<FluidValue> GetValueAsync(string name, TemplateContext context, bool nameHasDot, IMemberAccessor accessor)
+        {
+            if (nameHasDot)
             {
                 if (accessor != null)
                 {


### PR DESCRIPTION
Caches the things rendering re-resolves on every loop iteration and every render of a cached template, and stops `for` from rebuilding constants per execution.

BenchmarkDotNet, .NET 10 / AMD 5950X, against `df733e0`. Each side rebuilt from a clean `obj/bin` and verified by assembly marker, sides alternating, and any run the machine wasn't idle for discarded. `main` got the benefit of more samples than `branch`, so these deltas are conservative.

## Render

| Method | main | branch | |
|---|---:|---:|---:|
| Render | 32.80 μs | **23.50 μs** | **−28.4%** |
| Render (compiled parser) | 30.85 μs | **23.10 μs** | **−25.1%** |
| ParseAndRender | 35.81 μs | **27.73 μs** | **−22.6%** |
| Render allocations | 41.12 KB | **37.37 KB** | −9.1% |

## Shapes the catalogue template doesn't reach

`RenderScenarioBenchmarks` is new — heterogeneous collections, deep scope chains, scopes wider than the inline slots, names needing case conversion, numbers that can't be interned. These are where the caching could have *cost*.

| Benchmark | main | branch | | alloc |
|---|---:|---:|---:|---:|
| NestedLoopsWithParentLoop | 15.50 μs | **9.91 μs** | **−36.1%** | −52.1% |
| WideScope | 4.10 μs | **2.75 μs** | **−32.9%** | −20.9% |
| DeepScopeChain | 91.69 μs | **65.11 μs** | **−29.0%** | **−61.6%** |
| MonomorphicMembers | 7.61 μs | **5.73 μs** | **−24.7%** | −7.6% |
| PascalCaseMemberNames | 7.45 μs | **5.67 μs** | **−23.8%** | −9.0% |
| PolymorphicMembers | 8.74 μs | **6.88 μs** | **−21.3%** | −7.6% |
| NonInternedNumbers | 12.94 μs | **11.82 μs** | **−8.6%** | +1.9% |

Nested loops gain most: inline slots remove a `Dictionary` allocation per scope, and a nested loop creates a scope per iteration of the enclosing one.

## Cost

Parsing allocates **7–9% more** (`Parse` 3.21 → 3.44 KB): `IdentifierSegment` carries two more references, multiplied by parser backtracking. Parse time is +0.2% to +5.7% depending on the benchmark, i.e. at or near noise. Templates are parsed once and cached.

## Changes

- **`IdentifierSegment`** caches the resolved `IMemberAccessor` per call site, keyed on runtime type, comparer and a strategy-supplied token. A site that keeps missing — a heterogeneous loop, or a template rendered against several `TemplateOptions` — stops caching rather than allocating a replacement entry per access.
- **`MemberAccessStrategy.AccessorCacheToken`** — new, defaults to `null` (no caching) so custom strategies stay correct. `DefaultMemberAccessStrategy` retires its token only when a caller registers an accessor, so resolving a member doesn't invalidate every call site in the process. Only the exact type opts in: a subclass overriding `GetAccessor` may resolve from a source the strategy can't see.
- **`FilterExpression`** skips the async state machine when input and filter both complete synchronously, caches the resolved delegate, and gives up caching at a site that keeps missing. Errors still arrive as a faulted task.
- **`Scope`** holds up to 3 names in inline slots instead of a `Dictionary` — what a `for` loop needs (loop variable, `forloop`, `parentloop`). `Ordinal` and `OrdinalIgnoreCase` are compared without a virtual call.
- **`NumberValue`** shares instances for small non-negative whole numbers and renders them from precomputed text. Scale is part of a number's identity in Liquid, so only scale 0 qualifies; limited to targets where reading the scale is free.
- **`FluidValue.Create`** remembers types that are plain objects, skipping the enum check, type-code lookup and dozen pattern matches per item.
- **`MemberNameStrategies`** settles ordinally equal names without `ConvertName`, which allocates.
- **`ForStatement`** precomputes the `offset: continue` key and whitespace-only body check instead of rebuilding them with LINQ and `string.Join` per execution.

## Profile

CPU profile (ETW, 8 kHz) of the catalogue render, main → branch:

| | main | branch |
|---|---:|---:|
| `ObjectValueBase.GetValueAsync` | 10.9% | not in top 30 |
| `FilterExpression` async state machine | 4.8% | gone (sync path) |
| `TryFormatDecimal` + `NumberToString` | 2.9% | gone |
| `SpanHelpers.SequenceEqual` | 3.6% | 2.2% |

Remaining allocation is ~80% the final `ToString()` in `Render()`, i.e. inherent to returning a string.

## Tests

`RenderCacheInvalidationTests` (19 cases) covers what the caches could get wrong: accessors re-registered between renders; a strategy subclass that must never be cached; one template alternating across two `TemplateOptions`, including that it stops allocating once it gives up; one call site seeing alternating types; filters added, replaced and removed; `StrictFilters` and a throwing filter both arriving as faulted tasks; a null scope name throwing at the offending call; culture-invariance at the interning boundary; decimal-scale preservation. Suite: 2602 passing.

## Review notes

- `AccessorCacheToken` is new `protected internal virtual` surface — additive and binary-compatible, default disables caching.
- `Scope.Properties` now returns a snapshot rather than a live key view.
- `Fluid.Benchmarks/Program.cs` gains a `profile` mode: a steady-state loop for sampling profilers.
