### PR TITLE
Harden Fluid against template resource exhaustion

### DIFF
--- a/Fluid.Tests/MemberAccessStrategyTests.cs
+++ b/Fluid.Tests/MemberAccessStrategyTests.cs
@@ -41,6 +41,47 @@ namespace Fluid.Tests
         }
 
         [Fact]
+        public void ReflectedAccessorsShouldVaryByStringComparer()
+        {
+            var strategy = new DefaultMemberAccessStrategy();
+
+            Assert.NotNull(strategy.GetAccessor(typeof(Class1), "property1", StringComparer.OrdinalIgnoreCase));
+            Assert.Null(strategy.GetAccessor(typeof(Class1), "property1", StringComparer.Ordinal));
+        }
+
+        [Fact]
+        public void WildcardRegistrationShouldOverridePreviouslyReflectedAccessor()
+        {
+            var strategy = new DefaultMemberAccessStrategy();
+            var reflected = strategy.GetAccessor(typeof(Class1), nameof(Class1.Property1), StringComparer.Ordinal);
+
+            Assert.NotNull(reflected);
+
+            strategy.Register<Class1, object>((instance, name) =>
+                name == nameof(Class1.Property2) ? instance.Property2 : null);
+
+            var accessor = strategy.GetAccessor(typeof(Class1), nameof(Class1.Property1), StringComparer.Ordinal);
+
+            Assert.NotSame(reflected, accessor);
+            Assert.Null(accessor.Get(new Class1(), nameof(Class1.Property1), new TemplateContext()));
+        }
+
+        [Fact]
+        public void BaseRegistrationChangesShouldInvalidateDerivedAccessors()
+        {
+            var strategy = new DefaultMemberAccessStrategy();
+            strategy.Register<Class1, object>((instance, name) => "first");
+
+            var first = strategy.GetAccessor(typeof(DerivedClass1), "custom", StringComparer.Ordinal);
+            Assert.Equal("first", first.Get(new DerivedClass1(), "custom", new TemplateContext()));
+
+            strategy.Register<Class1, object>((instance, name) => "second");
+
+            var second = strategy.GetAccessor(typeof(DerivedClass1), "custom", StringComparer.Ordinal);
+            Assert.Equal("second", second.Get(new DerivedClass1(), "custom", new TemplateContext()));
+        }
+
+        [Fact]
         public void RegisterByTypeUsesAotSafePropertyAccessorWhenDynamicCodeIsUnavailable()
         {
             var strategy = new DefaultMemberAccessStrategy();
@@ -344,6 +385,10 @@ namespace Fluid.Tests
         public int Property2 { get; set; }
         public Task<string> Property3 { get; set; }
         public string WriteOnlyProperty { private get; set; }
+    }
+
+    public sealed class DerivedClass1 : Class1
+    {
     }
 
     public sealed class GeneratedModel

--- a/Fluid.Tests/ResourceLimitTests.cs
+++ b/Fluid.Tests/ResourceLimitTests.cs
@@ -95,6 +95,42 @@ namespace Fluid.Tests
         }
 
         [Fact]
+        public async Task ExactEncodedOutputWithinLimitIsAllowed()
+        {
+            var template = new FluidParser().Parse("{{ value }}");
+            var context = new TemplateContext(new { value = "&" }) { MaxOutputSize = 5 };
+
+            Assert.Equal("&amp;", await template.RenderAsync(context, System.Text.Encodings.Web.HtmlEncoder.Default));
+        }
+
+        [Fact]
+        public async Task MaxOutputSizeDoesNotLimitShrinkingFilterInputs()
+        {
+            var template = new FluidParser().Parse("{{ 'aaaa' | replace: 'aa', '' }}");
+            var context = new TemplateContext { MaxOutputSize = 1 };
+
+            Assert.Equal("", await template.RenderAsync(context));
+        }
+
+        [Fact]
+        public async Task MaxOutputSizeDoesNotLimitSplitInputs()
+        {
+            var template = new FluidParser().Parse("{{ 'aaaa' | split: '' | size }}");
+            var context = new TemplateContext { MaxOutputSize = 1, MaxCollectionSize = 4 };
+
+            Assert.Equal("4", await template.RenderAsync(context));
+        }
+
+        [Fact]
+        public async Task ExactBase64UrlSafeOutputWithinLimitIsAllowed()
+        {
+            var template = new FluidParser().Parse("{{ '1' | base64_url_safe_encode }}");
+            var context = new TemplateContext { MaxOutputSize = 2 };
+
+            Assert.Equal("MQ", await template.RenderAsync(context));
+        }
+
+        [Fact]
         public async Task MaxCollectionSizeLimitsRangesBeforeAllocation()
         {
             var template = new FluidParser().Parse("{{ (1..5) | size }}");
@@ -128,6 +164,21 @@ namespace Fluid.Tests
 
             await Assert.ThrowsAsync<InvalidOperationException>(
                 () => template.RenderAsync(context).AsTask());
+        }
+
+        [Fact]
+        public async Task MaxCollectionSizeDoesNotLimitScalarArrayOperations()
+        {
+            var template = new FluidParser().Parse("{{ values | first }}");
+            var context = new TemplateContext(new
+            {
+                values = new[] { 1, 2, 3, 4, 5 }
+            })
+            {
+                MaxCollectionSize = 2
+            };
+
+            Assert.Equal("1", await template.RenderAsync(context));
         }
 
         [Fact]

--- a/Fluid.Tests/ResourceLimitTests.cs
+++ b/Fluid.Tests/ResourceLimitTests.cs
@@ -1,0 +1,181 @@
+using Fluid.Values;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Fluid.Tests
+{
+    public class ResourceLimitTests
+    {
+        [Fact]
+        public async Task MaxOutputSizeLimitsStringRendering()
+        {
+            var template = new FluidParser().Parse("12345");
+            var context = new TemplateContext { MaxOutputSize = 4 };
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => template.RenderAsync(context).AsTask());
+
+            Assert.Contains("maximum template output size", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task MaxOutputSizeLimitsTextWriterRendering()
+        {
+            var template = new FluidParser().Parse("12345");
+            var context = new TemplateContext { MaxOutputSize = 4 };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => template.RenderAsync(new StringWriter(), context).AsTask());
+        }
+
+        [Fact]
+        public async Task MaxOutputSizeAppliesInsideLessRestrictiveOutput()
+        {
+            var template = new FluidParser().Parse("12345");
+            var context = new TemplateContext { MaxOutputSize = 4 };
+            await using var writerOutput = new Fluid.Utils.TextWriterFluidOutput(
+                new StringWriter(),
+                bufferSize: 16);
+            var output = Fluid.Utils.LimitedFluidOutput.Create(writerOutput, 100);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => template.RenderAsync(output, System.Text.Encodings.Web.HtmlEncoder.Default, context).AsTask());
+        }
+
+        [Fact]
+        public async Task MaxOutputSizeLimitsCapturedContent()
+        {
+            var template = new FluidParser().Parse("{% capture value %}12345{% endcapture %}");
+            var context = new TemplateContext { MaxOutputSize = 4 };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => template.RenderAsync(context).AsTask());
+        }
+
+        [Fact]
+        public async Task MaxOutputSizeRejectsStringConcatenationBeforeAllocation()
+        {
+            var template = new FluidParser().Parse("{% assign value = '1234' %}{% assign value = value | append: value %}");
+            var context = new TemplateContext { MaxOutputSize = 7 };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => template.RenderAsync(context).AsTask());
+        }
+
+        [Fact]
+        public async Task MaxOutputSizeRejectsEmptyPatternReplacementBeforeAllocation()
+        {
+            var template = new FluidParser().Parse("{{ '' | replace: '', '1234' }}");
+            var context = new TemplateContext { MaxOutputSize = 4 };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => template.RenderAsync(context).AsTask());
+        }
+
+        [Fact]
+        public async Task MaxOutputSizeRejectsBase64BeforeAllocation()
+        {
+            var template = new FluidParser().Parse("{{ '1234' | base64_encode }}");
+            var context = new TemplateContext { MaxOutputSize = 7 };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => template.RenderAsync(context).AsTask());
+        }
+
+        [Fact]
+        public async Task ExactStringGrowthWithinLimitIsAllowed()
+        {
+            var template = new FluidParser().Parse("{{ 'abcdef' | newline_to_br }}");
+            var context = new TemplateContext { MaxOutputSize = 6 };
+
+            Assert.Equal("abcdef", await template.RenderAsync(context));
+        }
+
+        [Fact]
+        public async Task MaxCollectionSizeLimitsRangesBeforeAllocation()
+        {
+            var template = new FluidParser().Parse("{{ (1..5) | size }}");
+            var context = new TemplateContext { MaxCollectionSize = 4 };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => template.RenderAsync(context).AsTask());
+        }
+
+        [Fact]
+        public async Task MaxCollectionSizeLimitsSplitBeforeMaterialization()
+        {
+            var template = new FluidParser().Parse("{{ 'a,b,c' | split: ',' | size }}");
+            var context = new TemplateContext { MaxCollectionSize = 2 };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => template.RenderAsync(context).AsTask());
+        }
+
+        [Fact]
+        public async Task MaxCollectionSizeLimitsArraySlice()
+        {
+            var template = new FluidParser().Parse("{{ values | slice: 0, 3 | size }}");
+            var context = new TemplateContext(new
+            {
+                values = new[] { 1, 2, 3, 4, 5 }
+            })
+            {
+                MaxCollectionSize = 2
+            };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => template.RenderAsync(context).AsTask());
+        }
+
+        [Fact]
+        public async Task MaxStepsAppliesToArrayFilterEnumeration()
+        {
+            var template = new FluidParser().Parse("{{ values | join: ',' }}");
+            var context = new TemplateContext(new
+            {
+                values = new[] { 1, 2, 3, 4, 5 }
+            })
+            {
+                MaxSteps = 2
+            };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => template.RenderAsync(context).AsTask());
+        }
+
+        [Fact]
+        public void CircularArrayStringificationThrows()
+        {
+            var values = new List<FluidValue>();
+            var array = new ArrayValue(values);
+            values.Add(array);
+
+            var exception = Assert.Throws<InvalidOperationException>(() => array.ToStringValue());
+
+            Assert.Contains("circular", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void CircularArrayHashingThrows()
+        {
+            var values = new List<FluidValue>();
+            var array = new ArrayValue(values);
+            values.Add(array);
+
+            Assert.Throws<InvalidOperationException>(() => array.GetHashCode());
+        }
+
+        [Fact]
+        public void AcyclicSharedArrayEqualityDoesNotLookRecursive()
+        {
+            var child = new ArrayValue([]);
+            var middle = new ArrayValue([child]);
+            var parent = new ArrayValue([middle]);
+
+            Assert.False(parent.Equals(middle));
+        }
+    }
+}

--- a/Fluid.Tests/SourceGeneration/SourceGenerationTests.cs
+++ b/Fluid.Tests/SourceGeneration/SourceGenerationTests.cs
@@ -105,6 +105,26 @@ namespace Fluid.Tests
         }
 
         [Fact]
+        public async Task GeneratedTemplate_EnforcesMaxOutputSize()
+        {
+            var parser = new FluidParser();
+            var template = parser.Parse("12345");
+            var source = template.Compile(new SourceGenerationOptions
+            {
+                Namespace = "Fluid.Tests.Generated",
+                ClassName = "T" + Guid.NewGuid().ToString("N")
+            });
+
+            var generated = CompileToAssembly(source.SourceCode);
+            var type = generated.GetType(source.FullTypeName, throwOnError: true);
+            var instance = (IFluidTemplate)Activator.CreateInstance(type, nonPublic: true);
+            var context = new TemplateContext { MaxOutputSize = 4 };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => instance.RenderAsync(new FlushTrackingOutput(), HtmlEncoder.Default, context).AsTask());
+        }
+
+        [Fact]
         public async Task GeneratedTemplate_RejectsTrimming()
         {
             var parser = new FluidParser();

--- a/Fluid/Ast/BinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpression.cs
@@ -25,22 +25,26 @@ namespace Fluid.Ast
 
             if (leftTask.IsCompletedSuccessfully && rightTask.IsCompletedSuccessfully)
             {
-                return Evaluate(leftTask.Result, rightTask.Result);
+                return Evaluate(leftTask.Result, rightTask.Result, context);
             }
 
-            return Awaited(leftTask, rightTask);
+            return Awaited(leftTask, rightTask, context);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private async ValueTask<FluidValue> Awaited(
             ValueTask<FluidValue> leftTask,
-            ValueTask<FluidValue> rightTask)
+            ValueTask<FluidValue> rightTask,
+            TemplateContext context)
         {
             var leftValue = await leftTask;
             var rightValue = await rightTask;
 
-            return Evaluate(leftValue, rightValue);
+            return Evaluate(leftValue, rightValue, context);
         }
+
+        internal virtual FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue, TemplateContext context)
+            => Evaluate(leftValue, rightValue);
 
         // sub-classes using the default implementation need to override this
         internal virtual FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)

--- a/Fluid/Ast/BinaryExpressions/AddBinaryExpression.cs
+++ b/Fluid/Ast/BinaryExpressions/AddBinaryExpression.cs
@@ -9,11 +9,14 @@ namespace Fluid.Ast.BinaryExpressions
         {
         }
 
-        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue)
+        internal override FluidValue Evaluate(FluidValue leftValue, FluidValue rightValue, TemplateContext context)
         {
             if (leftValue is StringValue)
             {
-                return new StringValue(leftValue.ToStringValue() + rightValue.ToStringValue());
+                var left = leftValue.ToStringValue();
+                var right = rightValue.ToStringValue();
+                context.EnsureOutputSize((long)left.Length + right.Length);
+                return new StringValue(left + right);
             }
 
             if (leftValue is NumberValue)
@@ -38,7 +41,10 @@ namespace Fluid.Ast.BinaryExpressions
             context.WriteLine("{");
             using (context.Indent())
             {
-                context.WriteLine("return new StringValue(leftValue.ToStringValue() + rightValue.ToStringValue());");
+                context.WriteLine("var left = leftValue.ToStringValue();");
+                context.WriteLine("var right = rightValue.ToStringValue();");
+                context.WriteLine($"{context.ContextName}.EnsureOutputSize((long)left.Length + right.Length);");
+                context.WriteLine("return new StringValue(left + right);");
             }
             context.WriteLine("}");
 

--- a/Fluid/Ast/CaptureStatement.cs
+++ b/Fluid/Ast/CaptureStatement.cs
@@ -38,7 +38,8 @@ namespace Fluid.Ast
 
             var completion = Completion.Normal;
 
-            using var captureOutput = new BufferFluidOutput();
+            using var captureBuffer = new BufferFluidOutput();
+            var captureOutput = LimitedFluidOutput.Create(captureBuffer, context.MaxOutputSize);
             for (var i = 0; i < Statements.Count; i++)
             {
                 completion = await Statements[i].WriteToAsync(captureOutput, encoder, context);
@@ -51,7 +52,7 @@ namespace Fluid.Ast
                 }
             }
 
-            FluidValue result = new StringValue(captureOutput.ToString(), false);
+            FluidValue result = new StringValue(captureBuffer.ToString(), false);
 
             // Substitute the result if a custom callback is provided
             if (context.Captured != null)
@@ -73,7 +74,8 @@ namespace Fluid.Ast
 
             context.WriteLine("var completion = Completion.Normal;");
             context.WriteLine("using var sw = new StringWriter();");
-            context.WriteLine("await using var captureOutput = new TextWriterFluidOutput(sw, 16 * 1024, leaveOpen: true);");
+            context.WriteLine("await using var captureBuffer = new TextWriterFluidOutput(sw, 16 * 1024, leaveOpen: true);");
+            context.WriteLine($"var captureOutput = LimitedFluidOutput.Create(captureBuffer, {context.ContextName}.MaxOutputSize);");
 
             context.WriteLine($"for (var i = 0; i < {Statements.Count}; i++)");
             context.WriteLine("{");
@@ -96,7 +98,7 @@ namespace Fluid.Ast
             }
             context.WriteLine("}");
 
-            context.WriteLine("await captureOutput.FlushAsync();");
+            context.WriteLine("await captureBuffer.FlushAsync();");
             context.WriteLine("FluidValue result = new StringValue(sw.ToString(), false);");
             context.WriteLine($"if ({context.ContextName}.Captured != null)");
             context.WriteLine("{");

--- a/Fluid/Ast/IfChangedStatement.cs
+++ b/Fluid/Ast/IfChangedStatement.cs
@@ -20,7 +20,8 @@ namespace Fluid.Ast
             var previousValue = previousValueObj as string;
 
             // Render inner statements to a buffer
-            using var captureOutput = new BufferFluidOutput();
+            using var captureBuffer = new BufferFluidOutput();
+            var captureOutput = LimitedFluidOutput.Create(captureBuffer, context.MaxOutputSize);
             var completion = Completion.Normal;
 
             for (var i = 0; i < Statements.Count; i++)
@@ -33,7 +34,7 @@ namespace Fluid.Ast
                 }
             }
 
-            var currentValue = captureOutput.ToString();
+            var currentValue = captureBuffer.ToString();
 
             // Output only if content has changed from the last ifchanged output
             if (!string.Equals(previousValue, currentValue, StringComparison.Ordinal))

--- a/Fluid/Ast/MacroStatement.cs
+++ b/Fluid/Ast/MacroStatement.cs
@@ -31,7 +31,8 @@ namespace Fluid.Ast
 
             var f = new FunctionValue(async (args, c) =>
             {
-                using var macroOutput = new BufferFluidOutput();
+                using var macroBuffer = new BufferFluidOutput();
+                var macroOutput = LimitedFluidOutput.Create(macroBuffer, context.MaxOutputSize);
 
                 context.EnterChildScope();
 
@@ -76,7 +77,7 @@ namespace Fluid.Ast
                         }
                     }
 
-                    var result = macroOutput.ToString();
+                    var result = macroBuffer.ToString();
 
                     // Don't encode the result
                     return new StringValue(result, false);
@@ -121,7 +122,8 @@ namespace Fluid.Ast
             using (context.Indent())
             {
                 context.WriteLine("using var sw = new StringWriter();");
-                context.WriteLine("await using var macroOutput = new TextWriterFluidOutput(sw, 16 * 1024, leaveOpen: true);");
+                context.WriteLine("await using var macroBuffer = new TextWriterFluidOutput(sw, 16 * 1024, leaveOpen: true);");
+                context.WriteLine($"var macroOutput = LimitedFluidOutput.Create(macroBuffer, {context.ContextName}.MaxOutputSize);");
                 context.WriteLine($"{context.ContextName}.EnterChildScope();");
                 context.WriteLine("try");
                 context.WriteLine("{");

--- a/Fluid/Ast/RangeExpression.cs
+++ b/Fluid/Ast/RangeExpression.cs
@@ -28,21 +28,24 @@ namespace Fluid.Ast
                 start = Convert.ToInt32(startTask.Result.ToNumberValue());
                 end = Convert.ToInt32(endTask.Result.ToNumberValue());
 
-                return BuildArray(start, end);
+                return BuildArray(start, end, context);
             }
             else
             {
-                return Awaited(startTask, endTask);
+                return Awaited(startTask, endTask, context);
             }
         }
 
-        private static ArrayValue BuildArray(int start, int end)
+        private static ArrayValue BuildArray(int start, int end, TemplateContext context)
         {
             // If end < start, we create an empty array
-            var list = new FluidValue[Math.Max(0, end - start + 1)];
+            var length = end < start ? 0L : (long)end - start + 1;
+            context.EnsureCollectionSize(length);
+            var list = new FluidValue[checked((int)length)];
 
             for (var i = 0; i < list.Length; i++)
             {
+                context.IncrementSteps();
                 list[i] = NumberValue.Create(start + i);
             }
 
@@ -52,12 +55,13 @@ namespace Fluid.Ast
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static async ValueTask<FluidValue> Awaited(
             ValueTask<FluidValue> leftTask,
-            ValueTask<FluidValue> rightTask)
+            ValueTask<FluidValue> rightTask,
+            TemplateContext context)
         {
             var start = Convert.ToInt32((await leftTask).ToNumberValue());
             var end = Convert.ToInt32((await rightTask).ToNumberValue());
 
-            return BuildArray(start, end);
+            return BuildArray(start, end, context);
         }
 
         protected internal override Expression Accept(AstVisitor visitor) => visitor.VisitRangeExpression(this);
@@ -70,11 +74,14 @@ namespace Fluid.Ast
             context.WriteLine($"var start = Convert.ToInt32((await {fromMethod}({context.ContextName})).ToNumberValue());");
             context.WriteLine($"var end = Convert.ToInt32((await {toMethod}({context.ContextName})).ToNumberValue());");
             context.WriteLine("// If end < start, we create an empty array");
-            context.WriteLine("var list = new FluidValue[Math.Max(0, end - start + 1)];");
+            context.WriteLine("var length = end < start ? 0L : (long)end - start + 1;");
+            context.WriteLine($"{context.ContextName}.EnsureCollectionSize(length);");
+            context.WriteLine("var list = new FluidValue[checked((int)length)];");
             context.WriteLine("for (var i = 0; i < list.Length; i++)");
             context.WriteLine("{");
             using (context.Indent())
             {
+                context.WriteLine($"{context.ContextName}.IncrementSteps();");
                 context.WriteLine("list[i] = NumberValue.Create(start + i);");
             }
             context.WriteLine("}");

--- a/Fluid/DefaultMemberAccessStrategy.cs
+++ b/Fluid/DefaultMemberAccessStrategy.cs
@@ -7,47 +7,75 @@ namespace Fluid
     public class DefaultMemberAccessStrategy : MemberAccessStrategy
     {
         internal record struct AccessorKey(Type Type, string Name);
+        internal record struct ReflectedAccessorKey(Type Type, string Name, StringComparer StringComparer);
+
+        private sealed class ReflectionCache
+        {
+            public ReflectionCache(object registrationToken)
+            {
+                RegistrationToken = registrationToken;
+            }
+
+            public object RegistrationToken { get; }
+            public volatile Dictionary<ReflectedAccessorKey, IMemberAccessor> Accessors = [];
+        }
 
         private static readonly bool _dynamicCodeSupported = IsDynamicCodeSupported();
 
-        private volatile Dictionary<AccessorKey, IMemberAccessor> _map = [];
-
-        // A standalone token rather than the map itself. Using the map would mean every cached accessor
-        // pinned the superseded copy it was resolved against, and would churn on every cold resolution,
-        // because GetAccessor registers what it resolves. Volatile so reading it is an acquire, keeping
-        // the map read that follows from being reordered before it.
-        private volatile object _accessorCacheToken = new();
+        private volatile Dictionary<AccessorKey, IMemberAccessor> _registrations = [];
+        private volatile ReflectionCache _reflectionCache;
 
         // Only the exact type opts in. A derived strategy may override GetAccessor to resolve from its
-        // own source, which this map -- and therefore the token -- would not reflect; it would then serve
+        // own source, which these maps -- and therefore the token -- would not reflect; it would then serve
         // a stale accessor forever. Subclasses give up the caching, not correctness.
         private readonly bool _accessorCachingSupported;
 
         public DefaultMemberAccessStrategy()
         {
             _accessorCachingSupported = GetType() == typeof(DefaultMemberAccessStrategy);
+            _reflectionCache = new ReflectionCache(_registrations);
         }
 
-        protected internal override object AccessorCacheToken => _accessorCachingSupported ? _accessorCacheToken : null;
+        protected internal override object AccessorCacheToken => _accessorCachingSupported ? _registrations : null;
 
         public override IMemberAccessor GetAccessor(Type type, string name, StringComparer stringComparer)
         {
-            if (!TryGetAccessor(type, name, stringComparer, out var accessor))
+            ArgumentNullException.ThrowIfNull(type);
+            ArgumentNullException.ThrowIfNull(name);
+            ArgumentNullException.ThrowIfNull(stringComparer);
+
+            var registrations = _registrations;
+
+            if (TryGetRegisteredAccessor(registrations, type, name, out var accessor))
             {
-                // Memoize what was resolved, but without invalidating cached accessors: this only fills
-                // in a pair that had no entry, so it cannot change what any other pair resolves to.
-                AddToMap(type, name, accessor = GetMemberAccessor(type, name, stringComparer) ?? GetAccessorUnlikely(type, name, stringComparer));
+                return accessor;
             }
 
+            var reflectionCache = GetReflectionCache(registrations);
+            var key = new ReflectedAccessorKey(type, name, stringComparer);
+            var reflectedAccessors = reflectionCache.Accessors;
+
+            if (reflectedAccessors.TryGetValue(key, out accessor))
+            {
+                return accessor;
+            }
+
+            accessor = GetMemberAccessor(type, name, stringComparer)
+                ?? GetAccessorUnlikely(registrations, type, name, stringComparer);
+
+            AddReflectedAccessor(reflectionCache, key, accessor);
             return accessor;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool TryGetAccessor(Type type, string name, StringComparer stringComparer, out IMemberAccessor accessor)
+        private static bool TryGetRegisteredAccessor(
+            Dictionary<AccessorKey, IMemberAccessor> registrations,
+            Type type,
+            string name,
+            out IMemberAccessor accessor)
         {
-            // Search for a specific accessor first, or a wildcard accessor.
-            // A wildcard accessor is only used when an accessor is provided by users.
-            return _map.TryGetValue(new AccessorKey(type, name), out accessor) || _map.TryGetValue(new AccessorKey(type, "*"), out accessor);
+            return registrations.TryGetValue(new AccessorKey(type, name), out accessor)
+                || registrations.TryGetValue(new AccessorKey(type, "*"), out accessor);
         }
 
         private static IMemberAccessor GetMemberAccessor(Type type, string name, StringComparer stringComparer)
@@ -145,13 +173,22 @@ namespace Fluid
         }
 
         // Creates accessors based on base types and interfaces
-        private IMemberAccessor GetAccessorUnlikely(Type type, string name, StringComparer stringComparer)
+        private static IMemberAccessor GetAccessorUnlikely(
+            Dictionary<AccessorKey, IMemberAccessor> registrations,
+            Type type,
+            string name,
+            StringComparer stringComparer)
         {
             var currentType = type.GetTypeInfo().BaseType;
             while (currentType != typeof(object) && currentType != null)
             {
-                // Look for specific property map
-                if (TryGetAccessor(currentType, name, stringComparer, out var accessor))
+                if (TryGetRegisteredAccessor(registrations, currentType, name, out var accessor))
+                {
+                    return accessor;
+                }
+
+                accessor = GetMemberAccessor(currentType, name, stringComparer);
+                if (accessor != null)
                 {
                     return accessor;
                 }
@@ -162,9 +199,13 @@ namespace Fluid
             // Search for accessors defined on interfaces
             foreach (var interfaceType in type.GetTypeInfo().GetInterfaces())
             {
-                // NB: Here we could also register this accessor in typeMap[type] such that
-                // next lookup on this type won't need to resolve its interfaces
-                if (TryGetAccessor(interfaceType, name, stringComparer, out var accessor))
+                if (TryGetRegisteredAccessor(registrations, interfaceType, name, out var accessor))
+                {
+                    return accessor;
+                }
+
+                accessor = GetMemberAccessor(interfaceType, name, stringComparer);
+                if (accessor != null)
                 {
                     return accessor;
                 }
@@ -175,18 +216,73 @@ namespace Fluid
 
         public override void Register(Type type, string name, IMemberAccessor accessor)
         {
-            AddToMap(type, name, accessor);
+            ArgumentNullException.ThrowIfNull(type);
+            ArgumentNullException.ThrowIfNull(name);
 
-            // A registration can replace what an already-resolved pair maps to, so retire the token and
-            // make every call site re-resolve.
-            _accessorCacheToken = new object();
+            while (true)
+            {
+                var registrations = _registrations;
+                var updated = new Dictionary<AccessorKey, IMemberAccessor>(registrations)
+                {
+                    [new AccessorKey(type, name)] = accessor
+                };
+
+                if (ReferenceEquals(
+                    Interlocked.CompareExchange(ref _registrations, updated, registrations),
+                    registrations))
+                {
+                    _reflectionCache = new ReflectionCache(updated);
+                    return;
+                }
+            }
         }
 
-        private void AddToMap(Type type, string name, IMemberAccessor accessor)
+        private ReflectionCache GetReflectionCache(object registrationToken)
         {
-            var map = new Dictionary<AccessorKey, IMemberAccessor>(_map);
-            map[new AccessorKey(type, name)] = accessor;
-            _map = map;
+            while (true)
+            {
+                var reflectionCache = _reflectionCache;
+                if (ReferenceEquals(reflectionCache.RegistrationToken, registrationToken))
+                {
+                    return reflectionCache;
+                }
+
+                var updated = new ReflectionCache(registrationToken);
+                if (ReferenceEquals(
+                    Interlocked.CompareExchange(ref _reflectionCache, updated, reflectionCache),
+                    reflectionCache))
+                {
+                    return updated;
+                }
+            }
+        }
+
+        private static void AddReflectedAccessor(
+            ReflectionCache reflectionCache,
+            ReflectedAccessorKey key,
+            IMemberAccessor accessor)
+        {
+            while (true)
+            {
+                var reflectedAccessors = reflectionCache.Accessors;
+
+                if (reflectedAccessors.ContainsKey(key))
+                {
+                    return;
+                }
+
+                var updated = new Dictionary<ReflectedAccessorKey, IMemberAccessor>(reflectedAccessors)
+                {
+                    [key] = accessor
+                };
+
+                if (ReferenceEquals(
+                    Interlocked.CompareExchange(ref reflectionCache.Accessors, updated, reflectedAccessors),
+                    reflectedAccessors))
+                {
+                    return;
+                }
+            }
         }
     }
 }

--- a/Fluid/ExceptionHelper.cs
+++ b/Fluid/ExceptionHelper.cs
@@ -101,4 +101,25 @@ internal static class ExceptionHelper
     {
         throw new InvalidOperationException("The maximum level of recursion has been reached. Your script must have a cyclic include statement.");
     }
+
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ThrowMaximumOutputSizeException(int maximum)
+    {
+        throw new InvalidOperationException($"The maximum template output size of {maximum} characters has been reached.");
+    }
+
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ThrowMaximumCollectionSizeException(int maximum)
+    {
+        throw new InvalidOperationException($"The maximum materialized collection size of {maximum} items has been reached.");
+    }
+
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ThrowRecursiveValueException()
+    {
+        throw new InvalidOperationException("A circular or excessively deep value cannot be converted.");
+    }
 }

--- a/Fluid/Filters/ArrayFilters.cs
+++ b/Fluid/Filters/ArrayFilters.cs
@@ -37,11 +37,18 @@ namespace Fluid.Filters
             var separator = arguments.Count > 0 ? arguments.At(0).ToStringValue() : " ";
 
             var list = new List<string>();
+            long outputLength = 0;
             await foreach (var item in input.EnumerateAsync(context))
             {
                 // Preserve nil/undefined items as empty strings (so separators remain)
                 if (item.IsNil())
                 {
+                    context.EnsureCollectionSize((long)list.Count + 1);
+                    if (list.Count > 0)
+                    {
+                        outputLength += separator.Length;
+                        context.EnsureOutputSize(outputLength);
+                    }
                     list.Add(string.Empty);
                     continue;
                 }
@@ -54,6 +61,13 @@ namespace Fluid.Filters
                     continue;
                 }
 
+                context.EnsureCollectionSize((long)list.Count + 1);
+                outputLength += s.Length;
+                if (list.Count > 0)
+                {
+                    outputLength += separator.Length;
+                }
+                context.EnsureOutputSize(outputLength);
                 list.Add(s);
             }
 
@@ -140,11 +154,13 @@ namespace Fluid.Filters
             {
                 foreach (var item in Flatten(input, context))
                 {
+                    context.EnsureCollectionSize((long)concat.Count + 1);
                     concat.Add(item);
                 }
             }
             else if (input.Type != FluidValues.Nil)
             {
+                context.EnsureCollectionSize(1);
                 concat.Add(input);
             }
 
@@ -152,6 +168,7 @@ namespace Fluid.Filters
             {
                 foreach (var item in Flatten(arg, context))
                 {
+                    context.EnsureCollectionSize((long)concat.Count + 1);
                     concat.Add(item);
                 }
             }
@@ -205,11 +222,13 @@ namespace Fluid.Filters
             {
                 await foreach (var item in FlattenForMap(input, context))
                 {
+                    context.EnsureCollectionSize((long)list.Count + 1);
                     list.Add(await item.GetIndexAsync(member, context));
                 }
             }
             else
             {
+                context.EnsureCollectionSize(1);
                 list.Add(await input.GetIndexAsync(member, context));
             }
 
@@ -252,6 +271,7 @@ namespace Fluid.Filters
                 }
                 else
                 {
+                    context.EnsureCollectionSize(value.Length);
                     var valueAsArray = value.ToCharArray();
 
                     Array.Reverse(valueAsArray);
@@ -735,6 +755,7 @@ namespace Fluid.Filters
                                 }
                                 if (!shouldReject.reject)
                                 {
+                                    context.EnsureCollectionSize((long)list.Count + 1);
                                     list.Add(deepItem);
                                 }
                             }
@@ -753,6 +774,7 @@ namespace Fluid.Filters
                             }
                             if (!shouldReject.reject)
                             {
+                                context.EnsureCollectionSize((long)list.Count + 1);
                                 list.Add(nestedItem);
                             }
                         }
@@ -774,6 +796,7 @@ namespace Fluid.Filters
                 
                 if (!result.reject)
                 {
+                    context.EnsureCollectionSize((long)list.Count + 1);
                     list.Add(item);
                 }
             }

--- a/Fluid/Filters/MiscFilters.cs
+++ b/Fluid/Filters/MiscFilters.cs
@@ -247,7 +247,7 @@ namespace Fluid.Filters
             else
             {
                 var byteCount = Encoding.UTF8.GetByteCount(value);
-                context.EnsureOutputSize(4L * ((byteCount + 2L) / 3L));
+                context.EnsureOutputSize(((4L * byteCount) + 2L) / 3L);
                 var encodedBase64StringBuilder = new StringBuilder(Convert.ToBase64String(Encoding.UTF8.GetBytes(value)));
 
                 encodedBase64StringBuilder.Replace('+', '-');

--- a/Fluid/Filters/MiscFilters.cs
+++ b/Fluid/Filters/MiscFilters.cs
@@ -214,9 +214,14 @@ namespace Fluid.Filters
 
             var value = input.ToStringValue();
 
-            return String.IsNullOrEmpty(value)
-                ? StringValue.Empty
-                : new StringValue(Convert.ToBase64String(Encoding.UTF8.GetBytes(value)));
+            if (String.IsNullOrEmpty(value))
+            {
+                return StringValue.Empty;
+            }
+
+            var byteCount = Encoding.UTF8.GetByteCount(value);
+            context.EnsureOutputSize(4L * ((byteCount + 2L) / 3L));
+            return new StringValue(Convert.ToBase64String(Encoding.UTF8.GetBytes(value)));
         }
 
         public static ValueTask<FluidValue> Base64Decode(FluidValue input, FilterArguments arguments, TemplateContext context)
@@ -241,6 +246,8 @@ namespace Fluid.Filters
             }
             else
             {
+                var byteCount = Encoding.UTF8.GetByteCount(value);
+                context.EnsureOutputSize(4L * ((byteCount + 2L) / 3L));
                 var encodedBase64StringBuilder = new StringBuilder(Convert.ToBase64String(Encoding.UTF8.GetBytes(value)));
 
                 encodedBase64StringBuilder.Replace('+', '-');

--- a/Fluid/Filters/StringFilters.cs
+++ b/Fluid/Filters/StringFilters.cs
@@ -15,6 +15,13 @@ namespace Fluid.Filters
                 : new StringValue(value);
         }
 
+        private static string GetStringValue(FluidValue value, TemplateContext context)
+        {
+            var result = value.ToStringValue();
+            context.EnsureOutputSize(result.Length);
+            return result;
+        }
+
         public static FilterCollection WithStringFilters(this FilterCollection filters)
         {
             filters.AddFilter("append", Append);
@@ -45,14 +52,17 @@ namespace Fluid.Filters
         {
             LiquidException.ThrowFilterArgumentsCount("append", expected: 1, arguments);
 
-            return CreateStringValue(input.ToStringValue() + arguments.At(0).ToStringValue(), input);
+            var left = GetStringValue(input, context);
+            var right = GetStringValue(arguments.At(0), context);
+            context.EnsureOutputSize((long)left.Length + right.Length);
+            return CreateStringValue(left + right, input);
         }
 
         public static ValueTask<FluidValue> Capitalize(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
             LiquidException.ThrowFilterArgumentsCount("capitalize", expected: 0, arguments);
 
-            var source = input.ToStringValue().ToCharArray();
+            var source = GetStringValue(input, context).ToCharArray();
 
             if (source.Length > 0 && char.IsLetter(source[0]))
             {
@@ -66,7 +76,7 @@ namespace Fluid.Filters
         {
             LiquidException.ThrowFilterArgumentsCount("downcase", expected: 0, arguments);
 
-            return CreateStringValue(input.ToStringValue().ToLower(context.CultureInfo), input);
+            return CreateStringValue(GetStringValue(input, context).ToLower(context.CultureInfo), input);
         }
 
         public static ValueTask<FluidValue> LStrip(FluidValue input, FilterArguments arguments, TemplateContext context)
@@ -87,8 +97,24 @@ namespace Fluid.Filters
         {
             LiquidException.ThrowFilterArgumentsCount("newline_to_br", expected: 0, arguments);
 
+            var value = GetStringValue(input, context);
+            long resultLength = value.Length;
+            for (var i = 0; i < value.Length; i++)
+            {
+                context.IncrementSteps();
+                if (value[i] == '\n')
+                {
+                    resultLength += 6;
+                }
+                else if (value[i] == '\r')
+                {
+                    resultLength += i + 1 < value.Length && value[i + 1] == '\n' ? -1 : 6;
+                }
+            }
+            context.EnsureOutputSize(resultLength);
+
             // Normalize line endings first, then replace with <br />
-            return CreateStringValue(input.ToStringValue()
+            return CreateStringValue(value
                 .Replace("\r\n", "\n")      // Windows -> Unix
                 .Replace("\r", "\n")         // Mac -> Unix
                 .Replace("\n", "<br />\n"), input); // Unix -> <br /> + newline
@@ -98,7 +124,10 @@ namespace Fluid.Filters
         {
             LiquidException.ThrowFilterArgumentsCount("prepend", expected: 1, arguments);
 
-            return CreateStringValue(arguments.At(0).ToStringValue() + input.ToStringValue(), input);
+            var left = GetStringValue(arguments.At(0), context);
+            var right = GetStringValue(input, context);
+            context.EnsureOutputSize((long)left.Length + right.Length);
+            return CreateStringValue(left + right, input);
         }
 
         public static ValueTask<FluidValue> RemoveFirst(FluidValue input, FilterArguments arguments, TemplateContext context)
@@ -164,6 +193,7 @@ namespace Fluid.Filters
                 return input;
             }
 
+            context.EnsureOutputSize((long)value.Length - remove.Length + insert.Length);
             var concat = string.Concat(value.Substring(0, index), insert, value.Substring(index + remove.Length));
             return CreateStringValue(concat, input);
         }
@@ -172,19 +202,21 @@ namespace Fluid.Filters
         {
             LiquidException.ThrowFilterArgumentsCount("replace", min: 1, max: 2, arguments);
 
-            var value = input.ToStringValue();
-            var oldValue = arguments.At(0).ToStringValue();
-            var newValue = arguments.At(1).ToStringValue();
+            var value = GetStringValue(input, context);
+            var oldValue = GetStringValue(arguments.At(0), context);
+            var newValue = GetStringValue(arguments.At(1), context);
 
             // .NET throws when oldValue is empty, but Liquid treats this as an insertion between every character.
             if (oldValue.Length == 0)
             {
                 if (value.Length == 0)
                 {
+                    context.EnsureOutputSize((long)newValue.Length * 2);
                     return CreateStringValue(newValue + newValue, input);
                 }
 
-                var sb = new System.Text.StringBuilder(value.Length + (newValue.Length * (value.Length + 1)));
+                context.EnsureOutputSize((long)value.Length + ((long)newValue.Length * (value.Length + 1)));
+                var sb = new System.Text.StringBuilder(checked(value.Length + (newValue.Length * (value.Length + 1))));
                 sb.Append(newValue);
                 for (var i = 0; i < value.Length; i++)
                 {
@@ -195,6 +227,20 @@ namespace Fluid.Filters
                 return CreateStringValue(sb.ToString(), input);
             }
 
+            if (newValue.Length > oldValue.Length)
+            {
+                var occurrences = 0;
+                var index = 0;
+                while ((index = value.IndexOf(oldValue, index, StringComparison.Ordinal)) >= 0)
+                {
+                    context.IncrementSteps();
+                    occurrences++;
+                    index += oldValue.Length;
+                }
+
+                context.EnsureOutputSize((long)value.Length + ((long)(newValue.Length - oldValue.Length) * occurrences));
+            }
+
             return CreateStringValue(value.Replace(oldValue, newValue), input);
         }
 
@@ -203,11 +249,13 @@ namespace Fluid.Filters
             LiquidException.ThrowFilterArgumentsCount("replace_last", expected: 2, arguments);
 
 #if NET6_0_OR_GREATER
-            var value = input.ToStringValue().AsSpan();
-            var remove = arguments.At(0).ToStringValue().AsSpan();
+            var valueString = GetStringValue(input, context);
+            var removeString = GetStringValue(arguments.At(0), context);
+            var value = valueString.AsSpan();
+            var remove = removeString.AsSpan();
 #else
-            var value = input.ToStringValue();
-            var remove = arguments.At(0).ToStringValue();
+            var value = GetStringValue(input, context);
+            var remove = GetStringValue(arguments.At(0), context);
 #endif
             var index = value.LastIndexOf(remove);
 
@@ -217,9 +265,13 @@ namespace Fluid.Filters
             }
 
 #if NET6_0_OR_GREATER
-            var concat = string.Concat(value.Slice(0, index), arguments.At(1).ToStringValue(), value.Slice(index + remove.Length));
+            var insert = GetStringValue(arguments.At(1), context);
+            context.EnsureOutputSize((long)value.Length - remove.Length + insert.Length);
+            var concat = string.Concat(value.Slice(0, index), insert, value.Slice(index + remove.Length));
 #else
-            var concat = string.Concat(value.Substring(0, index), arguments.At(1).ToStringValue(), value.Substring(index + remove.Length));
+            var insert = GetStringValue(arguments.At(1), context);
+            context.EnsureOutputSize((long)value.Length - remove.Length + insert.Length);
+            var concat = string.Concat(value.Substring(0, index), insert, value.Substring(index + remove.Length));
 #endif
             return CreateStringValue(concat, input);
         }
@@ -268,6 +320,7 @@ namespace Fluid.Filters
                 var length = requestedLength > sourceLength ? sourceLength : requestedLength;
                 length = startIndex > 0 && length + startIndex > sourceLength ? length - startIndex : length;
 
+                context.EnsureCollectionSize(length);
                 return new ArrayValue(sourceArray.Skip(startIndex).Take(length).ToArray());
             }
             else
@@ -301,8 +354,8 @@ namespace Fluid.Filters
 
             string[] strings;
 
-            var stringInput = input.ToStringValue();
-            var separator = arguments.At(0).ToStringValue();
+            var stringInput = GetStringValue(input, context);
+            var separator = GetStringValue(arguments.At(0), context);
 
             // Golden Liquid: splitting an empty string yields an empty array
             if (stringInput.Length == 0)
@@ -318,10 +371,12 @@ namespace Fluid.Filters
 
             if (separator == "")
             {
+                context.EnsureCollectionSize(stringInput.Length);
                 strings = new string[stringInput.Length];
 
                 for (var i = 0; i < stringInput.Length; i++)
                 {
+                    context.IncrementSteps();
                     strings[i] = stringInput[i].ToString();
                 }
             }
@@ -333,10 +388,12 @@ namespace Fluid.Filters
 
                 for (var i = 0; i < stringInput.Length; i++)
                 {
+                    context.IncrementSteps();
                     if (char.IsWhiteSpace(stringInput[i]))
                     {
                         if (start != -1)
                         {
+                            context.EnsureCollectionSize((long)parts.Count + 1);
                             parts.Add(stringInput.Substring(start, i - start));
                             start = -1;
                         }
@@ -349,6 +406,7 @@ namespace Fluid.Filters
 
                 if (start != -1)
                 {
+                    context.EnsureCollectionSize((long)parts.Count + 1);
                     parts.Add(stringInput.Substring(start));
                 }
 
@@ -356,12 +414,24 @@ namespace Fluid.Filters
             }
             else
             {
+                var parts = 1;
+                var index = 0;
+                while ((index = stringInput.IndexOf(separator, index, StringComparison.Ordinal)) >= 0)
+                {
+                    context.IncrementSteps();
+                    parts++;
+                    context.EnsureCollectionSize(parts);
+                    index += separator.Length;
+                }
+
                 strings = stringInput.Split(separator, StringSplitOptions.None);
             }
 
+            context.EnsureCollectionSize(strings.Length);
             var values = new FluidValue[strings.Length];
             for (var i = 0; i < strings.Length; i++)
             {
+                context.IncrementSteps();
                 values[i] = StringValue.Create(strings[i]);
             }
 
@@ -449,6 +519,7 @@ namespace Fluid.Filters
             }
 
             var l = Math.Max(0, length - ellipsisStr.Length);
+            context.EnsureOutputSize((long)l + ellipsisStr.Length);
 
 #if NET6_0_OR_GREATER
             var concat = string.Concat(inputStr.AsSpan().Slice(0, l), ellipsisStr);
@@ -462,7 +533,7 @@ namespace Fluid.Filters
         {
             LiquidException.ThrowFilterArgumentsCount("truncate_words", min: 0, max: 2, arguments);
 
-            var source = input.ToStringValue();
+            var source = GetStringValue(input, context);
 
             // If first argument is not provided, use default of 15
             // If first argument is nil (undefined variable), throw error per Golden Liquid spec
@@ -504,18 +575,39 @@ namespace Fluid.Filters
             }
 
             var chunks = new List<string>();
+            long resultLength = 0;
 
             var length = source.Length;
             for (var i = 0; i < length && chunks.Count < size;)
             {
-                while (i < length && char.IsWhiteSpace(source[i++])) ;
-                var start = i - 1;
-                while (i < length && !char.IsWhiteSpace(source[i++])) ;
-                chunks.Add(source.Substring(start, i - start - (i < length ? 1 : 0)));
+                while (i < length && char.IsWhiteSpace(source[i]))
+                {
+                    context.IncrementSteps();
+                    i++;
+                }
+
+                if (i == length)
+                {
+                    break;
+                }
+
+                var start = i;
+                while (i < length && !char.IsWhiteSpace(source[i]))
+                {
+                    context.IncrementSteps();
+                    i++;
+                }
+
+                var chunkLength = i - start;
+                context.EnsureCollectionSize((long)chunks.Count + 1);
+                resultLength += chunkLength + (chunks.Count > 0 ? 1 : 0);
+                context.EnsureOutputSize(resultLength);
+                chunks.Add(source.Substring(start, chunkLength));
             }
 
             if (chunks.Count >= size)
             {
+                context.EnsureOutputSize(resultLength + ellipsis.Length);
                 chunks[^1] += ellipsis;
             }
 
@@ -526,7 +618,7 @@ namespace Fluid.Filters
         {
             LiquidException.ThrowFilterArgumentsCount("upcase", expected: 0, arguments);
 
-            return CreateStringValue(input.ToStringValue().ToUpper(context.CultureInfo), input);
+            return CreateStringValue(GetStringValue(input, context).ToUpper(context.CultureInfo), input);
         }
     }
 }

--- a/Fluid/Filters/StringFilters.cs
+++ b/Fluid/Filters/StringFilters.cs
@@ -15,13 +15,6 @@ namespace Fluid.Filters
                 : new StringValue(value);
         }
 
-        private static string GetStringValue(FluidValue value, TemplateContext context)
-        {
-            var result = value.ToStringValue();
-            context.EnsureOutputSize(result.Length);
-            return result;
-        }
-
         public static FilterCollection WithStringFilters(this FilterCollection filters)
         {
             filters.AddFilter("append", Append);
@@ -52,8 +45,8 @@ namespace Fluid.Filters
         {
             LiquidException.ThrowFilterArgumentsCount("append", expected: 1, arguments);
 
-            var left = GetStringValue(input, context);
-            var right = GetStringValue(arguments.At(0), context);
+            var left = input.ToStringValue();
+            var right = arguments.At(0).ToStringValue();
             context.EnsureOutputSize((long)left.Length + right.Length);
             return CreateStringValue(left + right, input);
         }
@@ -62,7 +55,7 @@ namespace Fluid.Filters
         {
             LiquidException.ThrowFilterArgumentsCount("capitalize", expected: 0, arguments);
 
-            var source = GetStringValue(input, context).ToCharArray();
+            var source = input.ToStringValue().ToCharArray();
 
             if (source.Length > 0 && char.IsLetter(source[0]))
             {
@@ -76,7 +69,7 @@ namespace Fluid.Filters
         {
             LiquidException.ThrowFilterArgumentsCount("downcase", expected: 0, arguments);
 
-            return CreateStringValue(GetStringValue(input, context).ToLower(context.CultureInfo), input);
+            return CreateStringValue(input.ToStringValue().ToLower(context.CultureInfo), input);
         }
 
         public static ValueTask<FluidValue> LStrip(FluidValue input, FilterArguments arguments, TemplateContext context)
@@ -97,7 +90,7 @@ namespace Fluid.Filters
         {
             LiquidException.ThrowFilterArgumentsCount("newline_to_br", expected: 0, arguments);
 
-            var value = GetStringValue(input, context);
+            var value = input.ToStringValue();
             long resultLength = value.Length;
             for (var i = 0; i < value.Length; i++)
             {
@@ -124,8 +117,8 @@ namespace Fluid.Filters
         {
             LiquidException.ThrowFilterArgumentsCount("prepend", expected: 1, arguments);
 
-            var left = GetStringValue(arguments.At(0), context);
-            var right = GetStringValue(input, context);
+            var left = arguments.At(0).ToStringValue();
+            var right = input.ToStringValue();
             context.EnsureOutputSize((long)left.Length + right.Length);
             return CreateStringValue(left + right, input);
         }
@@ -202,9 +195,9 @@ namespace Fluid.Filters
         {
             LiquidException.ThrowFilterArgumentsCount("replace", min: 1, max: 2, arguments);
 
-            var value = GetStringValue(input, context);
-            var oldValue = GetStringValue(arguments.At(0), context);
-            var newValue = GetStringValue(arguments.At(1), context);
+            var value = input.ToStringValue();
+            var oldValue = arguments.At(0).ToStringValue();
+            var newValue = arguments.At(1).ToStringValue();
 
             // .NET throws when oldValue is empty, but Liquid treats this as an insertion between every character.
             if (oldValue.Length == 0)
@@ -249,13 +242,13 @@ namespace Fluid.Filters
             LiquidException.ThrowFilterArgumentsCount("replace_last", expected: 2, arguments);
 
 #if NET6_0_OR_GREATER
-            var valueString = GetStringValue(input, context);
-            var removeString = GetStringValue(arguments.At(0), context);
+            var valueString = input.ToStringValue();
+            var removeString = arguments.At(0).ToStringValue();
             var value = valueString.AsSpan();
             var remove = removeString.AsSpan();
 #else
-            var value = GetStringValue(input, context);
-            var remove = GetStringValue(arguments.At(0), context);
+            var value = input.ToStringValue();
+            var remove = arguments.At(0).ToStringValue();
 #endif
             var index = value.LastIndexOf(remove);
 
@@ -265,11 +258,11 @@ namespace Fluid.Filters
             }
 
 #if NET6_0_OR_GREATER
-            var insert = GetStringValue(arguments.At(1), context);
+            var insert = arguments.At(1).ToStringValue();
             context.EnsureOutputSize((long)value.Length - remove.Length + insert.Length);
             var concat = string.Concat(value.Slice(0, index), insert, value.Slice(index + remove.Length));
 #else
-            var insert = GetStringValue(arguments.At(1), context);
+            var insert = arguments.At(1).ToStringValue();
             context.EnsureOutputSize((long)value.Length - remove.Length + insert.Length);
             var concat = string.Concat(value.Substring(0, index), insert, value.Substring(index + remove.Length));
 #endif
@@ -354,8 +347,8 @@ namespace Fluid.Filters
 
             string[] strings;
 
-            var stringInput = GetStringValue(input, context);
-            var separator = GetStringValue(arguments.At(0), context);
+            var stringInput = input.ToStringValue();
+            var separator = arguments.At(0).ToStringValue();
 
             // Golden Liquid: splitting an empty string yields an empty array
             if (stringInput.Length == 0)
@@ -533,7 +526,7 @@ namespace Fluid.Filters
         {
             LiquidException.ThrowFilterArgumentsCount("truncate_words", min: 0, max: 2, arguments);
 
-            var source = GetStringValue(input, context);
+            var source = input.ToStringValue();
 
             // If first argument is not provided, use default of 15
             // If first argument is nil (undefined variable), throw error per Golden Liquid spec
@@ -618,7 +611,7 @@ namespace Fluid.Filters
         {
             LiquidException.ThrowFilterArgumentsCount("upcase", expected: 0, arguments);
 
-            return CreateStringValue(GetStringValue(input, context).ToUpper(context.CultureInfo), input);
+            return CreateStringValue(input.ToStringValue().ToUpper(context.CultureInfo), input);
         }
     }
 }

--- a/Fluid/FluidOutputExtensions.cs
+++ b/Fluid/FluidOutputExtensions.cs
@@ -31,7 +31,8 @@ namespace Fluid
                 bufferSize,
                 leaveOpen: true,
                 cancellationToken: context.CancellationToken);
-            var completion = await statement.WriteToAsync(output, encoder, context);
+            var limitedOutput = LimitedFluidOutput.Create(output, context.MaxOutputSize);
+            var completion = await statement.WriteToAsync(limitedOutput, encoder, context);
             context.CancellationToken.ThrowIfCancellationRequested();
             await output.FlushAsync();
             return completion;

--- a/Fluid/FluidOutputExtensions.cs
+++ b/Fluid/FluidOutputExtensions.cs
@@ -116,15 +116,14 @@ namespace Fluid
                 catch
                 {
                     // Some bounded outputs may reject size hints larger than their internal buffer.
-                    // Fall back to allocating the encoded string.
-                    output.Write(encoder.Encode(remaining.ToString()));
+                    EncodeAndWriteByScalar(output, encoder, remaining);
                     return;
                 }
 
                 if (destination.Length < minRequired)
                 {
                     // Can't guarantee progress with span encoding; fall back.
-                    output.Write(encoder.Encode(remaining.ToString()));
+                    EncodeAndWriteByScalar(output, encoder, remaining);
                     return;
                 }
 
@@ -142,7 +141,7 @@ namespace Fluid
                 else if (charsWritten == 0)
                 {
                     // Safety valve: avoid infinite loops if an encoder reports no progress.
-                    output.Write(encoder.Encode(remaining.ToString()));
+                    EncodeAndWriteByScalar(output, encoder, remaining);
                     return;
                 }
 
@@ -154,8 +153,18 @@ namespace Fluid
                 // For DestinationTooSmall, loop and request more space.
             }
             #else
-            output.Write(encoder.Encode(value));
+            EncodeAndWriteByScalar(output, encoder, value.AsSpan());
             #endif
+        }
+
+        private static void EncodeAndWriteByScalar(IFluidOutput output, TextEncoder encoder, ReadOnlySpan<char> value)
+        {
+            while (!value.IsEmpty)
+            {
+                var length = value.Length > 1 && char.IsHighSurrogate(value[0]) && char.IsLowSurrogate(value[1]) ? 2 : 1;
+                output.Write(encoder.Encode(value.Slice(0, length).ToString()));
+                value = value.Slice(length);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Fluid/FluidParserExtensions.cs
+++ b/Fluid/FluidParserExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Fluid.Ast;
 using Fluid.Parser;
+using Fluid.Utils;
 using System.Text.Encodings.Web;
 
 namespace Fluid
@@ -61,6 +62,8 @@ namespace Fluid
 
         public static ValueTask<Completion> RenderStatementsAsync(this IReadOnlyList<Statement> statements, IFluidOutput output, TextEncoder encoder, TemplateContext context)
         {
+            output = LimitedFluidOutput.Create(output, context.MaxOutputSize);
+
             static async ValueTask<Completion> Awaited(
                 ValueTask<Completion> task,
                 int startIndex,

--- a/Fluid/Parser/CompositeFluidTemplate.cs
+++ b/Fluid/Parser/CompositeFluidTemplate.cs
@@ -1,4 +1,5 @@
 ﻿using Fluid.Ast;
+using Fluid.Utils;
 using System.Text.Encodings.Web;
 
 namespace Fluid.Parser
@@ -28,6 +29,7 @@ namespace Fluid.Parser
             ArgumentNullException.ThrowIfNull(context);
 
             context.CancellationToken.ThrowIfCancellationRequested();
+            output = LimitedFluidOutput.Create(output, context.MaxOutputSize);
 
             var count = Statements.Count;
             for (var i = 0; i < count; i++)

--- a/Fluid/Parser/FluidTemplate.cs
+++ b/Fluid/Parser/FluidTemplate.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Encodings.Web;
 using Fluid.Ast;
+using Fluid.Utils;
 
 namespace Fluid.Parser
 {
@@ -24,6 +25,7 @@ namespace Fluid.Parser
             ArgumentNullException.ThrowIfNull(context);
 
             context.CancellationToken.ThrowIfCancellationRequested();
+            output = LimitedFluidOutput.Create(output, context.MaxOutputSize);
 
             var count = Statements.Count;
             for (var i = 0; i < count; i++)

--- a/Fluid/SourceGeneration/TemplateSourceGenerator.cs
+++ b/Fluid/SourceGeneration/TemplateSourceGenerator.cs
@@ -92,6 +92,7 @@ namespace Fluid.SourceGeneration
                         ctx.WriteLine("if (context == null) throw new ArgumentNullException(nameof(context));");
                         ctx.WriteLine("if (context.Options.Trimming != TrimmingFlags.None) throw new NotSupportedException(\"Source-generated templates do not support TemplateOptions.Trimming.\");");
                         ctx.WriteLine("context.CancellationToken.ThrowIfCancellationRequested();");
+                        ctx.WriteLine("writer = LimitedFluidOutput.Create(writer, context.MaxOutputSize);");
                         ctx.WriteLine();
 
                         foreach (var statement in statementList.Statements)

--- a/Fluid/TemplateContext.cs
+++ b/Fluid/TemplateContext.cs
@@ -24,8 +24,7 @@ namespace Fluid
         /// </summary>
         /// <param name="model">The model.</param>
         /// <param name="options">The template options.</param>
-        /// <param name="allowModelMembers">Whether the members of the model can be accessed by default.</param>
-        public TemplateContext(object model, TemplateOptions options, bool allowModelMembers = true) : this(options)
+        public TemplateContext(object model, TemplateOptions options) : this(options)
         {
             ArgumentNullException.ThrowIfNull(model);
 
@@ -36,7 +35,6 @@ namespace Fluid
             else
             {
                 Model = FluidValue.Create(model, options);
-                AllowModelMembers = allowModelMembers;
             }
         }
 
@@ -60,17 +58,18 @@ namespace Fluid
             Undefined = options.Undefined;
             Now = options.Now;
             MaxSteps = options.MaxSteps;
+            MaxOutputSize = options.MaxOutputSize;
+            MaxCollectionSize = options.MaxCollectionSize;
             ModelNamesComparer = modelNamesComparer;
             JsonSerializerOptions = options.JsonSerializerOptions;
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="TemplateContext"/> wih a model and option register its properties.
+        /// Initializes a new instance of <see cref="TemplateContext"/> with a model.
         /// </summary>
         /// <param name="model">The model.</param>
-        /// <param name="allowModelMembers">Whether the members of the model can be accessed by default.</param>
         /// <param name="modelNamesComparer">An optional <see cref="StringComparer"/> instance used when comparing model names.</param>
-        public TemplateContext(object model, bool allowModelMembers = true, StringComparer? modelNamesComparer = null) : this(TemplateOptions.Default, modelNamesComparer)
+        public TemplateContext(object model, StringComparer? modelNamesComparer = null) : this(TemplateOptions.Default, modelNamesComparer)
         {
             ArgumentNullException.ThrowIfNull(model);
 
@@ -81,7 +80,6 @@ namespace Fluid
             else
             {
                 Model = FluidValue.Create(model, TemplateOptions.Default);
-                AllowModelMembers = allowModelMembers;
             }
         }
 
@@ -94,6 +92,18 @@ namespace Fluid
         /// Gets or sets the maximum number of steps a script can execute. Leave to 0 for unlimited.
         /// </summary>
         public int MaxSteps { get; set; } = TemplateOptions.Default.MaxSteps;
+
+        /// <summary>
+        /// Gets or sets the maximum number of characters a template or captured block can render.
+        /// Leave to 0 for unlimited.
+        /// </summary>
+        public int MaxOutputSize { get; set; } = TemplateOptions.Default.MaxOutputSize;
+
+        /// <summary>
+        /// Gets or sets the maximum number of items a template operation can materialize.
+        /// Leave to 0 for unlimited.
+        /// </summary>
+        public int MaxCollectionSize { get; set; } = TemplateOptions.Default.MaxCollectionSize;
 
         /// <summary>
         /// Gets <see cref="StringComparer"/> used when comparing model names.
@@ -145,6 +155,28 @@ namespace Fluid
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void EnsureOutputSize(long size)
+        {
+            CancellationToken.ThrowIfCancellationRequested();
+
+            if (size < 0 || (MaxOutputSize > 0 && size > MaxOutputSize))
+            {
+                ExceptionHelper.ThrowMaximumOutputSizeException(MaxOutputSize);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void EnsureCollectionSize(long size)
+        {
+            CancellationToken.ThrowIfCancellationRequested();
+
+            if (size < 0 || (MaxCollectionSize > 0 && size > MaxCollectionSize))
+            {
+                ExceptionHelper.ThrowMaximumCollectionSizeException(MaxCollectionSize);
+            }
+        }
+
         /// <summary>
         /// Gets or sets the current scope.
         /// </summary>
@@ -166,11 +198,6 @@ namespace Fluid
         /// global scopes are unsuccessful.
         /// </summary>
         public FluidValue Model { get; } = NilValue.Instance;
-
-        /// <summary>
-        /// Whether the direct properties of the Model can be accessed without being registered. Default is <code>true</code>.
-        /// </summary>
-        public bool AllowModelMembers { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the delegate to execute when a Capture tag has been evaluated.

--- a/Fluid/TemplateOptions.cs
+++ b/Fluid/TemplateOptions.cs
@@ -108,6 +108,18 @@ namespace Fluid
         public int MaxSteps { get; set; }
 
         /// <summary>
+        /// Gets or sets the maximum number of characters a template or captured block can render.
+        /// Leave to 0 for unlimited.
+        /// </summary>
+        public int MaxOutputSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of items a template operation can materialize.
+        /// Leave to 0 for unlimited.
+        /// </summary>
+        public int MaxCollectionSize { get; set; }
+
+        /// <summary>
         /// Gets or sets the <see cref="StringComparer"/> to use when comparing model names.
         /// </summary>
         /// <value>

--- a/Fluid/Utils/LimitedFluidOutput.cs
+++ b/Fluid/Utils/LimitedFluidOutput.cs
@@ -1,0 +1,103 @@
+using System.Buffers;
+
+namespace Fluid.Utils
+{
+    /// <summary>
+    /// Enforces a cumulative character limit over another <see cref="IFluidOutput"/>.
+    /// </summary>
+    public sealed class LimitedFluidOutput : IFluidOutput
+    {
+        private readonly IFluidOutput _inner;
+        private readonly int _maximum;
+        private int _written;
+
+        private LimitedFluidOutput(IFluidOutput inner, int maximum)
+        {
+            _inner = inner;
+            _maximum = maximum;
+        }
+
+        public static IFluidOutput Create(IFluidOutput output, int maximum)
+        {
+            ArgumentNullException.ThrowIfNull(output);
+
+            if (maximum <= 0)
+            {
+                return output;
+            }
+
+            if (output is LimitedFluidOutput limited && limited._maximum <= maximum)
+            {
+                return output;
+            }
+
+            return new LimitedFluidOutput(output, maximum);
+        }
+
+        public void Advance(int count)
+        {
+            EnsureAvailable(count);
+            _inner.Advance(count);
+            _written += count;
+        }
+
+        public Memory<char> GetMemory(int sizeHint = 0)
+        {
+            var remaining = GetRemaining(sizeHint);
+            var memory = _inner.GetMemory(sizeHint);
+            return memory.Length <= remaining ? memory : memory.Slice(0, remaining);
+        }
+
+        public Span<char> GetSpan(int sizeHint = 0)
+        {
+            var remaining = GetRemaining(sizeHint);
+            var span = _inner.GetSpan(sizeHint);
+            return span.Length <= remaining ? span : span.Slice(0, remaining);
+        }
+
+        public void Write(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return;
+            }
+
+            EnsureAvailable(value.Length);
+            _inner.Write(value);
+            _written += value.Length;
+        }
+
+        public void Write(char[] buffer, int index, int count)
+        {
+            ArgumentNullException.ThrowIfNull(buffer);
+            EnsureAvailable(count);
+            _inner.Write(buffer, index, count);
+            _written += count;
+        }
+
+        public ValueTask FlushAsync() => _inner.FlushAsync();
+
+        private int GetRemaining(int sizeHint)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(sizeHint);
+
+            var remaining = _maximum - _written;
+            if (remaining <= 0 || sizeHint > remaining)
+            {
+                ExceptionHelper.ThrowMaximumOutputSizeException(_maximum);
+            }
+
+            return remaining;
+        }
+
+        private void EnsureAvailable(int count)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(count);
+
+            if (count > _maximum - _written)
+            {
+                ExceptionHelper.ThrowMaximumOutputSizeException(_maximum);
+            }
+        }
+    }
+}

--- a/Fluid/Values/ArrayValue.cs
+++ b/Fluid/Values/ArrayValue.cs
@@ -16,6 +16,11 @@ namespace Fluid.Values
 
         public override bool Equals(FluidValue other)
         {
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
             if (other.IsNil())
             {
                 return Values.Count == 0;
@@ -23,6 +28,8 @@ namespace Fluid.Values
 
             if (other is ArrayValue arrayValue)
             {
+                using var scope = RecursiveComparisonGuard.Enter(this, arrayValue);
+
                 if (Values.Count != arrayValue.Values.Count)
                 {
                     return false;
@@ -108,9 +115,10 @@ namespace Fluid.Values
         {
             AssertWriteToParameters(output, encoder, cultureInfo);
 
-            foreach (var v in Values)
+            using var scope = RecursiveValueGuard.Enter(this);
+            foreach (var item in Values)
             {
-                output.Write(v.ToStringValue());
+                output.Write(item.ToStringValue());
             }
 
             return default;
@@ -118,11 +126,13 @@ namespace Fluid.Values
 
         public override string ToStringValue()
         {
+            using var scope = RecursiveValueGuard.Enter(this);
             return String.Join("", Values.Select(x => x.ToStringValue()));
         }
 
         public override object ToObjectValue()
         {
+            using var scope = RecursiveValueGuard.Enter(this);
             return Values.Select(x => x.ToObjectValue()).ToArray();
         }
 
@@ -133,9 +143,11 @@ namespace Fluid.Values
 
         public override async IAsyncEnumerable<FluidValue> EnumerateAsync(TemplateContext context)
         {
+            context?.EnsureCollectionSize(Values.Count);
+
             foreach (var value in Values)
             {
-                context?.CancellationToken.ThrowIfCancellationRequested();
+                context?.IncrementSteps();
                 yield return value;
             }
 
@@ -155,6 +167,7 @@ namespace Fluid.Values
 
         public override int GetHashCode()
         {
+            using var scope = RecursiveValueGuard.Enter(this);
             var hc = new HashCode();
 
             IReadOnlyList<FluidValue> values = Values;

--- a/Fluid/Values/ArrayValue.cs
+++ b/Fluid/Values/ArrayValue.cs
@@ -143,8 +143,6 @@ namespace Fluid.Values
 
         public override async IAsyncEnumerable<FluidValue> EnumerateAsync(TemplateContext context)
         {
-            context?.EnsureCollectionSize(Values.Count);
-
             foreach (var value in Values)
             {
                 context?.IncrementSteps();

--- a/Fluid/Values/DictionaryValue.cs
+++ b/Fluid/Values/DictionaryValue.cs
@@ -162,8 +162,6 @@ namespace Fluid.Values
 
         public override async IAsyncEnumerable<FluidValue> EnumerateAsync(TemplateContext context)
         {
-            context?.EnsureCollectionSize(_value.Count);
-
             foreach (var key in _value.Keys)
             {
                 context?.IncrementSteps();

--- a/Fluid/Values/DictionaryValue.cs
+++ b/Fluid/Values/DictionaryValue.cs
@@ -17,6 +17,11 @@ namespace Fluid.Values
 
         public override bool Equals(FluidValue other)
         {
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
             if (other.IsNil())
             {
                 return _value.Count == 0;
@@ -24,6 +29,8 @@ namespace Fluid.Values
 
             if (other is DictionaryValue otherDictionary)
             {
+                using var scope = RecursiveComparisonGuard.Enter(this, otherDictionary);
+
                 if (_value.Count != otherDictionary._value.Count)
                 {
                     return false;
@@ -116,6 +123,8 @@ namespace Fluid.Values
 
         public override string ToStringValue()
         {
+            using var scope = RecursiveValueGuard.Enter(this);
+
             if (_value.Count == 0)
             {
                 return "{}";
@@ -134,6 +143,7 @@ namespace Fluid.Values
 
         public override object ToObjectValue()
         {
+            using var scope = RecursiveValueGuard.Enter(this);
             return _value;
         }
 
@@ -152,8 +162,11 @@ namespace Fluid.Values
 
         public override async IAsyncEnumerable<FluidValue> EnumerateAsync(TemplateContext context)
         {
+            context?.EnsureCollectionSize(_value.Count);
+
             foreach (var key in _value.Keys)
             {
+                context?.IncrementSteps();
                 _value.TryGetValue(key, out var value);
                 yield return new ArrayValue([new StringValue(key), value]);
             }
@@ -174,6 +187,7 @@ namespace Fluid.Values
 
         public override int GetHashCode()
         {
+            using var scope = RecursiveValueGuard.Enter(this);
             var hc = new HashCode();
             foreach (var key in _value.Keys.OrderBy(k => k))
             {

--- a/Fluid/Values/RecursiveComparisonGuard.cs
+++ b/Fluid/Values/RecursiveComparisonGuard.cs
@@ -1,0 +1,57 @@
+using System.Runtime.CompilerServices;
+
+namespace Fluid.Values
+{
+    internal static class RecursiveComparisonGuard
+    {
+        [ThreadStatic]
+        private static HashSet<Pair> _pairs;
+
+        public static Scope Enter(FluidValue left, FluidValue right)
+        {
+            var pairs = _pairs ??= new HashSet<Pair>(PairComparer.Instance);
+            var pair = new Pair(left, right);
+
+            if (!pairs.Add(pair))
+            {
+                ExceptionHelper.ThrowRecursiveValueException();
+            }
+
+            return new Scope(pair);
+        }
+
+        internal readonly record struct Pair(FluidValue Left, FluidValue Right);
+
+        internal readonly struct Scope : IDisposable
+        {
+            private readonly Pair _pair;
+
+            internal Scope(Pair pair)
+            {
+                _pair = pair;
+            }
+
+            public void Dispose()
+            {
+                _pairs.Remove(_pair);
+                if (_pairs.Count == 0)
+                {
+                    _pairs = null;
+                }
+            }
+        }
+
+        private sealed class PairComparer : IEqualityComparer<Pair>
+        {
+            public static readonly PairComparer Instance = new();
+
+            public bool Equals(Pair x, Pair y) =>
+                ReferenceEquals(x.Left, y.Left) && ReferenceEquals(x.Right, y.Right);
+
+            public int GetHashCode(Pair pair) =>
+                HashCode.Combine(
+                    RuntimeHelpers.GetHashCode(pair.Left),
+                    RuntimeHelpers.GetHashCode(pair.Right));
+        }
+    }
+}

--- a/Fluid/Values/RecursiveValueGuard.cs
+++ b/Fluid/Values/RecursiveValueGuard.cs
@@ -1,0 +1,52 @@
+using System.Runtime.CompilerServices;
+
+namespace Fluid.Values
+{
+    internal static class RecursiveValueGuard
+    {
+        private const int MaximumDepth = 100;
+
+        [ThreadStatic]
+        private static HashSet<FluidValue> _values;
+
+        public static Scope Enter(FluidValue value)
+        {
+            var values = _values ??= new HashSet<FluidValue>(ReferenceComparer.Instance);
+
+            if (values.Count >= MaximumDepth || !values.Add(value))
+            {
+                ExceptionHelper.ThrowRecursiveValueException();
+            }
+
+            return new Scope(value);
+        }
+
+        internal readonly struct Scope : IDisposable
+        {
+            private readonly FluidValue _value;
+
+            public Scope(FluidValue value)
+            {
+                _value = value;
+            }
+
+            public void Dispose()
+            {
+                _values.Remove(_value);
+                if (_values.Count == 0)
+                {
+                    _values = null;
+                }
+            }
+        }
+
+        private sealed class ReferenceComparer : IEqualityComparer<FluidValue>
+        {
+            public static readonly ReferenceComparer Instance = new();
+
+            public bool Equals(FluidValue x, FluidValue y) => ReferenceEquals(x, y);
+
+            public int GetHashCode(FluidValue obj) => RuntimeHelpers.GetHashCode(obj);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ else
 #### Result
 `Hello Bill Gates`
 
+### Model security
+
+Fluid templates can read public properties and fields from the model and from objects reachable through it. This is by design; a model passed to `TemplateContext` should be treated as the template's readable data boundary.
+
+When rendering an untrusted template, pass a dedicated model that contains only the data the template is allowed to read. Do not pass domain entities, service objects, configuration objects, or other object graphs that may expose sensitive data through public members.
+
 ### Thread-safety
 
 A `FluidParser` instance is thread-safe and should be shared by the whole application. A common pattern is to declare the parser in a local static variable:
@@ -576,8 +582,20 @@ To prevent this, the `TemplateOptions` class defines a default `MaxRecursion = 1
 
 ### Limiting template execution
 
-A template can inadvertently create an infinite loop that could block the server by running indefinitely. 
-To prevent this, the `TemplateOptions` class defines a default `MaxSteps`. By default, this value is not set.
+A template can inadvertently perform enough work to block the server. `MaxSteps` limits statements, loop iterations, range construction, and built-in collection enumeration. `MaxOutputSize` limits cumulative rendered output, captured blocks, macro results, and amplified string operations. `MaxCollectionSize` limits ranges and collections materialized by built-in operations.
+
+These limits are unlimited by default to preserve compatibility. Set all of them when rendering untrusted templates:
+
+```csharp
+var options = new TemplateOptions
+{
+    MaxSteps = 10_000,
+    MaxOutputSize = 1_000_000,
+    MaxCollectionSize = 10_000
+};
+```
+
+`TemplateContext.CancellationToken` complements these limits and should also be set for untrusted templates. Custom filters, values, and output implementations are responsible for enforcing equivalent limits for work they perform outside Fluid's built-in operations.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -584,18 +584,68 @@ To prevent this, the `TemplateOptions` class defines a default `MaxRecursion = 1
 
 A template can inadvertently perform enough work to block the server. `MaxSteps` limits statements, loop iterations, range construction, and built-in collection enumeration. `MaxOutputSize` limits cumulative rendered output, captured blocks, macro results, and amplified string operations. `MaxCollectionSize` limits ranges and collections materialized by built-in operations.
 
-These limits are unlimited by default to preserve compatibility. Set all of them when rendering untrusted templates:
+`MaxSteps`, `MaxOutputSize`, and `MaxCollectionSize` are unlimited by default to preserve compatibility. Set all of them when rendering untrusted templates. `TemplateContext.CancellationToken` complements these limits and should also be set.
+
+### Rendering user-provided templates safely
+
+Fluid is a template engine, not a security sandbox. An application that accepts templates from users should apply all of the following controls:
+
+1. Limit the template source length before parsing. Render limits do not limit parsing.
+2. Pass a dedicated model containing only data the user is allowed to read. Templates can read public properties and fields from every object reachable through the model. Do not pass domain entities, services, dependency-injection containers, configuration, or secrets.
+3. Configure recursion, work, output, and collection limits. The appropriate values depend on the templates and capacity of the application; start conservatively and adjust using representative load tests.
+4. Set a per-render cancellation deadline in addition to the request cancellation token.
+5. Keep the default null file provider unless user templates need `include`, `render`, or `from`. If they do, use a tenant-scoped or allow-listed provider that cannot access application files or another tenant's templates.
+6. Expose only trusted custom filters, tags, values, and file providers. Extension code executes with the permissions of the application and must honor cancellation and equivalent resource limits.
+7. Apply normal service protections such as request-size limits, authentication, rate limits, bounded concurrency, and memory or process isolation where the threat model requires it.
+
+The following is an example starting point. The numerical limits are illustrative and should be tuned for the application:
 
 ```csharp
-var options = new TemplateOptions
+private const int MaxTemplateLength = 100_000;
+
+private static readonly FluidParser Parser = new FluidParser();
+
+private static readonly TemplateOptions UserTemplateOptions = new TemplateOptions
 {
+    MaxRecursion = 20,
     MaxSteps = 10_000,
     MaxOutputSize = 1_000_000,
     MaxCollectionSize = 10_000
+    // FileProvider retains its default NullFileProvider.
 };
+
+public static async ValueTask<string> RenderUserTemplateAsync(
+    string source,
+    SafeTemplateModel model,
+    CancellationToken requestAborted)
+{
+    if (source.Length > MaxTemplateLength)
+    {
+        throw new ArgumentException("The template is too large.", nameof(source));
+    }
+
+    if (!Parser.TryParse(source, out var template, out var error))
+    {
+        throw new ArgumentException(error, nameof(source));
+    }
+
+    using var timeout = CancellationTokenSource.CreateLinkedTokenSource(requestAborted);
+    timeout.CancelAfter(TimeSpan.FromSeconds(2));
+
+    var context = new TemplateContext(model, UserTemplateOptions)
+    {
+        CancellationToken = timeout.Token
+    };
+
+    return await template.RenderAsync(context);
+}
 ```
 
-`TemplateContext.CancellationToken` complements these limits and should also be set for untrusted templates. Custom filters, values, and output implementations are responsible for enforcing equivalent limits for work they perform outside Fluid's built-in operations.
+`TemplateOptions`, `FluidParser`, and parsed templates can be shared. Create a new `TemplateContext` for every render because it is not thread-safe and owns the execution counters and cancellation token.
+
+When a file provider can return different content for the same path in different tenants or security scopes, set `TemplateSourceInfo.CacheKey` to a stable value that includes that scope. This prevents a cached parsed template from crossing the same boundary enforced by the provider.
+
+`MaxOutputSize` counts UTF-16 characters written through Fluid's output abstraction. If the rendered result is encoded to a response with a separate byte limit, enforce that transport limit as well. Custom filters, values, tags, and output implementations are responsible for enforcing equivalent limits for work they perform outside Fluid's built-in operations.
 
 <br>
 


### PR DESCRIPTION
Untrusted templates can amplify output and collections, recursively traverse values, and exploit stale member-access cache decisions. This change adds configurable execution safeguards while preserving existing behavior by default.

## What changed

- Add `MaxOutputSize` and `MaxCollectionSize` limits, both unlimited by default for backward compatibility.
- Enforce cumulative output limits across interpreted and source-generated templates, nested rendering, captures, macros, concatenation, and amplifying filters.
- Bound range and collection materialization, and charge built-in collection enumeration against `MaxSteps` and cancellation.
- Protect value conversion, equality, and hashing from cyclic or excessively deep object graphs.
- Separate explicit member registrations from reflection memoization, key reflection caches by comparer policy, and atomically invalidate cache generations when registrations change.
- Remove `AllowModelMembers` and document that applications running untrusted templates should expose only dedicated, constrained model objects.
- Add regression coverage for resource limits, recursive values, accessor caching, and source-generated behavior.

Parser recursion limits are intentionally excluded because that protection belongs in Parlot and is being developed separately.

## Validation

Both interpreted and compiled parser test passes complete with 2,732 passing tests, 20 existing skips, and no failures.

Fluid-only benchmarks show parsing and allocations effectively unchanged. A repeated 10-iteration render benchmark measured approximately 2.0% overhead and 8 additional bytes allocated per render.