### PR TITLE
Reduce render argument allocations

### DIFF
--- a/Fluid.Benchmarks/RenderScenarioBenchmarks.cs
+++ b/Fluid.Benchmarks/RenderScenarioBenchmarks.cs
@@ -32,6 +32,7 @@ namespace Fluid.Benchmarks
         private readonly IFluidTemplate _pascalCaseTemplate;
         private readonly IFluidTemplate _decimalPriceTemplate;
         private readonly IFluidTemplate _renderScopeTemplate;
+        private readonly IFluidTemplate _renderArgumentsTemplate;
         private readonly IFluidTemplate _includeScopeTemplate;
 
         private readonly List<object> _mixedItems = new(ItemCount);
@@ -111,6 +112,7 @@ namespace Fluid.Benchmarks
                     DateTimeOffset.UnixEpoch,
                     _ => new ValueTask<Stream>(new MemoryStream(partialBytes, writable: false)))));
             _parser.TryParse("{% assign outer = 'hidden' %}{% render 'partial', value: root %}", out _renderScopeTemplate);
+            _parser.TryParse("{% render 'partial', value: root, outer: root %}", out _renderArgumentsTemplate);
             _parser.TryParse("{% assign outer = 'hidden' %}{% include 'partial', value: root %}", out _includeScopeTemplate);
 
             CheckAll();
@@ -126,6 +128,7 @@ namespace Fluid.Benchmarks
             Verify(nameof(PascalCaseMemberNames), PascalCaseMemberNames(), "N0");
             Verify(nameof(NonInternedNumbers), NonInternedNumbers(), "19.99");
             Verify(nameof(IsolatedRenderScope), IsolatedRenderScope(), "RR");
+            Verify(nameof(RenderWithArguments), RenderWithArguments(), "RRR");
             Verify(nameof(WriteThroughIncludeScope), WriteThroughIncludeScope(), "RRhidden");
 
             static void Verify(string name, string result, string expected)
@@ -203,6 +206,14 @@ namespace Fluid.Benchmarks
         {
             var context = new TemplateContext(_partialOptions).SetValue("root", "R");
             return _renderScopeTemplate.Render(context);
+        }
+
+        /// <summary>An isolated partial render with two named arguments.</summary>
+        [Benchmark]
+        public string RenderWithArguments()
+        {
+            var context = new TemplateContext(_partialOptions).SetValue("root", "R");
+            return _renderArgumentsTemplate.Render(context);
         }
 
         /// <summary>A write-through include scope with a temporary named argument.</summary>

--- a/Fluid.Tests/IncludeStatementTests.cs
+++ b/Fluid.Tests/IncludeStatementTests.cs
@@ -690,6 +690,40 @@ shape: ''";
         }
 
         [Fact]
+        public async Task RenderTag_AssignedCallbacksCompleteBeforeArgumentsArePublished()
+        {
+            var fileProvider = new MockFileProvider();
+            fileProvider.Add("arguments.liquid", "{{ first }} {{ second }} {{ third }}");
+
+            var options = new TemplateOptions { FileProvider = fileProvider };
+            var callbackCount = 0;
+            options.Assigned = (identifier, value, context) =>
+            {
+                callbackCount++;
+                Assert.IsType<UndefinedValue>(context.GetValue("first"));
+
+                if (identifier == "third")
+                {
+                    throw new InvalidOperationException("assigned failed");
+                }
+
+                return new ValueTask<FluidValue>(value);
+            };
+
+            var context = new TemplateContext(options);
+            var rootScope = context.LocalScope;
+            _parser.TryParse("{% render 'arguments', first: 'a', second: 'b', third: 'c' %}", out var template);
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => template.RenderAsync(new StringWriter(), HtmlEncoder.Default, context).AsTask());
+
+            Assert.Equal("assigned failed", exception.Message);
+            Assert.Equal(3, callbackCount);
+            Assert.Same(rootScope, context.LocalScope);
+            Assert.IsType<UndefinedValue>(context.GetValue("first"));
+        }
+
+        [Fact]
         public async Task RenderTag_For_And_NamedArguments()
         {
             var fileProvider = new MockFileProvider();

--- a/Fluid/Ast/RenderStatement.cs
+++ b/Fluid/Ast/RenderStatement.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using Fluid.Values;
 using System.Text.Encodings.Web;
 using Fluid.SourceGeneration;
@@ -61,19 +62,19 @@ namespace Fluid.Ast
             }
 
             // Liquid evaluates named argument expressions in the caller before creating the isolated context.
-            var assignedValues = await EvaluateAssignStatementsAsync(AssignStatements, context);
+            using var assignedValues = await EvaluateAssignStatementsAsync(AssignStatements, context);
 
             using var scope = context.EnterScope(ScopeBehavior.Isolated);
 
             if (With != null)
             {
                 context.SetValue(Alias ?? identifier, withValue);
-                ApplyAssignStatements(assignedValues, context);
+                ApplyAssignStatements(AssignStatements, assignedValues, context);
                 await template.RenderAsync(output, encoder, context);
             }
             else if (For != null)
             {
-                ApplyAssignStatements(assignedValues, context);
+                ApplyAssignStatements(AssignStatements, assignedValues, context);
                 var forloop = new ForLoopValue { IsRenderLoop = true };
                 var length = forloop.Length = list.Count;
 
@@ -100,7 +101,7 @@ namespace Fluid.Ast
             }
             else
             {
-                ApplyAssignStatements(assignedValues, context);
+                ApplyAssignStatements(AssignStatements, assignedValues, context);
                 await template.RenderAsync(output, encoder, context);
             }
 
@@ -229,44 +230,131 @@ namespace Fluid.Ast
             context.WriteLine("return Completion.Normal;");
         }
 
-        private static async ValueTask<KeyValuePair<string, FluidValue>[]> EvaluateAssignStatementsAsync(
+        private static async ValueTask<EvaluatedArguments> EvaluateAssignStatementsAsync(
             IReadOnlyList<AssignStatement> assignStatements,
             TemplateContext context)
         {
             var length = assignStatements.Count;
             if (length == 0)
             {
-                return [];
+                return default;
             }
 
-            var evaluatedValues = new KeyValuePair<string, FluidValue>[length];
+            context.IncrementSteps();
 
-            for (var i = 0; i < length; i++)
+            var firstStatement = assignStatements[0];
+            var firstValue = await firstStatement.Value.EvaluateAsync(context);
+
+            if (context.Assigned != null)
             {
-                context.IncrementSteps();
+                firstValue = await context.Assigned.Invoke(firstStatement.Identifier, firstValue, context);
+            }
 
-                var assignStatement = assignStatements[i];
-                var value = await assignStatement.Value.EvaluateAsync(context);
+            if (length == 1)
+            {
+                return new EvaluatedArguments(firstValue);
+            }
 
-                if (context.Assigned != null)
+            context.IncrementSteps();
+
+            var secondStatement = assignStatements[1];
+            var secondValue = await secondStatement.Value.EvaluateAsync(context);
+
+            if (context.Assigned != null)
+            {
+                secondValue = await context.Assigned.Invoke(secondStatement.Identifier, secondValue, context);
+            }
+
+            if (length == 2)
+            {
+                return new EvaluatedArguments(firstValue, secondValue);
+            }
+
+            var evaluatedValues = ArrayPool<FluidValue>.Shared.Rent(length);
+            evaluatedValues[0] = firstValue;
+            evaluatedValues[1] = secondValue;
+
+            try
+            {
+                for (var i = 2; i < length; i++)
                 {
-                    value = await context.Assigned.Invoke(assignStatement.Identifier, value, context);
+                    context.IncrementSteps();
+
+                    var assignStatement = assignStatements[i];
+                    var value = await assignStatement.Value.EvaluateAsync(context);
+
+                    if (context.Assigned != null)
+                    {
+                        value = await context.Assigned.Invoke(assignStatement.Identifier, value, context);
+                    }
+
+                    evaluatedValues[i] = value;
                 }
 
-                evaluatedValues[i] = new KeyValuePair<string, FluidValue>(assignStatement.Identifier, value);
+                return new EvaluatedArguments(evaluatedValues, length);
             }
-
-            return evaluatedValues;
+            catch
+            {
+                ArrayPool<FluidValue>.Shared.Return(evaluatedValues, clearArray: true);
+                throw;
+            }
         }
 
         private static void ApplyAssignStatements(
-            KeyValuePair<string, FluidValue>[] assignedValues,
+            IReadOnlyList<AssignStatement> assignStatements,
+            EvaluatedArguments assignedValues,
             TemplateContext context)
         {
-            for (var i = 0; i < assignedValues.Length; i++)
+            for (var i = 0; i < assignedValues.Count; i++)
             {
-                var entry = assignedValues[i];
-                context.SetValue(entry.Key, entry.Value);
+                context.SetValue(assignStatements[i].Identifier, assignedValues[i]);
+            }
+        }
+
+        private readonly struct EvaluatedArguments : IDisposable
+        {
+            private readonly FluidValue _value0;
+            private readonly FluidValue _value1;
+            private readonly FluidValue[] _values;
+
+            public EvaluatedArguments(FluidValue value)
+            {
+                _value0 = value;
+                _value1 = null;
+                _values = null;
+                Count = 1;
+            }
+
+            public EvaluatedArguments(FluidValue value0, FluidValue value1)
+            {
+                _value0 = value0;
+                _value1 = value1;
+                _values = null;
+                Count = 2;
+            }
+
+            public EvaluatedArguments(FluidValue[] values, int count)
+            {
+                _value0 = null;
+                _value1 = null;
+                _values = values;
+                Count = count;
+            }
+
+            public int Count { get; }
+
+            public FluidValue this[int index] => _values is not null
+                ? _values[index]
+                : index == 0
+                    ? _value0
+                    : _value1;
+
+            public void Dispose()
+            {
+                if (_values != null)
+                {
+                    ArrayPool<FluidValue>.Shared.Return(_values, clearArray: true);
+                }
             }
         }
 


### PR DESCRIPTION
The scope-management rewrite merged in #981 already removes the redundant render scope allocation. Named render arguments still allocate a temporary `KeyValuePair[]` on every execution, even though most calls pass only one or two arguments.

## Approach

- Keep one- and two-argument values inline without temporary arrays.
- Rent cleared `FluidValue[]` storage only for three or more arguments and return it on both success and failure.
- Continue evaluating every expression and `Assigned` callback in the caller scope before publishing any argument into the isolated render scope.
- Add callback-order/error-cleanup coverage and a focused two-argument BenchmarkDotNet case.

## Benchmark

BenchmarkDotNet 0.15.8, .NET 10.0.11 Arm64, Apple M4 Pro, in-process toolchain, 3 warmup and 5 measurement iterations:

| Shape | `origin/main` | This change | Difference |
|---|---:|---:|---:|
| Two named render arguments | 207.2 ns / 744 B | 212.1 ns / 688 B | **-56 B (-7.5%)** |

The timing confidence intervals overlap (198.3-216.1 ns baseline and 207.8-216.5 ns after), so this is treated as allocation-neutral throughput rather than a speed improvement. A pool-only two-argument version measured 218.5 ns / 688 B; inline storage was retained for the common case, with pooling reserved for larger argument sets.

## Validation

- Targeted interpreted and compiled render tests: 3 passed in each mode
- `dotnet test --no-restore`: 2,750 passed, 20 skipped, 0 failed
- `dotnet test --no-restore /p:Compiled=true`: 2,750 passed, 20 skipped, 0 failed
- Release build of `Fluid`: netstandard2.0, net8.0, net9.0, and net10.0 with no warnings or errors

This PR now targets `main` directly because #981 merged the preceding scope-management layer.