### PR TITLE
Fix source generator NuGet packaging

### DIFF
--- a/Fluid.SourceGenerator/AdditionalFilesTemplateProvider.cs
+++ b/Fluid.SourceGenerator/AdditionalFilesTemplateProvider.cs
@@ -1,9 +1,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Collections.Immutable;
+using Fluid.SourceGeneration;
 using Microsoft.CodeAnalysis;
-using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.Primitives;
 
 namespace Fluid.SourceGenerator
 {
@@ -44,7 +43,7 @@ namespace Fluid.SourceGenerator
             return templates;
         }
 
-        public static IFileProvider BuildFileProvider(IReadOnlyList<Template> templates)
+        public static Func<string, string> BuildTemplateResolver(IReadOnlyList<Template> templates)
         {
             var map = new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase);
 
@@ -66,7 +65,15 @@ namespace Fluid.SourceGenerator
                 }
             }
 
-            return new InMemoryFileProvider(map);
+            return path =>
+            {
+                if (map.TryGetValue(Normalize(path), out var content))
+                {
+                    return content;
+                }
+
+                throw new SourceGenerationException($"Rendered template '{path}' was not found in the provided additional files.");
+            };
         }
 
         private static string? TryGetRelativePath(string fullPath, string? projectDir)
@@ -101,61 +108,5 @@ namespace Fluid.SourceGenerator
 
         private static string Normalize(string? path) => (path ?? string.Empty).Replace('\\', '/').TrimStart('/');
 
-        private sealed class InMemoryFileProvider : IFileProvider
-        {
-            private readonly IReadOnlyDictionary<string, string> _files;
-
-            public InMemoryFileProvider(IReadOnlyDictionary<string, string> files)
-            {
-                _files = files;
-            }
-
-            public IDirectoryContents GetDirectoryContents(string subpath) => EmptyDirectoryContents.Singleton;
-
-            public IFileInfo GetFileInfo(string subpath)
-            {
-                var normalized = Normalize(subpath);
-
-                if (_files.TryGetValue(normalized, out var content))
-                {
-                    return new InMemoryFileInfo(normalized, content);
-                }
-
-                return new NotFoundFileInfo(subpath);
-            }
-
-            public IChangeToken Watch(string filter) => NullChangeToken.Singleton;
-
-            private sealed class InMemoryFileInfo : IFileInfo
-            {
-                private readonly byte[] _bytes;
-
-                public InMemoryFileInfo(string name, string content)
-                {
-                    Name = Path.GetFileName(name);
-                    _bytes = System.Text.Encoding.UTF8.GetBytes(content);
-                }
-
-                public bool Exists => true;
-                public long Length => _bytes.Length;
-                public string? PhysicalPath => null;
-                public string Name { get; }
-                public DateTimeOffset LastModified => DateTimeOffset.MinValue;
-                public bool IsDirectory => false;
-
-                public Stream CreateReadStream() => new MemoryStream(_bytes, writable: false);
-            }
-
-            private sealed class EmptyDirectoryContents : IDirectoryContents
-            {
-                public static readonly EmptyDirectoryContents Singleton = new();
-
-                public bool Exists => false;
-
-                public IEnumerator<IFileInfo> GetEnumerator() => System.Linq.Enumerable.Empty<IFileInfo>().GetEnumerator();
-
-                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
-            }
-        }
     }
 }

--- a/Fluid.SourceGenerator/Fluid.SourceGenerator.csproj
+++ b/Fluid.SourceGenerator/Fluid.SourceGenerator.csproj
@@ -15,8 +15,10 @@
     <!-- Required so the analyzer can load its dependencies at compile-time -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 
-    <!-- Keep build output so this can be referenced from tests in this repo -->
-    <IncludeBuildOutput>true</IncludeBuildOutput>
+    <!-- Source generators are consumed as analyzer assets, not library references. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,13 +26,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Fluid\Fluid.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\Fluid\Fluid.csproj"
+                      AdditionalProperties="AssemblyName=Fluid.SourceGenerator.Runtime;IntermediateOutputPath=obj\SourceGeneratorRuntime\$(Configuration)\$(TargetFramework)\;OutputPath=bin\SourceGeneratorRuntime\$(Configuration)\$(TargetFramework)\"
+                      Private="false"
+                      PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="EmbedAnalyzerRuntimeDependencies" AfterTargets="ResolveReferences" BeforeTargets="PrepareResources">
     <ItemGroup>
-      <_EmbedAnalyzerDep Include="@(ReferenceCopyLocalPaths)"
-                         Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'Fluid'" />
+      <_EmbedAnalyzerDep Include="@(ReferencePath)"
+                         Condition="'%(ReferencePath.Filename)' == 'Fluid.SourceGenerator.Runtime'" />
       <_EmbedAnalyzerDep Include="@(ReferenceCopyLocalPaths)"
                          Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'Parlot'" />
       <_EmbedAnalyzerDep Include="@(ReferenceCopyLocalPaths)"
@@ -51,9 +56,9 @@
   </Target>
 
   <ItemGroup>
-  <None Include="$(OutputPath)\*.dll" 
-          Pack="true" 
-          PackagePath="analyzers/dotnet/cs" 
+    <None Include="$(TargetPath)"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
           Visible="false" />
   </ItemGroup>
 

--- a/Fluid.SourceGenerator/FluidTemplateGenerator.cs
+++ b/Fluid.SourceGenerator/FluidTemplateGenerator.cs
@@ -139,7 +139,7 @@ namespace Fluid.SourceGenerator
                 return;
             }
 
-            var fileProvider = AdditionalFilesTemplateProvider.BuildFileProvider(templates);
+            var templateResolver = AdditionalFilesTemplateProvider.BuildTemplateResolver(templates);
             var parser = new FluidParser();
 
             // Compiled templates are emitted into a separate namespace to avoid polluting the user type.
@@ -170,7 +170,7 @@ namespace Fluid.SourceGenerator
                 {
                     Namespace = compiledNamespace,
                     ClassName = className,
-                    FileProvider = fileProvider
+                    TemplateContentResolver = templateResolver
                 };
 
                 var compiled = TemplateSourceGenerator.Generate(parsedTemplate, sourceOptions);

--- a/Fluid.Tests/SourceGenerator/FluidSourceGeneratorTests.cs
+++ b/Fluid.Tests/SourceGenerator/FluidSourceGeneratorTests.cs
@@ -59,11 +59,50 @@ public static partial class Templates
         }
 
         [Fact]
+        public async Task TemplatesAttribute_Compiles_Rendered_AdditionalFiles()
+        {
+            var userSource = @"
+using Fluid;
+using Fluid.SourceGenerator;
+
+namespace MyApp;
+
+[FluidTemplates(""**/*.liquid"")]
+public static partial class Templates
+{
+}
+";
+
+            var compilation = CreateCompilation(userSource);
+
+            var additional = ImmutableArray.Create<AdditionalText>(
+                new InMemoryAdditionalText("hello.liquid", "{% render 'partial' %}"),
+                new InMemoryAdditionalText("partial.liquid", "hi"));
+
+            var generator = new FluidTemplateGenerator();
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator.AsSourceGenerator() }, additionalTexts: additional);
+
+            driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
+
+            Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+
+            var emit = EmitToAssembly(outputCompilation);
+            var template = (IFluidTemplate)emit.Assembly.GetType("MyApp.Templates")!
+                .GetProperty("Hello", BindingFlags.Public | BindingFlags.Static)!
+                .GetValue(null)!;
+
+            var sw = new StringWriter();
+            await template.RenderAsync(sw, HtmlEncoder.Default, new TemplateContext());
+
+            Assert.Equal("hi", sw.ToString());
+        }
+
+        [Fact]
         public void GeneratorAssembly_EmbedsTemplateCompilerDependencies()
         {
             var resources = typeof(FluidTemplateGenerator).Assembly.GetManifestResourceNames();
 
-            Assert.Contains("Fluid.SourceGenerator.Dependencies.Fluid.dll", resources);
+            Assert.Contains("Fluid.SourceGenerator.Dependencies.Fluid.SourceGenerator.Runtime.dll", resources);
             Assert.Contains("Fluid.SourceGenerator.Dependencies.Parlot.dll", resources);
         }
 

--- a/Fluid/SourceGeneration/SourceGenerationOptions.cs
+++ b/Fluid/SourceGeneration/SourceGenerationOptions.cs
@@ -13,6 +13,11 @@ namespace Fluid.SourceGeneration
         public IFileProvider FileProvider { get; set; }
 
         /// <summary>
+        /// Optional resolver used at compile-time to load sub-template content.
+        /// </summary>
+        public Func<string, string> TemplateContentResolver { get; set; }
+
+        /// <summary>
         /// Optional known model type. When set, code generation can optimize model access.
         /// </summary>
         public Type ModelType { get; set; }

--- a/Fluid/SourceGeneration/TemplateSourceGenerator.cs
+++ b/Fluid/SourceGeneration/TemplateSourceGenerator.cs
@@ -194,9 +194,10 @@ namespace Fluid.SourceGeneration
                 return result;
             }
 
-            if (options.FileProvider == null)
+            if (options.TemplateContentResolver == null && options.FileProvider == null)
             {
-                throw new SourceGenerationException("SourceGenerationOptions.FileProvider is required to compile templates that use the 'render' tag.");
+                throw new SourceGenerationException(
+                    "SourceGenerationOptions.TemplateContentResolver or FileProvider is required to compile templates that use the 'render' tag.");
             }
 
             var queue = new Queue<RenderStatement>(visitor.RenderStatements);
@@ -212,7 +213,7 @@ namespace Fluid.SourceGeneration
                     continue;
                 }
 
-                var content = ReadTemplateContent(options.FileProvider, path);
+                var content = ReadTemplateContent(options, path);
 
                 if (!render.Parser.TryParse(content, out var parsedTemplate, out var errors))
                 {
@@ -245,8 +246,20 @@ namespace Fluid.SourceGeneration
             return result;
         }
 
-        private static string ReadTemplateContent(IFileProvider fileProvider, string relativePath)
+        private static string ReadTemplateContent(SourceGenerationOptions options, string relativePath)
         {
+            if (options.TemplateContentResolver != null)
+            {
+                var content = options.TemplateContentResolver(relativePath);
+                if (content == null)
+                {
+                    throw new SourceGenerationException($"Rendered template '{relativePath}' was not found by the provided TemplateContentResolver.");
+                }
+
+                return content;
+            }
+
+            var fileProvider = options.FileProvider;
             var fileInfo = fileProvider.GetFileInfo(relativePath);
             if (fileInfo == null || !fileInfo.Exists || fileInfo.IsDirectory)
             {


### PR DESCRIPTION
The source generator package currently uses an output-directory wildcard, which can ship Roslyn compiler assemblies on Windows and matches no analyzer assemblies on Unix-like systems. This fixes the package while preserving the original goal of making the generator and its compile-time dependencies load reliably from NuGet.

## Approach

- Package only `Fluid.SourceGenerator.dll` under `analyzers/dotnet/cs`, with no `lib/` asset or NuGet dependency group.
- Embed the curated compile-time dependency graph into the analyzer instead of copying arbitrary output DLLs.
- Build the embedded Fluid runtime with a distinct assembly identity and isolated output/intermediate paths so it cannot conflict with or overwrite the consumer-facing `Fluid.dll`.
- Resolve rendered `AdditionalFiles` through a BCL-only delegate to avoid analyzer load-context conflicts with `Microsoft.Extensions.FileProviders`.
- Preserve the existing `FileProvider` fallback for public source-generation callers.

## Validation

- Inspected the packed archive: it contains only `analyzers/dotnet/cs/Fluid.SourceGenerator.dll`.
- Built and ran a fresh NuGet consumer; the packaged generator compiled and rendered a Liquid template successfully.
- Verified normal and private Fluid builds can run concurrently without output collisions or runtime leakage.
- Ran the focused source-generation suites in standard and compiled-parser modes: 25/25 passed in each mode.