### PR TITLE
Add asynchronous template file providers

### DIFF
--- a/Fluid.MvcViewEngine/FluidMvcViewOptions.cs
+++ b/Fluid.MvcViewEngine/FluidMvcViewOptions.cs
@@ -1,11 +1,17 @@
 ﻿using Fluid.ViewEngine;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.Extensions.FileProviders;
 using System.Threading.Tasks;
 
 namespace Fluid.MvcViewEngine
 {
     public class FluidMvcViewOptions : FluidViewEngineOptions
     {
+        /// <summary>
+        /// Gets or sets the synchronous provider used by ASP.NET Core to locate named views.
+        /// </summary>
+        public IFileProvider ViewLocationFileProvider { get; set; }
+
         public delegate ValueTask RenderingMvcViewDelegate(string path, ViewContext viewContext, TemplateContext context);
 
         /// <summary>

--- a/Fluid.MvcViewEngine/FluidRendering.cs
+++ b/Fluid.MvcViewEngine/FluidRendering.cs
@@ -24,11 +24,14 @@ namespace Fluid.MvcViewEngine
             _hostingEnvironment = hostingEnvironment;
             _options = optionsAccessor.Value;
 
-            _options.TemplateOptions.FileProvider = _options.PartialsFileProvider ?? _hostingEnvironment.ContentRootFileProvider;
+            _options.TemplateOptions.FileProvider =
+                _options.PartialsFileProvider ??
+                new FileProviderTemplateFileProvider(_hostingEnvironment.ContentRootFileProvider);
+
+            _options.ViewsFileProvider ??=
+                new FileProviderTemplateFileProvider(_hostingEnvironment.ContentRootFileProvider);
 
             _fluidViewRenderer = new FluidViewRenderer(_options);
-
-            _options.ViewsFileProvider ??= _hostingEnvironment.ContentRootFileProvider;
         }
 
         private readonly IWebHostEnvironment _hostingEnvironment;
@@ -36,7 +39,10 @@ namespace Fluid.MvcViewEngine
 
         public async Task RenderAsync(TextWriter writer, string path, ViewContext viewContext)
         {
-            var context = new TemplateContext(_options.TemplateOptions);
+            var context = new TemplateContext(_options.TemplateOptions)
+            {
+                CancellationToken = viewContext.HttpContext.RequestAborted
+            };
             context.SetValue("ViewData", viewContext.ViewData);
             context.SetValue("ModelState", viewContext.ModelState);
             context.SetValue("Model", viewContext.ViewData.Model);
@@ -52,7 +58,12 @@ namespace Fluid.MvcViewEngine
                 bufferSize = 16 * 1024;
             }
 
-            await using var output = new TextWriterFluidOutput(writer, bufferSize, leaveOpen: true, allowSynchronousIO: false);
+            await using var output = new TextWriterFluidOutput(
+                writer,
+                bufferSize,
+                leaveOpen: true,
+                allowSynchronousIO: false,
+                cancellationToken: context.CancellationToken);
             await _fluidViewRenderer.RenderViewAsync(output, path, context);
             await output.FlushAsync();
         }

--- a/Fluid.MvcViewEngine/FluidViewEngine.cs
+++ b/Fluid.MvcViewEngine/FluidViewEngine.cs
@@ -48,7 +48,7 @@ namespace Fluid.MvcViewEngine
                 return ViewEngineResult.Found(viewName, fluidView);
             }
 
-            var fileProvider = _options.ViewsFileProvider ?? _hostingEnvironment.ContentRootFileProvider;
+            var fileProvider = _options.ViewLocationFileProvider ?? _hostingEnvironment.ContentRootFileProvider;
 
             List<string> checkedLocations = null;
 

--- a/Fluid.MvcViewEngine/FluidViewEngineOptionsSetup.cs
+++ b/Fluid.MvcViewEngine/FluidViewEngineOptionsSetup.cs
@@ -12,8 +12,10 @@ namespace Fluid.MvcViewEngine
         public FluidViewEngineOptionsSetup(IWebHostEnvironment webHostEnvironment)
             : base(options =>
             {
-                options.PartialsFileProvider = new FileProviderMapper(webHostEnvironment.ContentRootFileProvider, "Views");
-                options.ViewsFileProvider = new FileProviderMapper(webHostEnvironment.ContentRootFileProvider, "Views");
+                var fileProvider = new FileProviderMapper(webHostEnvironment.ContentRootFileProvider, "Views");
+                options.PartialsFileProvider = fileProvider;
+                options.ViewsFileProvider = fileProvider;
+                options.ViewLocationFileProvider = fileProvider;
 
                 options.ViewsLocationFormats.Clear();
                 options.ViewsLocationFormats.Add("/{1}/{0}" + Constants.ViewExtension);

--- a/Fluid.Tests/FromStatementTests.cs
+++ b/Fluid.Tests/FromStatementTests.cs
@@ -124,4 +124,36 @@ public class FromStatementTests
         var result = await template.RenderAsync(context);
         Assert.Equal("Hello world! Hello John Doe!", result);
     }
+
+    [Fact]
+    public async Task FromStatement_ShouldLoadMacrosAsynchronously()
+    {
+        var sourceLoader = new AsyncTemplateFileProvider()
+            .Add("_Macros.liquid", "{% macro hello() %}Hello{% endmacro %}");
+        var options = new TemplateOptions { FileProvider = sourceLoader };
+        var source = "{% from '_Macros' import hello %}{{ hello() }}";
+
+        _parser.TryParse(source, out var template, out var error);
+
+        var renderTask = template.RenderAsync(new TemplateContext(options));
+        Assert.False(renderTask.IsCompletedSuccessfully);
+        Assert.Equal("Hello", await renderTask);
+        Assert.Equal(1, sourceLoader.GetReadCount("_Macros.liquid"));
+    }
+
+    [Fact]
+    public async Task FromStatement_ShouldReloadMacrosWhenSourceVersionChanges()
+    {
+        var sourceLoader = new AsyncTemplateFileProvider()
+            .Add("_Macros.liquid", "{% macro hello() %}First{% endmacro %}");
+        var options = new TemplateOptions { FileProvider = sourceLoader };
+        _parser.TryParse("{% from '_Macros' import hello %}{{ hello() }}", out var template);
+
+        Assert.Equal("First", await template.RenderAsync(new TemplateContext(options)));
+
+        sourceLoader.Add("_Macros.liquid", "{% macro hello() %}Second{% endmacro %}");
+
+        Assert.Equal("Second", await template.RenderAsync(new TemplateContext(options)));
+        Assert.Equal(2, sourceLoader.GetReadCount("_Macros.liquid"));
+    }
 }

--- a/Fluid.Tests/IncludeStatementTests.cs
+++ b/Fluid.Tests/IncludeStatementTests.cs
@@ -54,7 +54,10 @@ Partials: '{{ Partials }}'
 color: '{{ color }}'
 shape: '{{ shape }}'");
 
-            var options = new TemplateOptions() { FileProvider = fileProvider };
+            var options = new TemplateOptions()
+            {
+                FileProvider = new FileProviderTemplateFileProvider(fileProvider)
+            };
             var context = new TemplateContext(options);
             var expectedResult = @"Partial Content
 Partials: ''
@@ -85,7 +88,10 @@ shape_Two: '{{ shape }}'");
 
             var model = new Domain.Person { Firstname = "_First.liquid" };
 
-            var options = new TemplateOptions() { FileProvider = fileProvider };
+            var options = new TemplateOptions()
+            {
+                FileProvider = new FileProviderTemplateFileProvider(fileProvider)
+            };
             var context = new TemplateContext(model, options);
             var expectedResultFirstCall = @"Partial Content One
 Partials_One: ''
@@ -128,7 +134,10 @@ Partials: '{{ Partials }}'
 color: '{{ color }}'
 shape: '{{ shape }}'");
 
-            var options = new TemplateOptions() { FileProvider = fileProvider };
+            var options = new TemplateOptions()
+            {
+                FileProvider = new FileProviderTemplateFileProvider(fileProvider)
+            };
             var context = new TemplateContext(options);
             var expectedResult = @"Partial Content
 Partials: ''
@@ -456,7 +465,10 @@ shape: ''";
 
             var fileInfos = templates.ToDictionary(t => t.Key, t => fileProvider.GetFileInfo(t.Key));
 
-            var options = new TemplateOptions() { FileProvider = fileProvider };
+            var options = new TemplateOptions()
+            {
+                FileProvider = new FileProviderTemplateFileProvider(fileProvider)
+            };
             _parser.TryParse("{%- include file -%}", out var template);
 
             // The first time a template is included it will be read from the file provider
@@ -541,7 +553,10 @@ shape: ''";
             File.WriteAllText(tempPath + "/this-folder/this_file.liquid", "content1");
             File.WriteAllText(tempPath + "/this-folder/that-folder/this_file.liquid", "content2");
 
-            var options = new TemplateOptions() { FileProvider = fileProvider };
+            var options = new TemplateOptions()
+            {
+                FileProvider = new FileProviderTemplateFileProvider(fileProvider)
+            };
             _parser.TryParse("{%- include file -%}", out var template);
 
             var context = new TemplateContext(options);
@@ -580,7 +595,10 @@ shape: ''";
             File.WriteAllText(tempPath + "/this_file.liquid", "content1");
             File.WriteAllText(tempPath + "/This_file.liquid", "content2");
 
-            var options = new TemplateOptions() { FileProvider = fileProvider };
+            var options = new TemplateOptions()
+            {
+                FileProvider = new FileProviderTemplateFileProvider(fileProvider)
+            };
             _parser.TryParse("{%- include file -%}", out var template);
 
             var context = new TemplateContext(options);
@@ -1019,6 +1037,126 @@ shape: ''";
             var result2 = await template.RenderAsync(context);
             Assert.Equal("8", result2);
             Assert.Equal(1, callbackCount); // Callback count should still be 1
+        }
+
+        [Theory]
+        [InlineData("{% include 'inner' %}")]
+        [InlineData("{% render 'inner' %}")]
+        public async Task TemplateFileProvider_ShouldLoadAndCacheTemplatesAsynchronously(string source)
+        {
+            var sourceLoader = new AsyncTemplateFileProvider()
+                .Add("inner.liquid", "{{ value }}");
+            var options = new TemplateOptions
+            {
+                FileProvider = sourceLoader
+            };
+            var context = new TemplateContext(options).SetValue("value", "loaded");
+            _parser.TryParse(source, out var template);
+
+            var renderTask = template.RenderAsync(context);
+            Assert.False(renderTask.IsCompletedSuccessfully);
+            Assert.Equal("loaded", await renderTask);
+
+            Assert.Equal("loaded", await template.RenderAsync(context));
+            Assert.Equal(1, sourceLoader.GetReadCount("inner.liquid"));
+            Assert.Contains("inner", sourceLoader.RequestedPaths);
+            Assert.Contains("inner.liquid", sourceLoader.RequestedPaths);
+        }
+
+        [Theory]
+        [InlineData("{% include 'inner' %}")]
+        [InlineData("{% render 'inner' %}")]
+        public async Task TemplateFileProvider_ShouldInvalidateCachedTemplatesWhenVersionChanges(string source)
+        {
+            var sourceLoader = new AsyncTemplateFileProvider()
+                .Add("inner.liquid", "first");
+            var options = new TemplateOptions { FileProvider = sourceLoader };
+            var context = new TemplateContext(options);
+            _parser.TryParse(source, out var template);
+
+            Assert.Equal("first", await template.RenderAsync(context));
+
+            sourceLoader.Add("inner.liquid", "second");
+
+            Assert.Equal("second", await template.RenderAsync(context));
+            Assert.Equal(2, sourceLoader.GetReadCount("inner.liquid"));
+        }
+
+        [Fact]
+        public async Task TemplateFileProvider_ShouldCacheTemplateParsedResult()
+        {
+            var sourceLoader = new AsyncTemplateFileProvider()
+                .Add("inner.liquid", "{{ 2 | plus: 2 }}");
+            var callbackCount = 0;
+            var options = new TemplateOptions { FileProvider = sourceLoader };
+            options.TemplateParsed = (path, template) =>
+            {
+                callbackCount++;
+                var visitor = new Visitors.ReplaceTwosVisitor(NumberValue.Create(4));
+                return visitor.VisitTemplate(template);
+            };
+            _parser.TryParse("{% include 'inner' %}", out var template);
+
+            Assert.Equal("8", await template.RenderAsync(new TemplateContext(options)));
+            Assert.Equal("8", await template.RenderAsync(new TemplateContext(options)));
+            Assert.Equal(1, callbackCount);
+            Assert.Equal(1, sourceLoader.GetReadCount("inner.liquid"));
+        }
+
+        [Fact]
+        public async Task TemplateFileProvider_ShouldThrowWhenTemplateIsMissing()
+        {
+            var sourceLoader = new AsyncTemplateFileProvider();
+            var options = new TemplateOptions { FileProvider = sourceLoader };
+            _parser.TryParse("{% include 'missing' %}", out var template);
+
+            await Assert.ThrowsAsync<FileNotFoundException>(
+                () => template.RenderAsync(new TemplateContext(options)).AsTask());
+        }
+
+        [Fact]
+        public async Task TemplateFileProvider_ShouldReceiveTheContextCancellationToken()
+        {
+            var sourceLoader = new AsyncTemplateFileProvider()
+                .Add("inner.liquid", "content");
+            var options = new TemplateOptions { FileProvider = sourceLoader };
+            using var cancellationTokenSource = new CancellationTokenSource();
+            var context = new TemplateContext(options)
+            {
+                CancellationToken = cancellationTokenSource.Token
+            };
+            _parser.TryParse("{% include 'inner' %}", out var template);
+
+            Assert.Equal("content", await template.RenderAsync(context));
+            Assert.Equal(cancellationTokenSource.Token, sourceLoader.LastCancellationToken);
+            Assert.Equal(1, sourceLoader.GetReadCount("inner.liquid"));
+        }
+
+        [Fact]
+        public async Task TemplateFileProvider_ShouldIsolateCachedTemplatesBySourceCacheKey()
+        {
+            var lastModified = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            var options = new TemplateOptions
+            {
+                FileProvider = new DelegateTemplateFileProvider(async (path, context, cancellationToken) =>
+                {
+                    await Task.Yield();
+                    var tenant = context.GetValue("tenant").ToStringValue();
+                    return new TemplateSourceInfo(
+                        lastModified,
+                        cancellationToken => new ValueTask<Stream>(
+                            new MemoryStream(System.Text.Encoding.UTF8.GetBytes(tenant))),
+                        cacheKey: $"{tenant}:{path}");
+                })
+            };
+            _parser.TryParse("{% include 'inner.liquid' %}", out var template);
+
+            var tenantA = new TemplateContext(options).SetValue("tenant", "A");
+            var tenantB = new TemplateContext(options).SetValue("tenant", "B");
+
+            Assert.Equal("A", await template.RenderAsync(tenantA));
+            Assert.Equal("B", await template.RenderAsync(tenantB));
+            Assert.Equal("A", await template.RenderAsync(tenantA));
         }
     }
 }

--- a/Fluid.Tests/Mocks/AsyncTemplateFileProvider.cs
+++ b/Fluid.Tests/Mocks/AsyncTemplateFileProvider.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fluid.Tests.Mocks;
+
+public sealed class AsyncTemplateFileProvider : ITemplateFileProvider
+{
+    private sealed record Entry(string Content, DateTimeOffset LastModified);
+
+    private readonly Dictionary<string, Entry> _sources = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, int> _readCounts = new(StringComparer.OrdinalIgnoreCase);
+    private long _version;
+
+    public List<string> RequestedPaths { get; } = [];
+    public CancellationToken LastCancellationToken { get; private set; }
+
+    public AsyncTemplateFileProvider Add(string path, string content)
+    {
+        _sources[NormalizePath(path)] = new Entry(
+            content,
+            new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero).AddTicks(++_version));
+        return this;
+    }
+
+    public AsyncTemplateFileProvider Remove(string path)
+    {
+        _sources.Remove(NormalizePath(path));
+        return this;
+    }
+
+    public int GetReadCount(string path) =>
+        _readCounts.TryGetValue(NormalizePath(path), out var count) ? count : 0;
+
+    public async ValueTask<TemplateSourceInfo> GetFileInfoAsync(
+        string path,
+        TemplateContext context,
+        CancellationToken cancellationToken)
+    {
+        await Task.Yield();
+        LastCancellationToken = cancellationToken;
+        cancellationToken.ThrowIfCancellationRequested();
+
+        path = NormalizePath(path);
+        RequestedPaths.Add(path);
+
+        if (!_sources.TryGetValue(path, out var entry))
+        {
+            return null;
+        }
+
+        return new TemplateSourceInfo(entry.LastModified, async cancellationToken =>
+        {
+            await Task.Yield();
+            cancellationToken.ThrowIfCancellationRequested();
+            _readCounts[path] = GetReadCount(path) + 1;
+            return new MemoryStream(Encoding.UTF8.GetBytes(entry.Content));
+        });
+    }
+
+    private static string NormalizePath(string path) => path.Replace('\\', '/').TrimStart('/');
+}

--- a/Fluid.Tests/Mocks/MockFileProvider.cs
+++ b/Fluid.Tests/Mocks/MockFileProvider.cs
@@ -3,10 +3,12 @@ using Microsoft.Extensions.Primitives;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Fluid.Tests.Mocks
 {
-    public class MockFileProvider : IFileProvider
+    public class MockFileProvider : IFileProvider, ITemplateFileProvider
     {
         private Dictionary<string, MockFileInfo> _files = new Dictionary<string, MockFileInfo>();
         private readonly bool _caseSensitive;
@@ -33,6 +35,25 @@ namespace Fluid.Tests.Mocks
             {
                 return MockFileInfo.Null;
             }
+        }
+
+        public ValueTask<TemplateSourceInfo> GetFileInfoAsync(
+            string path,
+            TemplateContext context,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var fileInfo = GetFileInfo(path);
+            if (!fileInfo.Exists)
+            {
+                return default;
+            }
+
+            return new ValueTask<TemplateSourceInfo>(
+                new TemplateSourceInfo(
+                    fileInfo.LastModified,
+                    _ => new ValueTask<Stream>(fileInfo.CreateReadStream())));
         }
 
         public MockFileProvider Add(string path, string content)

--- a/Fluid.Tests/MvcViewEngine/FunctionalServerTests.cs
+++ b/Fluid.Tests/MvcViewEngine/FunctionalServerTests.cs
@@ -31,6 +31,7 @@ namespace Fluid.Tests.MvcViewEngine
                 options.TemplateOptions.OutputBufferSize = 16;
                 options.ViewsFileProvider = mockFileProvider;
                 options.PartialsFileProvider = mockFileProvider;
+                options.ViewLocationFileProvider = mockFileProvider;
             });
 
             builder.Services

--- a/Fluid.Tests/MvcViewEngine/ViewEngineTests.cs
+++ b/Fluid.Tests/MvcViewEngine/ViewEngineTests.cs
@@ -1,5 +1,6 @@
 using Fluid.Tests.Mocks;
 using Fluid.ViewEngine;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -394,6 +395,175 @@ namespace Fluid.Tests.MvcViewEngine
             Assert.Equal("5 Hello", sw.ToString());
 
             _options.TemplateOptions.TemplateParsed = null;
+        }
+
+        [Fact]
+        public async Task ShouldLoadViewsPartialsViewStartsAndLayoutsAsynchronously()
+        {
+            var sourceLoader = new AsyncTemplateFileProvider()
+                .Add("Home/Index.liquid", "{% layout '_Layout' %}View {% partial 'Part' %}")
+                .Add("_ViewStart.liquid", "Root ")
+                .Add("Home/_ViewStart.liquid", "Home ")
+                .Add("Home/_Layout.liquid", "Layout [{% renderbody %}]")
+                .Add("Part.liquid", "Partial");
+            var options = CreateAsyncOptions(sourceLoader);
+            var renderer = new FluidViewRenderer(options);
+            var writer = new StringWriter();
+
+            await renderer.RenderViewAsync(writer, "Home/Index.liquid", new TemplateContext());
+
+            Assert.Equal("Layout [Root Home View Partial]", writer.ToString());
+            Assert.Equal(1, sourceLoader.GetReadCount("Home/Index.liquid"));
+            Assert.Equal(1, sourceLoader.GetReadCount("_ViewStart.liquid"));
+            Assert.Equal(1, sourceLoader.GetReadCount("Home/_ViewStart.liquid"));
+            Assert.Equal(1, sourceLoader.GetReadCount("Home/_Layout.liquid"));
+            Assert.Equal(1, sourceLoader.GetReadCount("Part.liquid"));
+        }
+
+        [Fact]
+        public async Task ShouldReuseAndInvalidateAsynchronouslyLoadedViews()
+        {
+            var sourceLoader = new AsyncTemplateFileProvider()
+                .Add("Index.liquid", "first");
+            var renderer = new FluidViewRenderer(CreateAsyncOptions(sourceLoader));
+
+            var first = new StringWriter();
+            await renderer.RenderViewAsync(first, "Index.liquid", new TemplateContext());
+
+            var cached = new StringWriter();
+            await renderer.RenderViewAsync(cached, "Index.liquid", new TemplateContext());
+
+            sourceLoader.Add("Index.liquid", "second");
+
+            var updated = new StringWriter();
+            await renderer.RenderViewAsync(updated, "Index.liquid", new TemplateContext());
+
+            Assert.Equal("first", first.ToString());
+            Assert.Equal("first", cached.ToString());
+            Assert.Equal("second", updated.ToString());
+            Assert.Equal(2, sourceLoader.GetReadCount("Index.liquid"));
+        }
+
+        [Fact]
+        public async Task ViewsFileProvider_ShouldNotReplacePartialsFileProvider()
+        {
+            var sourceLoader = new AsyncTemplateFileProvider()
+                .Add("Index.liquid", "View {% partial 'Part' %}");
+            var partialsFileProvider = new MockFileProvider()
+                .Add("Part.liquid", "Partial");
+            var options = new FluidViewEngineOptions
+            {
+                ViewsFileProvider = sourceLoader,
+                PartialsFileProvider = partialsFileProvider
+            };
+            var renderer = new FluidViewRenderer(options);
+            var writer = new StringWriter();
+
+            await renderer.RenderViewAsync(writer, "Index.liquid", new TemplateContext());
+
+            Assert.Equal("View Partial", writer.ToString());
+        }
+
+        [Fact]
+        public async Task PartialsFileProvider_ShouldFallBackToViewsFileProvider()
+        {
+            var sourceLoader = new AsyncTemplateFileProvider()
+                .Add("Index.liquid", "View {% include 'Part' %}")
+                .Add("Part.liquid", "Partial");
+            var options = new FluidViewEngineOptions
+            {
+                ViewsFileProvider = sourceLoader
+            };
+            var renderer = new FluidViewRenderer(options);
+            var writer = new StringWriter();
+
+            await renderer.RenderViewAsync(
+                writer,
+                "Index.liquid",
+                new TemplateContext(options.TemplateOptions));
+
+            Assert.Equal("View Partial", writer.ToString());
+        }
+
+        [Fact]
+        public async Task DisabledChangeTracking_ShouldStillIsolateViewStartCacheKeys()
+        {
+            var lastModified = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            var sourceLoader = new DelegateTemplateFileProvider(async (path, context, cancellationToken) =>
+            {
+                await Task.Yield();
+                path = path.Replace('\\', '/').TrimStart('/');
+
+                if (path == "Home/Index.liquid")
+                {
+                    return new TemplateSourceInfo(
+                        lastModified,
+                        _ => new ValueTask<Stream>(
+                            new MemoryStream(System.Text.Encoding.UTF8.GetBytes("View"))),
+                        cacheKey: "shared-view");
+                }
+
+                if (path == "Home/_ViewStart.liquid")
+                {
+                    var tenant = context.GetValue("tenant").ToStringValue();
+                    return new TemplateSourceInfo(
+                        lastModified,
+                        _ => new ValueTask<Stream>(
+                            new MemoryStream(System.Text.Encoding.UTF8.GetBytes(tenant + " "))),
+                        cacheKey: tenant + ":view-start");
+                }
+
+                return null;
+            });
+            var options = new FluidViewEngineOptions
+            {
+                ViewsFileProvider = sourceLoader,
+                TrackFileChanges = false
+            };
+            var renderer = new FluidViewRenderer(options);
+
+            var tenantAWriter = new StringWriter();
+            var tenantAContext = new TemplateContext(options.TemplateOptions).SetValue("tenant", "A");
+            await renderer.RenderViewAsync(tenantAWriter, "Home/Index.liquid", tenantAContext);
+
+            var tenantBWriter = new StringWriter();
+            var tenantBContext = new TemplateContext(options.TemplateOptions).SetValue("tenant", "B");
+            await renderer.RenderViewAsync(tenantBWriter, "Home/Index.liquid", tenantBContext);
+
+            Assert.Equal("A View", tenantAWriter.ToString());
+            Assert.Equal("B View", tenantBWriter.ToString());
+        }
+
+        [Fact]
+        public async Task ShouldReevaluateAsyncLayoutLocations()
+        {
+            var sourceLoader = new AsyncTemplateFileProvider()
+                .Add("Home/Index.liquid", "{% layout '_Layout' %}View")
+                .Add("Shared/_Layout.liquid", "Shared [{% renderbody %}]");
+            var options = CreateAsyncOptions(sourceLoader);
+            var renderer = new FluidViewRenderer(options);
+            var first = new StringWriter();
+
+            await renderer.RenderViewAsync(first, "Home/Index.liquid", new TemplateContext());
+
+            sourceLoader.Add("Home/_Layout.liquid", "Local [{% renderbody %}]");
+
+            var second = new StringWriter();
+            await renderer.RenderViewAsync(second, "Home/Index.liquid", new TemplateContext());
+
+            Assert.Equal("Shared [View]", first.ToString());
+            Assert.Equal("Local [View]", second.ToString());
+        }
+
+        private static FluidViewEngineOptions CreateAsyncOptions(AsyncTemplateFileProvider sourceLoader)
+        {
+            var options = new FluidViewEngineOptions
+            {
+                ViewsFileProvider = sourceLoader,
+                PartialsFileProvider = sourceLoader
+            };
+            options.LayoutsLocationFormats.Add("/Shared/{0}" + Constants.ViewExtension);
+            return options;
         }
 
         [Fact]

--- a/Fluid.Tests/TemplateTests.cs
+++ b/Fluid.Tests/TemplateTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using System.Text.Encodings.Web;
+using System.Threading;
 using System.Threading.Tasks;
 using Fluid.Parser;
 using Fluid.Tests.Domain;
@@ -55,6 +56,61 @@ namespace Fluid.Tests
         public Task ShouldRenderText(string source, string expected)
         {
             return CheckAsync(source, expected);
+        }
+
+        [Fact]
+        public async Task RenderAsync_ShouldObserveAPreCanceledContext()
+        {
+            _parser.TryParse("", out var template);
+            using var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+            var context = new TemplateContext
+            {
+                CancellationToken = cancellationTokenSource.Token
+            };
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => template.RenderAsync(context).AsTask());
+        }
+
+        [Fact]
+        public async Task RenderAsync_ShouldObserveCancellationBetweenStatements()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource();
+            var options = new TemplateOptions();
+            options.Filters.AddFilter("cancel", (input, arguments, context) =>
+            {
+                cancellationTokenSource.Cancel();
+                return input;
+            });
+            var context = new TemplateContext(options)
+            {
+                CancellationToken = cancellationTokenSource.Token
+            };
+            _parser.TryParse("{{ '' | cancel }}{{ 'unreachable' }}", out var template);
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => template.RenderAsync(context).AsTask());
+        }
+
+        [Fact]
+        public async Task RenderAsync_ShouldObserveCancellationAfterTheLastStatement()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource();
+            var options = new TemplateOptions();
+            options.Filters.AddFilter("cancel", (input, arguments, context) =>
+            {
+                cancellationTokenSource.Cancel();
+                return input;
+            });
+            var context = new TemplateContext(options)
+            {
+                CancellationToken = cancellationTokenSource.Token
+            };
+            _parser.TryParse("{{ '' | cancel }}", out var template);
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => template.RenderAsync(context).AsTask());
         }
 
         [Theory]

--- a/Fluid.ViewEngine/FileProviderMapper.cs
+++ b/Fluid.ViewEngine/FileProviderMapper.cs
@@ -1,10 +1,12 @@
 ﻿using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Fluid.ViewEngine
 {
-    public class FileProviderMapper : IFileProvider
+    public class FileProviderMapper : IFileProvider, ITemplateFileProvider
     {
         private readonly IFileProvider _fileProvider;
         private readonly string _mappedFolder;
@@ -30,6 +32,25 @@ namespace Fluid.ViewEngine
         {
             var path = _mappedFolder + subpath;
             return _fileProvider.GetFileInfo(path);
+        }
+
+        public ValueTask<TemplateSourceInfo> GetFileInfoAsync(
+            string subpath,
+            TemplateContext context,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var fileInfo = GetFileInfo(subpath);
+            if (fileInfo == null || !fileInfo.Exists || fileInfo.IsDirectory)
+            {
+                return default;
+            }
+
+            return new ValueTask<TemplateSourceInfo>(
+                new TemplateSourceInfo(
+                    fileInfo.LastModified,
+                    _ => new ValueTask<Stream>(fileInfo.CreateReadStream())));
         }
 
         public IChangeToken Watch(string filter)

--- a/Fluid.ViewEngine/FluidViewEngineOptions.cs
+++ b/Fluid.ViewEngine/FluidViewEngineOptions.cs
@@ -1,4 +1,3 @@
-﻿using Microsoft.Extensions.FileProviders;
 using System.Collections.Generic;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
@@ -26,14 +25,14 @@ namespace Fluid.ViewEngine
         public TemplateOptions TemplateOptions { get; } = new TemplateOptions();
 
         /// <summary>
-        /// Gets or sets the <see cref="IFileProvider"/> used to access views.
+        /// Gets or sets the <see cref="ITemplateFileProvider"/> used to access views.
         /// </summary>
-        public IFileProvider ViewsFileProvider { get; set; }
+        public ITemplateFileProvider ViewsFileProvider { get; set; }
 
         /// <summary>
-        /// Gets or sets the <see cref="IFileProvider"/> used to access includes.
+        /// Gets or sets the <see cref="ITemplateFileProvider"/> used to access includes.
         /// </summary>
-        public IFileProvider PartialsFileProvider { get; set; }
+        public ITemplateFileProvider PartialsFileProvider { get; set; }
 
         /// <summary>
         /// Gets the list of view location format strings. The formatting arguments can differ for each implementation of <see cref="IFluidViewRenderer"/>.

--- a/Fluid.ViewEngine/FluidViewRenderer.cs
+++ b/Fluid.ViewEngine/FluidViewRenderer.cs
@@ -1,11 +1,11 @@
 ﻿using Fluid.Ast;
 using Fluid.Parser;
 using Fluid.Utils;
-using Microsoft.Extensions.FileProviders;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Fluid.ViewEngine
@@ -17,22 +17,38 @@ namespace Fluid.ViewEngine
     {
         private static readonly char[] PathSeparators = { '/', '\\' };
 
-        private record struct LayoutKey (string ViewPath, string LayoutPath);
-
-        private class CacheEntry
+        private sealed class CacheEntry
         {
-            public IDisposable Callback;
-            public ConcurrentDictionary<string, IFluidTemplate> TemplateCache = new();
+            public ConcurrentDictionary<string, AsyncTemplateCacheEntry> TemplateCache = new();
         }
 
-        private readonly ConcurrentDictionary<IFileProvider, CacheEntry> _cache = new();
-        private readonly ConcurrentDictionary<LayoutKey, string> _layoutsCache = new();
+        private sealed record AsyncTemplateCacheEntry(
+            IFluidTemplate Template,
+            IReadOnlyList<TemplateSourceVersion> Sources);
+
+        private readonly record struct TemplateSourceVersion(
+            string Path,
+            string CacheKey,
+            DateTimeOffset LastModified);
+
+        private readonly record struct ResolvedTemplateSource(string Path, TemplateSourceInfo Source);
+
+        private readonly ConcurrentDictionary<ITemplateFileProvider, CacheEntry> _cache = new();
+        private readonly ITemplateFileProvider _viewsFileProvider;
+        private readonly ITemplateFileProvider _partialsFileProvider;
 
         public FluidViewRenderer(FluidViewEngineOptions fluidViewEngineOptions)
         {
             _fluidViewEngineOptions = fluidViewEngineOptions;
 
-            _fluidViewEngineOptions.TemplateOptions.FileProvider = _fluidViewEngineOptions.PartialsFileProvider ?? _fluidViewEngineOptions.ViewsFileProvider ?? new NullFileProvider();
+            _viewsFileProvider =
+                _fluidViewEngineOptions.ViewsFileProvider ??
+                _fluidViewEngineOptions.TemplateOptions.FileProvider;
+            _partialsFileProvider =
+                _fluidViewEngineOptions.PartialsFileProvider ??
+                _fluidViewEngineOptions.ViewsFileProvider ??
+                _fluidViewEngineOptions.TemplateOptions.FileProvider;
+            _fluidViewEngineOptions.TemplateOptions.FileProvider = _partialsFileProvider;
         }
 
         private readonly FluidViewEngineOptions _fluidViewEngineOptions;
@@ -50,19 +66,26 @@ namespace Fluid.ViewEngine
                 bufferSize = 16 * 1024;
             }
 
-            await using var output = new TextWriterFluidOutput(writer, bufferSize, leaveOpen: true, allowSynchronousIO: false);
+            await using var output = new TextWriterFluidOutput(
+                writer,
+                bufferSize,
+                leaveOpen: true,
+                allowSynchronousIO: false,
+                cancellationToken: context.CancellationToken);
             await RenderViewAsync(output, relativePath, context);
             await output.FlushAsync();
         }
 
         public virtual async Task RenderViewAsync(IFluidOutput output, string relativePath, TemplateContext context)
         {
+            context.CancellationToken.ThrowIfCancellationRequested();
+
             // Provide some services to all statements
             context.AmbientValues[Constants.ViewPathIndex] = relativePath;
             context.AmbientValues[Constants.SectionsIndex] = null; // it is lazily initialized when first used
             context.AmbientValues[Constants.RendererIndex] = this;
 
-            var template = await GetFluidTemplateAsync(relativePath, _fluidViewEngineOptions.ViewsFileProvider, true);
+            var template = await GetFluidTemplateAsync(relativePath, _viewsFileProvider, true, context);
 
             if (_fluidViewEngineOptions.RenderingViewAsync != null)
             {
@@ -79,13 +102,21 @@ namespace Fluid.ViewEngine
             // If a layout is specified while rendering a view, execute it
             if (context.AmbientValues.TryGetValue(Constants.LayoutIndex, out var layoutPath) && layoutPath is string layoutPathString && !String.IsNullOrEmpty(layoutPathString))
             {
-                layoutPathString = ResolveLayoutPath(relativePath, layoutPathString, _fluidViewEngineOptions.ViewsFileProvider);
+                layoutPathString = await ResolveLayoutPathAsync(
+                    relativePath,
+                    layoutPathString,
+                    _viewsFileProvider,
+                    context);
 
                 context.AmbientValues[Constants.ViewPathIndex] = layoutPathString;
                 context.AmbientValues[Constants.BodyIndex] = body;
 
                 // Parse the Layout file but ignore viewstarts
-                var layoutTemplate = await GetFluidTemplateAsync(layoutPathString, _fluidViewEngineOptions.ViewsFileProvider, includeViewStarts: false);
+                var layoutTemplate = await GetFluidTemplateAsync(
+                    layoutPathString,
+                    _viewsFileProvider,
+                    includeViewStarts: false,
+                    context);
 
                 await layoutTemplate.RenderAsync(output, _fluidViewEngineOptions.TextEncoder, context);
             }
@@ -108,13 +139,20 @@ namespace Fluid.ViewEngine
                 bufferSize = 16 * 1024;
             }
 
-            await using var output = new TextWriterFluidOutput(writer, bufferSize, leaveOpen: true, allowSynchronousIO: false);
+            await using var output = new TextWriterFluidOutput(
+                writer,
+                bufferSize,
+                leaveOpen: true,
+                allowSynchronousIO: false,
+                cancellationToken: context.CancellationToken);
             await RenderPartialAsync(output, relativePath, context);
             await output.FlushAsync();
         }
 
         public virtual async Task RenderPartialAsync(IFluidOutput output, string relativePath, TemplateContext context)
         {
+            context.CancellationToken.ThrowIfCancellationRequested();
+
             // Substitute View Path
             context.AmbientValues[Constants.ViewPathIndex] = relativePath;
 
@@ -123,202 +161,199 @@ namespace Fluid.ViewEngine
                 await _fluidViewEngineOptions.RenderingViewAsync.Invoke(relativePath, context);
             }
 
-            var template = await GetFluidTemplateAsync(relativePath, _fluidViewEngineOptions.PartialsFileProvider, false);
+            var template = await GetFluidTemplateAsync(
+                relativePath,
+                _partialsFileProvider,
+                includeViewStarts: false,
+                context);
 
             await template.RenderAsync(output, _fluidViewEngineOptions.TextEncoder, context);
         }
 
-        protected virtual List<string> FindViewStarts(string viewPath, IFileProvider fileProvider)
+        private async ValueTask<string> ResolveLayoutPathAsync(
+            string viewPath,
+            string layoutPath,
+            ITemplateFileProvider fileProvider,
+            TemplateContext context)
         {
-            var viewStarts = new List<string>();
-            int index = viewPath.Length - 1;
-            
-            while (!String.IsNullOrEmpty(viewPath))
-            {
-                if (index == -1)
-                {
-                    return viewStarts;
-                }
-
-                index = viewPath.LastIndexOfAny(PathSeparators, index);
-
-                viewPath = viewPath.Substring(0, index + 1);
-
-                var viewStartPath = viewPath + Constants.ViewStartFilename;
-
-                var viewStartInfo = fileProvider.GetFileInfo(viewStartPath);
-
-                if (viewStartInfo.Exists)
-                {
-                    viewStarts.Add(viewStartPath);
-                }
-
-                index = index - 1;
-            }
-
-            viewStarts.Reverse();
-
-            return viewStarts;
-        }
-
-        protected virtual string ResolveLayoutPath(string viewPath, string layoutPath, IFileProvider fileProvider)
-        {
-            // When a partial view is referenced by name without a file extension, the following locations are searched in the stated order:
-            // Currently executing view's folder
-            // Directory graph above the view's folder
-            // options.LayoutsLocationFormats
-
             if (layoutPath.EndsWith(Constants.ViewExtension))
             {
                 return Path.Combine(Path.GetDirectoryName(viewPath), layoutPath);
             }
 
-            var key = new LayoutKey(viewPath, layoutPath);
+            var currentViewPath = viewPath;
+            var index = currentViewPath.Length - 1;
 
-            return _layoutsCache.GetOrAdd(key, k =>
+            while (!String.IsNullOrEmpty(currentViewPath))
             {
-                var layoutPath = k.LayoutPath;
-                var viewPath = k.ViewPath;
-
-                int index = viewPath.Length - 1;
-
-                while (!String.IsNullOrEmpty(viewPath))
+                if (index == -1)
                 {
-                    if (index == -1)
-                    {
-                        return layoutPath;
-                    }
-
-                    index = viewPath.LastIndexOfAny(PathSeparators, index);
-
-                    viewPath = viewPath.Substring(0, index + 1);
-
-                    var layoutPathPath = Path.Combine(viewPath, layoutPath) + Constants.ViewExtension;
-
-                    var layoutPathInfo = fileProvider.GetFileInfo(layoutPathPath);
-
-                    if (layoutPathInfo.Exists)
-                    {
-                        return layoutPathPath;
-                    }
-
-                    index = index - 1;
+                    return layoutPath;
                 }
 
-                // Not found in hierarchy, fall-back to LayoutsLocationFormats
+                index = currentViewPath.LastIndexOfAny(PathSeparators, index);
+                currentViewPath = currentViewPath.Substring(0, index + 1);
 
-                foreach (var location in _fluidViewEngineOptions.LayoutsLocationFormats)
+                var candidate = Path.Combine(currentViewPath, layoutPath) + Constants.ViewExtension;
+                if (await fileProvider.GetFileInfoAsync(candidate, context, context.CancellationToken) != null)
                 {
-                    var layoutPathPath = String.Format(location, Path.GetFileName(layoutPath));
-
-                    var layoutPathInfo = fileProvider.GetFileInfo(layoutPathPath);
-
-                    if (layoutPathInfo.Exists)
-                    {
-                        return layoutPathPath;
-                    }
+                    return candidate;
                 }
 
-                return layoutPath;
-            });
-        }
-
-        protected virtual async ValueTask<IFluidTemplate> GetFluidTemplateAsync(string path, IFileProvider fileProvider, bool includeViewStarts)
-        {
-            var cache = _cache.GetOrAdd(fileProvider, f =>
-            {
-                var cacheEntry = new CacheEntry();
-
-                if (_fluidViewEngineOptions.TrackFileChanges)
-                {
-                    Action<object> callback = null;
-
-                    callback = c =>
-                    {
-                        // The order here is important. We need to take the token and then apply our changes BEFORE
-                        // registering. This prevents us from possible having two change updates to process concurrently.
-                        //
-                        // If the file changes after we take the token, then we'll process the update immediately upon
-                        // registering the callback.
-
-                        var entry = (CacheEntry)c;
-                        var previousCallBack = entry.Callback;
-                        previousCallBack?.Dispose();
-                        var token = fileProvider.Watch("**/*" + Constants.ViewExtension);
-                        entry.TemplateCache.Clear();
-                        entry.Callback = token.RegisterChangeCallback(callback, c);
-                    };
-
-                    cacheEntry.Callback = fileProvider.Watch("**/*" + Constants.ViewExtension).RegisterChangeCallback(callback, cacheEntry);
-                }
-                return cacheEntry;
-            });
-
-            if (cache.TemplateCache.TryGetValue(path, out var template))
-            {
-                return template;
+                index--;
             }
 
-            template = await ParseLiquidFileAsync(path, fileProvider, includeViewStarts);
+            foreach (var location in _fluidViewEngineOptions.LayoutsLocationFormats)
+            {
+                var candidate = String.Format(location, Path.GetFileName(layoutPath));
+                if (await fileProvider.GetFileInfoAsync(candidate, context, context.CancellationToken) != null)
+                {
+                    return candidate;
+                }
+            }
 
-            // Allow user to modify the template before caching (e.g., apply visitors/rewriters)
+            return layoutPath;
+        }
+
+        private async ValueTask<IFluidTemplate> GetFluidTemplateAsync(
+            string path,
+            ITemplateFileProvider fileProvider,
+            bool includeViewStarts,
+            TemplateContext context)
+        {
+            var source = await fileProvider.GetFileInfoAsync(path, context, context.CancellationToken);
+            if (source == null)
+            {
+                return new FluidTemplate();
+            }
+
+            var sources = new List<ResolvedTemplateSource>();
+            if (includeViewStarts)
+            {
+                sources.AddRange(await FindViewStartSourcesAsync(path, fileProvider, context));
+            }
+
+            sources.Add(new ResolvedTemplateSource(path, source));
+
+            var cache = _cache.GetOrAdd(fileProvider, static _ => new CacheEntry());
+            var cacheKey = source.CacheKey ?? path;
+            if (cache.TemplateCache.TryGetValue(cacheKey, out var cachedTemplate) &&
+                SourcesMatch(
+                    cachedTemplate.Sources,
+                    sources,
+                    _fluidViewEngineOptions.TrackFileChanges))
+            {
+                return cachedTemplate.Template;
+            }
+
+            var subTemplates = new List<IFluidTemplate>(sources.Count * 2);
+
+            for (var i = 0; i < sources.Count - 1; i++)
+            {
+                var viewStartPath = sources[i].Path;
+                subTemplates.Add(new FluidTemplate(new CallbackStatement((writer, encoder, templateContext) =>
+                {
+                    templateContext.AmbientValues[Constants.ViewPathIndex] = viewStartPath;
+                    return Statement.NormalCompletion;
+                })));
+
+                subTemplates.Add(await GetFluidTemplateAsync(viewStartPath, fileProvider, includeViewStarts: false, context));
+            }
+
+            subTemplates.Add(await ParseTemplateSourceAsync(source, context.CancellationToken));
+
+            IFluidTemplate template = new CompositeFluidTemplate(subTemplates);
+
             if (_fluidViewEngineOptions.TemplateOptions.TemplateParsed != null)
             {
                 template = _fluidViewEngineOptions.TemplateOptions.TemplateParsed(path, template);
             }
 
-            cache.TemplateCache[path] = template;
+            var versions = new TemplateSourceVersion[sources.Count];
+            for (var i = 0; i < sources.Count; i++)
+            {
+                versions[i] = new TemplateSourceVersion(
+                    sources[i].Path,
+                    sources[i].Source.CacheKey,
+                    sources[i].Source.LastModified);
+            }
 
+            cache.TemplateCache[cacheKey] = new AsyncTemplateCacheEntry(template, versions);
             return template;
         }
 
-        protected virtual async ValueTask<IFluidTemplate> ParseLiquidFileAsync(string path, IFileProvider fileProvider, bool includeViewStarts)
+        private static bool SourcesMatch(
+            IReadOnlyList<TemplateSourceVersion> cachedSources,
+            IReadOnlyList<ResolvedTemplateSource> sources,
+            bool compareLastModified)
         {
-            var fileInfo = fileProvider.GetFileInfo(path);
-
-            if (!fileInfo.Exists)
+            if (cachedSources.Count != sources.Count)
             {
-                return new FluidTemplate();
+                return false;
             }
 
-            var subTemplates = new List<IFluidTemplate>();
-                
-            if (includeViewStarts)
+            for (var i = 0; i < cachedSources.Count; i++)
             {
-                // Add ViewStart files
-                foreach (var viewStartPath in FindViewStarts(path, fileProvider))
+                if (!string.Equals(cachedSources[i].Path, sources[i].Path, StringComparison.Ordinal) ||
+                    !string.Equals(cachedSources[i].CacheKey, sources[i].Source.CacheKey, StringComparison.Ordinal) ||
+                    (compareLastModified &&
+                     cachedSources[i].LastModified < sources[i].Source.LastModified))
                 {
-                    // Redefine the current view path while processing ViewStart files
-                    var callbackTemplate = new FluidTemplate(new CallbackStatement((writer, encoder, context) =>
-                    {
-                        context.AmbientValues[Constants.ViewPathIndex] = viewStartPath;
-                        return Statement.NormalCompletion;
-                    }));
-
-                    var viewStartTemplate = await GetFluidTemplateAsync(viewStartPath, fileProvider, false);
-
-                    subTemplates.Add(callbackTemplate);
-                    subTemplates.Add(viewStartTemplate);
+                    return false;
                 }
             }
 
-            using (var stream = fileInfo.CreateReadStream())
-            {
-                using (var sr = new StreamReader(stream))
-                {
-                    var fileContent = sr.ReadToEnd();
-                    if (_fluidViewEngineOptions.Parser.TryParse(fileContent, out var template, out var errors))
-                    {
-                        subTemplates.Add(template);
-
-                        return new CompositeFluidTemplate(subTemplates);
-                    }
-                    else
-                    {
-                        throw new ParseException(errors);
-                    }
-                }
-            }
+            return true;
         }
+
+        private static async ValueTask<List<ResolvedTemplateSource>> FindViewStartSourcesAsync(
+            string viewPath,
+            ITemplateFileProvider fileProvider,
+            TemplateContext context)
+        {
+            var viewStarts = new List<ResolvedTemplateSource>();
+            var index = viewPath.Length - 1;
+
+            while (!String.IsNullOrEmpty(viewPath))
+            {
+                if (index == -1)
+                {
+                    break;
+                }
+
+                index = viewPath.LastIndexOfAny(PathSeparators, index);
+                viewPath = viewPath.Substring(0, index + 1);
+
+                var viewStartPath = viewPath + Constants.ViewStartFilename;
+                var source = await fileProvider.GetFileInfoAsync(
+                    viewStartPath,
+                    context,
+                    context.CancellationToken);
+                if (source != null)
+                {
+                    viewStarts.Add(new ResolvedTemplateSource(viewStartPath, source));
+                }
+
+                index--;
+            }
+
+            viewStarts.Reverse();
+            return viewStarts;
+        }
+
+        private async ValueTask<IFluidTemplate> ParseTemplateSourceAsync(
+            TemplateSourceInfo source,
+            CancellationToken cancellationToken)
+        {
+            var content = await source.ReadToEndAsync(cancellationToken);
+
+            if (_fluidViewEngineOptions.Parser.TryParse(content, out var template, out var errors))
+            {
+                return template;
+            }
+
+            throw new ParseException(errors);
+        }
+
     }
 }

--- a/Fluid/Ast/ForStatement.cs
+++ b/Fluid/Ast/ForStatement.cs
@@ -87,7 +87,7 @@ namespace Fluid.Ast
             // Avoid re-enumerating and allocating a new List<T> in this very hot path.
             IReadOnlyList<FluidValue> source = evaluatedSource is ArrayValue array
                 ? array.Values
-                : await evaluatedSource.EnumerateAsync(context).ToListAsync();
+                : await evaluatedSource.EnumerateAsync(context).ToListAsync(context.CancellationToken);
 
             if (source.Count == 0)
             {
@@ -320,7 +320,7 @@ namespace Fluid.Ast
             using (context.Indent())
             {
                 context.WriteLine("? array.Values");
-                context.WriteLine($": await evaluatedSource.EnumerateAsync({context.ContextName}).ToListAsync();");
+                context.WriteLine($": await evaluatedSource.EnumerateAsync({context.ContextName}).ToListAsync({context.ContextName}.CancellationToken);");
             }
             context.WriteLine("if (source.Count == 0)");
             context.WriteLine("{");

--- a/Fluid/Ast/FromStatement.cs
+++ b/Fluid/Ast/FromStatement.cs
@@ -10,8 +10,6 @@ namespace Fluid.Ast
     {
         public const string ViewExtension = ".liquid";
 
-        private volatile CachedTemplate _cachedTemplate;
-
         public FromStatement(FluidParser parser, Expression path, IReadOnlyList<string> functions = null)
         {
             Parser = parser;
@@ -33,33 +31,8 @@ namespace Fluid.Ast
                 relativePath += ViewExtension;
             }
 
-            var cachedTemplate = _cachedTemplate;
-
-            if (cachedTemplate == null || !string.Equals(cachedTemplate.Name, System.IO.Path.GetFileNameWithoutExtension(relativePath), StringComparison.Ordinal))
-            {
-                var fileProvider = context.Options.FileProvider;
-                var fileInfo = fileProvider.GetFileInfo(relativePath);
-                if (fileInfo == null || !fileInfo.Exists)
-                {
-                    throw new FileNotFoundException(relativePath);
-                }
-
-                var content = "";
-
-                using (var stream = fileInfo.CreateReadStream())
-                using (var streamReader = new StreamReader(stream))
-                {
-                    content = await streamReader.ReadToEndAsync();
-                }
-
-                if (!Parser.TryParse(content, out var template, out var errors))
-                {
-                    throw new ParseException(errors);
-                }
-
-                var identifier = System.IO.Path.GetFileNameWithoutExtension(relativePath);
-                _cachedTemplate = cachedTemplate = new CachedTemplate(template, identifier);
-            }
+            var loadedTemplate = await TemplateLoader.LoadAsync(Parser, relativePath, context, defaultFileExtension: null);
+            var template = loadedTemplate.Template;
 
             var parentScope = context.LocalScope;
 
@@ -68,7 +41,7 @@ namespace Fluid.Ast
 
             try
             {
-                await cachedTemplate.Template.RenderAsync(NullFluidOutput.Instance, encoder, context);
+                await template.RenderAsync(NullFluidOutput.Instance, encoder, context);
 
                 if (Functions.Count > 0)
                 {
@@ -102,7 +75,5 @@ namespace Fluid.Ast
         }
 
         protected internal override Statement Accept(AstVisitor visitor) => visitor.VisitFromStatement(this);
-
-        private sealed record CachedTemplate(IFluidTemplate Template, string Name);
     }
 }

--- a/Fluid/Ast/IncludeStatement.cs
+++ b/Fluid/Ast/IncludeStatement.cs
@@ -31,57 +31,13 @@ namespace Fluid.Ast
             context.IncrementSteps();
 
             var relativePath = (await Path.EvaluateAsync(context)).ToStringValue();
-            var fileProvider = context.Options.FileProvider;
-
-            // First, try to get the file with the exact path provided
-            var fileInfo = fileProvider.GetFileInfo(relativePath);
-
-            // If the file doesn't exist and a default extension is configured
-            if ((fileInfo == null || !fileInfo.Exists || fileInfo.IsDirectory) && !string.IsNullOrEmpty(context.Options.DefaultFileExtension))
-            {
-                // Check if the path already ends with the default extension
-                if (!relativePath.EndsWith(context.Options.DefaultFileExtension, StringComparison.OrdinalIgnoreCase))
-                {
-                    // Try adding the default extension
-                    var pathWithExtension = relativePath + context.Options.DefaultFileExtension;
-                    var fileInfoWithExtension = fileProvider.GetFileInfo(pathWithExtension);
-
-                    if (fileInfoWithExtension != null && fileInfoWithExtension.Exists && !fileInfoWithExtension.IsDirectory)
-                    {
-                        relativePath = pathWithExtension;
-                        fileInfo = fileInfoWithExtension;
-                    }
-                }
-            }
-
-            if (fileInfo == null || !fileInfo.Exists || fileInfo.IsDirectory)
-            {
-                throw new FileNotFoundException(relativePath);
-            }
-
-            if (context.Options.TemplateCache == null || !context.Options.TemplateCache.TryGetTemplate(relativePath, fileInfo.LastModified, out var template))
-            {
-                var content = "";
-
-                using (var stream = fileInfo.CreateReadStream())
-                using (var streamReader = new StreamReader(stream))
-                {
-                    content = await streamReader.ReadToEndAsync();
-                }
-
-                if (!Parser.TryParse(content, out template, out var errors))
-                {
-                    throw new ParseException(errors);
-                }
-
-                // Allow user to modify the template before caching (e.g., apply visitors/rewriters)
-                if (context.Options.TemplateParsed != null)
-                {
-                    template = context.Options.TemplateParsed(relativePath, template);
-                }
-
-                context.Options.TemplateCache?.SetTemplate(relativePath, fileInfo.LastModified, template);
-            }
+            var loadedTemplate = await TemplateLoader.LoadAsync(
+                Parser,
+                relativePath,
+                context,
+                context.Options.DefaultFileExtension);
+            relativePath = loadedTemplate.Path;
+            var template = loadedTemplate.Template;
 
             var identifier = System.IO.Path.GetFileNameWithoutExtension(relativePath);
 
@@ -140,7 +96,7 @@ namespace Fluid.Ast
                         // Fast-path: avoid re-enumerating already materialized arrays.
                         IReadOnlyList<FluidValue> list = evaluatedFor is ArrayValue array
                             ? array.Values
-                            : await evaluatedFor.EnumerateAsync(context).ToListAsync();
+                            : await evaluatedFor.EnumerateAsync(context).ToListAsync(context.CancellationToken);
 
                         var length = forloop.Length = list.Count;
 
@@ -228,6 +184,7 @@ namespace Fluid.Ast
                 await template.RenderAsync(output, encoder, context);
             }
 
+            context.CancellationToken.ThrowIfCancellationRequested();
             await output.FlushAsync();
             return Completion.Normal;
         }

--- a/Fluid/Ast/RenderStatement.cs
+++ b/Fluid/Ast/RenderStatement.cs
@@ -35,57 +35,13 @@ namespace Fluid.Ast
             context.IncrementSteps();
 
             var relativePath = Path;
-            var fileProvider = context.Options.FileProvider;
-
-            // First, try to get the file with the exact path provided
-            var fileInfo = fileProvider.GetFileInfo(relativePath);
-
-            // If the file doesn't exist and a default extension is configured
-            if ((fileInfo == null || !fileInfo.Exists || fileInfo.IsDirectory) && !string.IsNullOrEmpty(context.Options.DefaultFileExtension))
-            {
-                // Check if the path already ends with the default extension
-                if (!relativePath.EndsWith(context.Options.DefaultFileExtension, StringComparison.OrdinalIgnoreCase))
-                {
-                    // Try adding the default extension
-                    var pathWithExtension = relativePath + context.Options.DefaultFileExtension;
-                    var fileInfoWithExtension = fileProvider.GetFileInfo(pathWithExtension);
-
-                    if (fileInfoWithExtension != null && fileInfoWithExtension.Exists && !fileInfoWithExtension.IsDirectory)
-                    {
-                        relativePath = pathWithExtension;
-                        fileInfo = fileInfoWithExtension;
-                    }
-                }
-            }
-
-            if (fileInfo == null || !fileInfo.Exists || fileInfo.IsDirectory)
-            {
-                throw new FileNotFoundException(relativePath);
-            }
-
-            if (context.Options.TemplateCache == null || !context.Options.TemplateCache.TryGetTemplate(relativePath, fileInfo.LastModified, out var template))
-            {
-                var content = "";
-
-                using (var stream = fileInfo.CreateReadStream())
-                using (var streamReader = new StreamReader(stream))
-                {
-                    content = await streamReader.ReadToEndAsync();
-                }
-
-                if (!Parser.TryParse(content, out template, out var errors))
-                {
-                    throw new ParseException(errors);
-                }
-
-                // Allow user to modify the template before caching (e.g., apply visitors/rewriters)
-                if (context.Options.TemplateParsed != null)
-                {
-                    template = context.Options.TemplateParsed(relativePath, template);
-                }
-
-                context.Options.TemplateCache?.SetTemplate(relativePath, fileInfo.LastModified, template);
-            }
+            var loadedTemplate = await TemplateLoader.LoadAsync(
+                Parser,
+                relativePath,
+                context,
+                context.Options.DefaultFileExtension);
+            relativePath = loadedTemplate.Path;
+            var template = loadedTemplate.Template;
 
             var identifier = System.IO.Path.GetFileNameWithoutExtension(relativePath);
 
@@ -122,7 +78,7 @@ namespace Fluid.Ast
                         // Fast-path: avoid re-enumerating already materialized arrays.
                         IReadOnlyList<FluidValue> list = evaluatedFor is ArrayValue array
                             ? array.Values
-                            : await evaluatedFor.EnumerateAsync(context).ToListAsync();
+                            : await evaluatedFor.EnumerateAsync(context).ToListAsync(context.CancellationToken);
 
                         context.LocalScope = new Scope(context.RootScope);
                         previousScope.CopyTo(context.LocalScope);
@@ -286,7 +242,7 @@ namespace Fluid.Ast
                         using (context.Indent())
                         {
                             context.WriteLine("? array.Values");
-                            context.WriteLine($": await evaluatedFor.EnumerateAsync({context.ContextName}).ToListAsync();");
+                            context.WriteLine($": await evaluatedFor.EnumerateAsync({context.ContextName}).ToListAsync({context.ContextName}.CancellationToken);");
                         }
 
                         context.WriteLine($"{context.ContextName}.LocalScope = new Scope(rootScope);");

--- a/Fluid/Ast/TableRowStatement.cs
+++ b/Fluid/Ast/TableRowStatement.cs
@@ -43,7 +43,7 @@ namespace Fluid.Ast
 
             IReadOnlyList<FluidValue> source = evaluatedSource is ArrayValue array
                 ? array.Values
-                : await evaluatedSource.EnumerateAsync(context).ToListAsync();
+                : await evaluatedSource.EnumerateAsync(context).ToListAsync(context.CancellationToken);
 
             if (source.Count == 0)
             {

--- a/Fluid/DelegateTemplateFileProvider.cs
+++ b/Fluid/DelegateTemplateFileProvider.cs
@@ -1,0 +1,22 @@
+namespace Fluid;
+
+/// <summary>
+/// Provides asynchronous template files through a delegate.
+/// </summary>
+public sealed class DelegateTemplateFileProvider : ITemplateFileProvider
+{
+    private readonly Func<string, TemplateContext, CancellationToken, ValueTask<TemplateSourceInfo>> _getFileInfoAsync;
+
+    public DelegateTemplateFileProvider(
+        Func<string, TemplateContext, CancellationToken, ValueTask<TemplateSourceInfo>> getFileInfoAsync)
+    {
+        ArgumentNullException.ThrowIfNull(getFileInfoAsync);
+        _getFileInfoAsync = getFileInfoAsync;
+    }
+
+    public ValueTask<TemplateSourceInfo> GetFileInfoAsync(
+        string subpath,
+        TemplateContext context,
+        CancellationToken cancellationToken) =>
+        _getFileInfoAsync(subpath, context, cancellationToken);
+}

--- a/Fluid/FileProviderTemplateFileProvider.cs
+++ b/Fluid/FileProviderTemplateFileProvider.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.FileProviders;
+
+namespace Fluid;
+
+/// <summary>
+/// Adapts an <see cref="IFileProvider"/> to <see cref="ITemplateFileProvider"/>.
+/// </summary>
+public sealed class FileProviderTemplateFileProvider : ITemplateFileProvider
+{
+    private readonly IFileProvider _fileProvider;
+
+    public FileProviderTemplateFileProvider(IFileProvider fileProvider)
+    {
+        ArgumentNullException.ThrowIfNull(fileProvider);
+        _fileProvider = fileProvider;
+    }
+
+    public ValueTask<TemplateSourceInfo> GetFileInfoAsync(
+        string subpath,
+        TemplateContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var fileInfo = _fileProvider.GetFileInfo(subpath);
+        if (fileInfo == null || !fileInfo.Exists || fileInfo.IsDirectory)
+        {
+            return default;
+        }
+
+        return new ValueTask<TemplateSourceInfo>(
+            new TemplateSourceInfo(
+                fileInfo.LastModified,
+                _ => new ValueTask<Stream>(fileInfo.CreateReadStream())));
+    }
+}

--- a/Fluid/FluidOutputExtensions.cs
+++ b/Fluid/FluidOutputExtensions.cs
@@ -26,8 +26,13 @@ namespace Fluid
                 bufferSize = 16 * 1024;
             }
 
-            await using var output = new TextWriterFluidOutput(writer, bufferSize, leaveOpen: true);
+            await using var output = new TextWriterFluidOutput(
+                writer,
+                bufferSize,
+                leaveOpen: true,
+                cancellationToken: context.CancellationToken);
             var completion = await statement.WriteToAsync(output, encoder, context);
+            context.CancellationToken.ThrowIfCancellationRequested();
             await output.FlushAsync();
             return completion;
         }
@@ -45,8 +50,13 @@ namespace Fluid
                 bufferSize = 16 * 1024;
             }
 
-            await using var output = new TextWriterFluidOutput(writer, bufferSize, leaveOpen: true);
+            await using var output = new TextWriterFluidOutput(
+                writer,
+                bufferSize,
+                leaveOpen: true,
+                cancellationToken: context.CancellationToken);
             await template.RenderAsync(output, encoder, context);
+            context.CancellationToken.ThrowIfCancellationRequested();
             await output.FlushAsync();
         }
 

--- a/Fluid/FluidTemplateExtensions.String.cs
+++ b/Fluid/FluidTemplateExtensions.String.cs
@@ -44,6 +44,8 @@ namespace Fluid
             ArgumentNullException.ThrowIfNull(template);
             ArgumentNullException.ThrowIfNull(encoder);
 
+            context.CancellationToken.ThrowIfCancellationRequested();
+
             // Mirror the TextWriter-based overload: evaluate in a child scope so the provided TemplateContext is immutable.
             if (isolateContext)
             {
@@ -60,6 +62,7 @@ namespace Fluid
 
                 using var output = new BufferFluidOutput(initialCapacity);
                 await template.RenderAsync(output, encoder, context);
+                context.CancellationToken.ThrowIfCancellationRequested();
                 await output.FlushAsync();
                 return output.ToString();
             }

--- a/Fluid/FluidTemplateExtensions.cs
+++ b/Fluid/FluidTemplateExtensions.cs
@@ -48,6 +48,8 @@ namespace Fluid
             ArgumentNullException.ThrowIfNull(context);
             ArgumentNullException.ThrowIfNull(template);
 
+            context.CancellationToken.ThrowIfCancellationRequested();
+
             // A template is evaluated in a child scope such that the provided TemplateContext is immutable
             if (isolateContext)
             {
@@ -60,11 +62,16 @@ namespace Fluid
                 bufferSize = 16 * 1024;
             }
 
-            await using var output = new TextWriterFluidOutput(textWriter, bufferSize, leaveOpen: true);
+            await using var output = new TextWriterFluidOutput(
+                textWriter,
+                bufferSize,
+                leaveOpen: true,
+                cancellationToken: context.CancellationToken);
 
             try
             {
                 await template.RenderAsync(output, encoder, context);
+                context.CancellationToken.ThrowIfCancellationRequested();
                 await output.FlushAsync();
                 await textWriter.FlushAsync();
             }

--- a/Fluid/ITemplateFileProvider.cs
+++ b/Fluid/ITemplateFileProvider.cs
@@ -1,0 +1,19 @@
+namespace Fluid;
+
+/// <summary>
+/// Provides asynchronous access to template files.
+/// </summary>
+public interface ITemplateFileProvider
+{
+    /// <summary>
+    /// Asynchronously resolves a template source.
+    /// </summary>
+    /// <param name="subpath">The relative path that identifies the template.</param>
+    /// <param name="context">The context used for the current render.</param>
+    /// <param name="cancellationToken">The token used to cancel the asynchronous operation.</param>
+    /// <returns>The template source, or <see langword="null"/> when the path does not exist.</returns>
+    ValueTask<TemplateSourceInfo> GetFileInfoAsync(
+        string subpath,
+        TemplateContext context,
+        CancellationToken cancellationToken);
+}

--- a/Fluid/Parser/CompositeFluidTemplate.cs
+++ b/Fluid/Parser/CompositeFluidTemplate.cs
@@ -27,6 +27,8 @@ namespace Fluid.Parser
             ArgumentNullException.ThrowIfNull(encoder);
             ArgumentNullException.ThrowIfNull(context);
 
+            context.CancellationToken.ThrowIfCancellationRequested();
+
             var count = Statements.Count;
             for (var i = 0; i < count; i++)
             {
@@ -43,6 +45,7 @@ namespace Fluid.Parser
                 }
             }
 
+            context.CancellationToken.ThrowIfCancellationRequested();
             return output.FlushAsync();
         }
 
@@ -60,6 +63,7 @@ namespace Fluid.Parser
                 await statements[i].WriteToAsync(output, encoder, context);
             }
 
+            context.CancellationToken.ThrowIfCancellationRequested();
             await output.FlushAsync();
         }
 

--- a/Fluid/Parser/FluidTemplate.cs
+++ b/Fluid/Parser/FluidTemplate.cs
@@ -23,6 +23,8 @@ namespace Fluid.Parser
             ArgumentNullException.ThrowIfNull(encoder);
             ArgumentNullException.ThrowIfNull(context);
 
+            context.CancellationToken.ThrowIfCancellationRequested();
+
             var count = Statements.Count;
             for (var i = 0; i < count; i++)
             {
@@ -39,6 +41,7 @@ namespace Fluid.Parser
                 }
             }
 
+            context.CancellationToken.ThrowIfCancellationRequested();
             return output.FlushAsync();
         }
 
@@ -56,6 +59,7 @@ namespace Fluid.Parser
                 await statements[i].WriteToAsync(output, encoder, context);
             }
 
+            context.CancellationToken.ThrowIfCancellationRequested();
             await output.FlushAsync();
         }
     }

--- a/Fluid/SourceGeneration/TemplateSourceGenerator.cs
+++ b/Fluid/SourceGeneration/TemplateSourceGenerator.cs
@@ -91,6 +91,7 @@ namespace Fluid.SourceGeneration
                         ctx.WriteLine("if (encoder == null) throw new ArgumentNullException(nameof(encoder));");
                         ctx.WriteLine("if (context == null) throw new ArgumentNullException(nameof(context));");
                         ctx.WriteLine("if (context.Options.Trimming != TrimmingFlags.None) throw new NotSupportedException(\"Source-generated templates do not support TemplateOptions.Trimming.\");");
+                        ctx.WriteLine("context.CancellationToken.ThrowIfCancellationRequested();");
                         ctx.WriteLine();
 
                         foreach (var statement in statementList.Statements)
@@ -114,6 +115,7 @@ namespace Fluid.SourceGeneration
                             ctx.WriteLine($"_ = await {methodName}(writer, encoder, context);");
                         }
 
+                        ctx.WriteLine("context.CancellationToken.ThrowIfCancellationRequested();");
                         ctx.WriteLine("await writer.FlushAsync();");
                     }
                     ctx.WriteLine("}");

--- a/Fluid/TemplateContext.cs
+++ b/Fluid/TemplateContext.cs
@@ -127,11 +127,18 @@ namespace Fluid
         public JsonSerializerOptions JsonSerializerOptions { get; set; } = TemplateOptions.Default.JsonSerializerOptions;
 
         /// <summary>
+        /// Gets or sets the token used to cancel asynchronous template operations.
+        /// </summary>
+        public CancellationToken CancellationToken { get; set; }
+
+        /// <summary>
         /// Increments the number of statements the current template is processing.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void IncrementSteps()
         {
+            CancellationToken.ThrowIfCancellationRequested();
+
             if (MaxSteps > 0 && _steps++ > MaxSteps)
             {
                 ExceptionHelper.ThrowMaximumRecursionException();

--- a/Fluid/TemplateLoader.cs
+++ b/Fluid/TemplateLoader.cs
@@ -1,0 +1,57 @@
+namespace Fluid;
+
+internal static class TemplateLoader
+{
+    internal readonly record struct LoadedTemplate(string Path, IFluidTemplate Template);
+
+    public static async ValueTask<LoadedTemplate> LoadAsync(
+        FluidParser parser,
+        string path,
+        TemplateContext context,
+        string defaultFileExtension)
+    {
+        var resolvedPath = path;
+        var source = await GetSourceAsync(resolvedPath, context);
+
+        if (source == null &&
+            !string.IsNullOrEmpty(defaultFileExtension) &&
+            !resolvedPath.EndsWith(defaultFileExtension, StringComparison.OrdinalIgnoreCase))
+        {
+            resolvedPath += defaultFileExtension;
+            source = await GetSourceAsync(resolvedPath, context);
+        }
+
+        if (source == null)
+        {
+            throw new FileNotFoundException(path);
+        }
+
+        var cacheKey = source.CacheKey ?? resolvedPath;
+
+        if (context.Options.TemplateCache == null ||
+            !context.Options.TemplateCache.TryGetTemplate(cacheKey, source.LastModified, out var template))
+        {
+            var content = await source.ReadToEndAsync(context.CancellationToken);
+
+            if (!parser.TryParse(content, out template, out var errors))
+            {
+                throw new ParseException(errors);
+            }
+
+            if (context.Options.TemplateParsed != null)
+            {
+                template = context.Options.TemplateParsed(resolvedPath, template);
+            }
+
+            context.Options.TemplateCache?.SetTemplate(cacheKey, source.LastModified, template);
+        }
+
+        return new LoadedTemplate(resolvedPath, template);
+    }
+
+    private static ValueTask<TemplateSourceInfo> GetSourceAsync(string path, TemplateContext context)
+    {
+        context.CancellationToken.ThrowIfCancellationRequested();
+        return context.Options.FileProvider.GetFileInfoAsync(path, context, context.CancellationToken);
+    }
+}

--- a/Fluid/TemplateOptions.cs
+++ b/Fluid/TemplateOptions.cs
@@ -79,9 +79,10 @@ namespace Fluid
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="IFileProvider"/> used to access files for include and render statements.
+        /// Gets or sets the <see cref="ITemplateFileProvider"/> used to access files for include, render, and from statements.
         /// </summary>
-        public IFileProvider FileProvider { get; set; } = new NullFileProvider();
+        public ITemplateFileProvider FileProvider { get; set; } =
+            new FileProviderTemplateFileProvider(new NullFileProvider());
 
         /// <summary>
         /// Gets or sets the <see cref="ITemplateCache"/> used to cache templates loaded from <see cref="FileProvider"/>.

--- a/Fluid/TemplateSourceInfo.cs
+++ b/Fluid/TemplateSourceInfo.cs
@@ -1,0 +1,79 @@
+namespace Fluid;
+
+/// <summary>
+/// Represents a template source that can be read asynchronously.
+/// </summary>
+public sealed class TemplateSourceInfo
+{
+    private readonly Func<CancellationToken, ValueTask<Stream>> _openReadAsync;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="TemplateSourceInfo"/>.
+    /// </summary>
+    /// <param name="lastModified">The last modification date used to invalidate parsed templates.</param>
+    /// <param name="openReadAsync">A delegate that asynchronously opens the template content.</param>
+    /// <param name="cacheKey">
+    /// An optional cache key that uniquely identifies this source across rendering contexts.
+    /// The requested path is used when this value is <see langword="null"/>.
+    /// </param>
+    public TemplateSourceInfo(
+        DateTimeOffset lastModified,
+        Func<CancellationToken, ValueTask<Stream>> openReadAsync,
+        string cacheKey = null)
+    {
+        ArgumentNullException.ThrowIfNull(openReadAsync);
+
+        LastModified = lastModified;
+        _openReadAsync = openReadAsync;
+        CacheKey = cacheKey;
+    }
+
+    /// <summary>
+    /// Gets the last modification date used to invalidate parsed templates.
+    /// </summary>
+    public DateTimeOffset LastModified { get; }
+
+    /// <summary>
+    /// Gets the cache key that uniquely identifies this source across rendering contexts.
+    /// </summary>
+    public string CacheKey { get; }
+
+    /// <summary>
+    /// Asynchronously opens the template content.
+    /// </summary>
+    /// <param name="cancellationToken">The token used to cancel the asynchronous operation.</param>
+    public ValueTask<Stream> OpenReadAsync(CancellationToken cancellationToken = default) =>
+        _openReadAsync(cancellationToken);
+
+    /// <summary>
+    /// Asynchronously reads the template content.
+    /// </summary>
+    /// <param name="cancellationToken">The token used to cancel the asynchronous operation.</param>
+    public async ValueTask<string> ReadToEndAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        using var stream = await OpenReadAsync(cancellationToken);
+        using var reader = new StreamReader(stream);
+#if NET8_0_OR_GREATER
+        return await reader.ReadToEndAsync(cancellationToken);
+#else
+        using var registration = cancellationToken.Register(static state => ((Stream) state).Dispose(), stream);
+
+        try
+        {
+            var content = await reader.ReadToEndAsync();
+            cancellationToken.ThrowIfCancellationRequested();
+            return content;
+        }
+        catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException(cancellationToken);
+        }
+        catch (IOException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException(cancellationToken);
+        }
+#endif
+    }
+}

--- a/Fluid/Utils/TextWriterFluidOutput.cs
+++ b/Fluid/Utils/TextWriterFluidOutput.cs
@@ -7,11 +7,28 @@ namespace Fluid.Utils
         private readonly TextWriter _writer;
         private readonly bool _leaveOpen;
         private readonly bool _allowSynchronousIO;
+        private readonly CancellationToken _cancellationToken;
         private readonly ArrayPool<char> _pool;
         private char[] _buffer;
         private int _index;
 
-        public TextWriterFluidOutput(TextWriter writer, int bufferSize, bool leaveOpen = false, ArrayPool<char> pool = null, bool allowSynchronousIO = true)
+        public TextWriterFluidOutput(
+            TextWriter writer,
+            int bufferSize,
+            bool leaveOpen = false,
+            ArrayPool<char> pool = null,
+            bool allowSynchronousIO = true)
+            : this(writer, bufferSize, default, leaveOpen, pool, allowSynchronousIO)
+        {
+        }
+
+        public TextWriterFluidOutput(
+            TextWriter writer,
+            int bufferSize,
+            CancellationToken cancellationToken,
+            bool leaveOpen = false,
+            ArrayPool<char> pool = null,
+            bool allowSynchronousIO = true)
         {
             ArgumentNullException.ThrowIfNull(writer);
 
@@ -27,6 +44,7 @@ namespace Fluid.Utils
             _writer = writer;
             _leaveOpen = leaveOpen;
             _allowSynchronousIO = allowSynchronousIO;
+            _cancellationToken = cancellationToken;
             _pool = pool ?? ArrayPool<char>.Shared;
             _buffer = _pool.Rent(bufferSize);
         }
@@ -102,14 +120,17 @@ namespace Fluid.Utils
 
         public ValueTask FlushAsync()
         {
+            _cancellationToken.ThrowIfCancellationRequested();
+
             if (_index == 0)
             {
                 return default;
             }
 
-            var task = _writer.WriteAsync(_buffer, 0, _index);
+            var task = WriteAsync(_buffer, 0, _index);
             if (task.IsCompletedSuccessfully())
             {
+                _cancellationToken.ThrowIfCancellationRequested();
                 _index = 0;
                 return default;
             }
@@ -119,6 +140,7 @@ namespace Fluid.Utils
             static async ValueTask Awaited(Task t, TextWriterFluidOutput output)
             {
                 await t.ConfigureAwait(false);
+                output._cancellationToken.ThrowIfCancellationRequested();
                 output._index = 0;
             }
         }
@@ -127,7 +149,10 @@ namespace Fluid.Utils
         {
             if (_buffer != null)
             {
-                FlushCoreSync();
+                if (!_cancellationToken.IsCancellationRequested)
+                {
+                    FlushCoreSync();
+                }
 
                 var toReturn = _buffer;
                 _buffer = null;
@@ -144,7 +169,10 @@ namespace Fluid.Utils
         {
             if (_buffer != null)
             {
-                await FlushAsync();
+                if (!_cancellationToken.IsCancellationRequested)
+                {
+                    await FlushAsync();
+                }
 
                 var toReturn = _buffer;
                 _buffer = null;
@@ -215,6 +243,8 @@ namespace Fluid.Utils
         // sync writes when allowed, async API when synchronous IO is disallowed.
         private void FlushCoreWithPolicy()
         {
+            _cancellationToken.ThrowIfCancellationRequested();
+
             if (_index == 0)
             {
                 return;
@@ -226,7 +256,8 @@ namespace Fluid.Utils
             }
             else
             {
-                CompleteSynchronously(_writer.WriteAsync(_buffer, 0, _index));
+                CompleteSynchronously(WriteAsync(_buffer, 0, _index));
+                _cancellationToken.ThrowIfCancellationRequested();
             }
 
             _index = 0;
@@ -247,27 +278,55 @@ namespace Fluid.Utils
         // Writes large string payloads directly to the underlying writer, bypassing the buffer.
         private void WriteDirect(string value)
         {
+            _cancellationToken.ThrowIfCancellationRequested();
+
             if (_allowSynchronousIO)
             {
                 _writer.Write(value);
             }
             else
             {
-                CompleteSynchronously(_writer.WriteAsync(value));
+                CompleteSynchronously(WriteAsync(value));
+                _cancellationToken.ThrowIfCancellationRequested();
             }
         }
 
         // Writes large char[] payloads directly to the underlying writer, bypassing the buffer.
         private void WriteDirect(char[] buffer, int index, int count)
         {
+            _cancellationToken.ThrowIfCancellationRequested();
+
             if (_allowSynchronousIO)
             {
                 _writer.Write(buffer, index, count);
             }
             else
             {
-                CompleteSynchronously(_writer.WriteAsync(buffer, index, count));
+                CompleteSynchronously(WriteAsync(buffer, index, count));
+                _cancellationToken.ThrowIfCancellationRequested();
             }
+        }
+
+        private Task WriteAsync(char[] buffer, int index, int count)
+        {
+#if NET8_0_OR_GREATER
+            if (_cancellationToken.CanBeCanceled)
+            {
+                return _writer.WriteAsync(buffer.AsMemory(index, count), _cancellationToken);
+            }
+#endif
+            return _writer.WriteAsync(buffer, index, count);
+        }
+
+        private Task WriteAsync(string value)
+        {
+#if NET8_0_OR_GREATER
+            if (_cancellationToken.CanBeCanceled)
+            {
+                return _writer.WriteAsync(value.AsMemory(), _cancellationToken);
+            }
+#endif
+            return _writer.WriteAsync(value);
         }
     }
 }

--- a/Fluid/Values/ArrayValue.cs
+++ b/Fluid/Values/ArrayValue.cs
@@ -135,6 +135,7 @@ namespace Fluid.Values
         {
             foreach (var value in Values)
             {
+                context?.CancellationToken.ThrowIfCancellationRequested();
                 yield return value;
             }
 

--- a/MinimalApis.LiquidViews/ActionViewResult.cs
+++ b/MinimalApis.LiquidViews/ActionViewResult.cs
@@ -4,8 +4,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using System;
-using System.Collections.Concurrent;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Fluid.Utils;
 
@@ -15,8 +15,6 @@ namespace MinimalApis.LiquidViews
     {
         private readonly string _viewName;
         private readonly object _model;
-
-        private readonly static ConcurrentDictionary<string, string> _viewLocationsCache = new();
 
         public ActionViewResult(string viewName)
         {
@@ -36,8 +34,20 @@ namespace MinimalApis.LiquidViews
         {
             var fluidViewRenderer = httpContext.RequestServices.GetService<IFluidViewRenderer>();
             var options = httpContext.RequestServices.GetService<IOptions<FluidViewEngineOptions>>().Value;
+            var context = new TemplateContext(_model, options.TemplateOptions)
+            {
+                CancellationToken = httpContext.RequestAborted
+            };
+            context.Options.FileProvider =
+                options.PartialsFileProvider ??
+                options.ViewsFileProvider ??
+                options.TemplateOptions.FileProvider;
 
-            var viewPath = LocatePageFromViewLocations(_viewName, options);
+            var viewPath = await LocatePageFromViewLocationsAsync(
+                _viewName,
+                options,
+                context,
+                httpContext.RequestAborted);
 
             if (viewPath == null)
             {
@@ -48,9 +58,6 @@ namespace MinimalApis.LiquidViews
             httpContext.Response.StatusCode = 200;
             httpContext.Response.ContentType = ContentType;
 
-            var context = new TemplateContext(_model, options.TemplateOptions);
-            context.Options.FileProvider = options.PartialsFileProvider;
-
             await using var sw = new StreamWriter(httpContext.Response.Body);
             var bufferSize = context.Options.OutputBufferSize;
             if (bufferSize <= 0)
@@ -58,29 +65,33 @@ namespace MinimalApis.LiquidViews
                 bufferSize = 16 * 1024;
             }
 
-            await using var output = new TextWriterFluidOutput(sw, bufferSize, leaveOpen: true, allowSynchronousIO: false);
+            await using var output = new TextWriterFluidOutput(
+                sw,
+                bufferSize,
+                httpContext.RequestAborted,
+                leaveOpen: true,
+                allowSynchronousIO: false);
             await fluidViewRenderer.RenderViewAsync(output, viewPath, context);
             await output.FlushAsync();
+            await sw.FlushAsync(httpContext.RequestAborted);
         }
 
-        private static string LocatePageFromViewLocations(string viewName, FluidViewEngineOptions options)
+        private static async ValueTask<string> LocatePageFromViewLocationsAsync(
+            string viewName,
+            FluidViewEngineOptions options,
+            TemplateContext context,
+            CancellationToken cancellationToken)
         {
-            if (_viewLocationsCache.TryGetValue(viewName, out var cachedLocation) && cachedLocation != null)
-            {
-                return cachedLocation;
-            }
-
-            var fileProvider = options.ViewsFileProvider;
+            var fileProvider = options.ViewsFileProvider ?? options.TemplateOptions.FileProvider;
 
             foreach (var location in options.ViewsLocationFormats)
             {
                 var viewFilename = Path.Combine(String.Format(location, viewName));
 
-                var fileInfo = fileProvider.GetFileInfo(viewFilename);
+                var fileInfo = await fileProvider.GetFileInfoAsync(viewFilename, context, cancellationToken);
 
-                if (fileInfo.Exists)
+                if (fileInfo != null)
                 {
-                    _viewLocationsCache[viewName] = viewFilename;
                     return viewFilename;
                 }
             }

--- a/README.md
+++ b/README.md
@@ -520,6 +520,51 @@ With this setting, both model properties and context properties are accessible u
 {{ firstName }} {{ lastName }}
 ```
 
+### Loading templates asynchronously
+
+`TemplateOptions.FileProvider` uses the asynchronous `ITemplateFileProvider` contract. Templates stored in a remote service can be loaded without blocking:
+
+```csharp
+var options = new TemplateOptions
+{
+    FileProvider = new DelegateTemplateFileProvider(async (path, context, cancellationToken) =>
+    {
+        var metadata = await templateStore.GetMetadataAsync(path, cancellationToken);
+        if (metadata is null)
+        {
+            return null;
+        }
+
+        return new TemplateSourceInfo(
+            metadata.LastModified,
+            async cancellationToken => await templateStore.OpenReadAsync(path, cancellationToken),
+            cacheKey: $"{tenantId}:{path}");
+    })
+};
+
+var context = new TemplateContext(options)
+{
+    CancellationToken = requestAborted
+};
+var result = await template.RenderAsync(context);
+```
+
+The provider returns `null` when a path does not exist. Fluid tries the requested path first, then appends `DefaultFileExtension` when necessary.
+
+Fluid calls the provider to obtain the source version before checking its parsed-template cache. The stream is opened only on a cache miss. `LastModified` must advance whenever the content changes; remote implementations can cache metadata themselves if checking it requires a network request. When a provider can return different content for the same path in different contexts, set `TemplateSourceInfo.CacheKey` to a stable value that includes the tenant or other source identity.
+
+Existing `Microsoft.Extensions.FileProviders.IFileProvider` implementations can be adapted:
+
+```csharp
+options.FileProvider = new FileProviderTemplateFileProvider(existingFileProvider);
+```
+
+`FluidViewEngineOptions.ViewsFileProvider` and `PartialsFileProvider` use the same asynchronous contract for views, layouts, `_ViewStart` files, and partials. ASP.NET Core MVC view-name discovery remains synchronous because `IViewEngine.FindView` has no asynchronous contract; configure `FluidMvcViewOptions.ViewLocationFileProvider` with an `IFileProvider` for that lookup.
+
+Always use `RenderAsync` with an asynchronous provider. The synchronous `Render` APIs must block if the provider suspends.
+
+`TemplateContext.CancellationToken` is also checked at render entry, between statements, on loop iterations and built-in array enumeration, and before buffered output is flushed. Custom filters and `FluidValue` implementations receive the context and should check the token during long-running work.
+
 <br>
 
 ## Execution limits
@@ -1531,7 +1576,10 @@ Console.WriteLine(result); // writes -1
 You can apply visitors and rewriters to templates that are parsed before they are cached by using the `TemplateParsed` callback on `TemplateOptions`. This works for all template parsing scenarios including the ViewEngine, `include` and `render` statements.
 
 ```c#
-var options = new TemplateOptions { FileProvider = fileProvider };
+var options = new TemplateOptions
+{
+    FileProvider = new FileProviderTemplateFileProvider(fileProvider)
+};
 options.TemplateParsed = (path, template) =>
 {
     var visitor = new MyCustomVisitor();


### PR DESCRIPTION
Remote template stores such as S3, Azure Blob Storage, and databases expose asynchronous APIs, but Fluid previously resolved runtime templates through synchronous `IFileProvider` calls. This forced integrations to block during template lookup and content reads.

## Summary

- Introduces `ITemplateFileProvider` and `TemplateSourceInfo` for two-stage asynchronous metadata and content loading, including source versions and context-specific cache keys.
- Adds adapters for existing `IFileProvider` implementations and delegate-based custom providers.
- Routes `include`, `render`, `from`, views, partials, layouts, and `_ViewStart` files through the async provider contract.
- Propagates `TemplateContext.CancellationToken` through loading, rendering checkpoints, enumeration, generated templates, and output writes. MVC and Minimal APIs use the request cancellation token.
- Keeps MVC named-view discovery on a separate synchronous provider because ASP.NET Core's `IViewEngine` contract is synchronous.

## Migration

This is an intentional Fluid 3.0 source-breaking change: `TemplateOptions.FileProvider` and the ViewEngine provider properties now accept `ITemplateFileProvider`. Existing providers can be wrapped with `FileProviderTemplateFileProvider`.

## Tests

- `dotnet build --no-restore --nologo`
- `dotnet test --no-build --no-restore`
- `dotnet test --no-restore /p:Compiled=true`

Fixes: #955