### PR TITLE
Fixed invalid configuration in the Fluid.SourceGenerator when packing to NuGet

### DIFF
--- a/Fluid.SourceGenerator/Fluid.SourceGenerator.csproj
+++ b/Fluid.SourceGenerator/Fluid.SourceGenerator.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Fluid\Fluid.csproj" />
+    <ProjectReference Include="..\Fluid\Fluid.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="EmbedAnalyzerRuntimeDependencies" AfterTargets="ResolveReferences" BeforeTargets="PrepareResources">
@@ -49,5 +49,12 @@
       </EmbeddedResource>
     </ItemGroup>
   </Target>
+
+  <ItemGroup>
+  <None Include="$(OutputPath)\*.dll" 
+          Pack="true" 
+          PackagePath="analyzers/dotnet/cs" 
+          Visible="false" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Fixed invalid configuration in the Fluid.SourceGenerator when packing to NuGet

### Problem
- The `.csproj` did not include a `<None />` entry for the generator and its dependencies, so they were not placed into the `analyzers/dotnet/cs/` directory during `dotnet pack`. As a result, the source generator was not discoverable by consuming projects.
- The `Fluid` project reference was not marked with `PrivateAssets="all"`, causing dependency conflicts with `Fluid.Core` when installed via NuGet.
- The behaviour was seen in both `main` branch of git repository and in the compiled nuget package `Fluid.SourceGenerator` for version `3.0.0-beta.6`. 

### Solution
- Added proper `<None />` entries for the generator assembly and its dependencies.
- Marked the `Fluid` project reference with `PrivateAssets="all"` to prevent version conflicts.

### Impact
- The source generator is now correctly packaged and usable via NuGet local feed without type collisions.
- Verified that all source generator tests in `Fluid.Tests` pass.