### PR TITLE
Add regression tests for boolean and null equality

### DIFF
--- a/Fluid.Tests/BinaryExpressionTests.cs
+++ b/Fluid.Tests/BinaryExpressionTests.cs
@@ -398,6 +398,22 @@ namespace Fluid.Tests
         [InlineData("true == 1", "false")]        
         [InlineData("false == '1'", "false")]
         [InlineData("false == 1", "false")]
+        [InlineData("true == null", "false")]
+        [InlineData("true != null", "true")]
+        [InlineData("false == null", "false")]
+        [InlineData("false != null", "true")]
+        [InlineData("null == true", "false")]
+        [InlineData("null != true", "true")]
+        [InlineData("null == false", "false")]
+        [InlineData("null != false", "true")]
+        [InlineData("true == nil", "false")]
+        [InlineData("true != nil", "true")]
+        [InlineData("false == nil", "false")]
+        [InlineData("false != nil", "true")]
+        [InlineData("nil == true", "false")]
+        [InlineData("nil != true", "true")]
+        [InlineData("nil == false", "false")]
+        [InlineData("nil != false", "true")]
         public Task BooleanEquality(string source, string expected)
         {
             return CheckAsync(source, expected);


### PR DESCRIPTION
Main already prevents booleans from comparing equal to null-like values, but the exact regression reported in the issue was not covered by tests.

Add symmetric equality and inequality cases for `true` and `false` against both `null` and `nil`, including reversed operand order. This protects the type-aware behavior while leaving the intentional `blank == false` semantics unchanged.

Tests pass for both the normal and compiled parser configurations.

Fixes: #960