### PR TITLE
Add direct UTF-8 template rendering

### DIFF
--- a/Fluid.Benchmarks/Program.cs
+++ b/Fluid.Benchmarks/Program.cs
@@ -1,13 +1,20 @@
 using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Running;
 
 namespace Fluid.Benchmarks
 {
     class Program
     {
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
+            if (args.Length > 0 && args[0].Equals("utf8-metrics", StringComparison.OrdinalIgnoreCase))
+            {
+                await Utf8OutputBenchmarks.PrintMeasurementsAsync();
+                return;
+            }
+
             // Steady-state loop for sampling profilers (for instance `ultra profile -- Fluid.Benchmarks.exe profile render 25`).
             // BenchmarkDotNet spawns short-lived child processes, which a profiler can't follow.
             if (args.Length > 0 && args[0].Equals("profile", StringComparison.OrdinalIgnoreCase))

--- a/Fluid.Benchmarks/Utf8OutputBenchmarks.cs
+++ b/Fluid.Benchmarks/Utf8OutputBenchmarks.cs
@@ -1,0 +1,290 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using Fluid.Utils;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fluid.Benchmarks
+{
+    [MemoryDiagnoser]
+    [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+    [ShortRunJob]
+    public class Utf8OutputBenchmarks
+    {
+        private static readonly UTF8Encoding Utf8 = new UTF8Encoding(false);
+        private static readonly Scenario[] Scenarios =
+        [
+            new(
+                "SmallAscii",
+                "Hello {{ name }}!",
+                () => new TemplateContext().SetValue("name", "Fluid"),
+                NullEncoder.Default),
+            new(
+                "ProductTemplate",
+                """
+                <section class="products">
+                {% for product in products %}
+                  <article data-id="{{ product.id }}">
+                    <h2>{{ product.name }}</h2>
+                    <p>{{ product.description }}</p>
+                    <strong>{{ product.price }}</strong>
+                  </article>
+                {% endfor %}
+                </section>
+                """,
+                CreateProductContext,
+                HtmlEncoder.Default),
+            new(
+                "UnicodeEncoded",
+                "<h1>{{ title }}</h1><p>{{ description }}</p>",
+                () => new TemplateContext()
+                    .SetValue("title", "\u65b0\u5546\u54c1 \ud83d\ude80")
+                    .SetValue("description", "<strong>Cr\u00e8me & caf\u00e9</strong>"),
+                HtmlEncoder.Default),
+            new(
+                "LargeOutput",
+                "{{ content }}",
+                () => new TemplateContext().SetValue("content", new string('x', 256 * 1024)),
+                NullEncoder.Default)
+        ];
+
+        private readonly CountingStream _stream = new();
+        private readonly CountingByteWriter _byteWriter = new(512 * 1024);
+        private IFluidTemplate _template;
+
+        [ParamsSource(nameof(ScenarioValues))]
+        public Scenario BenchmarkScenario { get; set; }
+
+        public IEnumerable<Scenario> ScenarioValues => Scenarios;
+
+        [GlobalSetup]
+        public async Task Setup()
+        {
+            _template = new FluidParser().Parse(BenchmarkScenario.Template);
+
+            var baseline = await TextWriterThenUtf8();
+            var candidate = await DirectUtf8();
+            if (baseline.BytesWritten != candidate.BytesWritten ||
+                baseline.FlushCount == 0 ||
+                candidate.FlushCount == 0)
+            {
+                throw new InvalidOperationException(
+                    $"Invalid output metrics for {BenchmarkScenario}: {baseline} vs {candidate}.");
+            }
+        }
+
+        [Benchmark(Baseline = true)]
+        [BenchmarkCategory("UTF8")]
+        public async ValueTask<RenderMeasurement> TextWriterThenUtf8()
+        {
+            _stream.Reset();
+
+            await using (var writer = new StreamWriter(
+                _stream,
+                Utf8,
+                bufferSize: 1024,
+                leaveOpen: true))
+            {
+                await using (var output = new TextWriterFluidOutput(
+                    writer,
+                    bufferSize: 16 * 1024,
+                    leaveOpen: true,
+                    allowSynchronousIO: false))
+                {
+                    await _template.RenderAsync(
+                        output,
+                        BenchmarkScenario.Encoder,
+                        BenchmarkScenario.CreateContext());
+                }
+
+            }
+
+            return new RenderMeasurement(_stream.BytesWritten, _stream.FlushCount);
+        }
+
+        [Benchmark]
+        [BenchmarkCategory("UTF8")]
+        public async ValueTask<RenderMeasurement> DirectUtf8()
+        {
+            _byteWriter.Reset();
+
+            await using (var output = new Utf8FluidOutput(_byteWriter))
+            {
+                await _template.RenderAsync(
+                    output,
+                    BenchmarkScenario.Encoder,
+                    BenchmarkScenario.CreateContext());
+            }
+
+            await _byteWriter.FlushAsync();
+            return new RenderMeasurement(_byteWriter.BytesWritten, _byteWriter.FlushCount);
+        }
+
+        public static async Task PrintMeasurementsAsync()
+        {
+            Console.WriteLine("| Scenario | Path | Bytes written | Flushes |");
+            Console.WriteLine("| --- | --- | ---: | ---: |");
+
+            foreach (var scenario in Scenarios)
+            {
+                var benchmark = new Utf8OutputBenchmarks { BenchmarkScenario = scenario };
+                await benchmark.Setup();
+
+                var baseline = await benchmark.TextWriterThenUtf8();
+                var candidate = await benchmark.DirectUtf8();
+                Console.WriteLine($"| {scenario} | TextWriter + UTF-8 | {baseline.BytesWritten} | {baseline.FlushCount} |");
+                Console.WriteLine($"| {scenario} | Direct UTF-8 | {candidate.BytesWritten} | {candidate.FlushCount} |");
+            }
+        }
+
+        private static TemplateContext CreateProductContext()
+        {
+            var products = new List<Dictionary<string, object>>(100);
+            for (var i = 0; i < 100; i++)
+            {
+                products.Add(new Dictionary<string, object>
+                {
+                    ["id"] = i,
+                    ["name"] = "Product " + i,
+                    ["description"] = "A practical <item> for home & office.",
+                    ["price"] = 19.95m + i
+                });
+            }
+
+            return new TemplateContext().SetValue("products", products);
+        }
+
+        public sealed class Scenario
+        {
+            public Scenario(
+                string name,
+                string template,
+                Func<TemplateContext> createContext,
+                TextEncoder encoder)
+            {
+                Name = name;
+                Template = template;
+                CreateContext = createContext;
+                Encoder = encoder;
+            }
+
+            public string Name { get; }
+
+            public string Template { get; }
+
+            public Func<TemplateContext> CreateContext { get; }
+
+            public TextEncoder Encoder { get; }
+
+            public override string ToString() => Name;
+        }
+
+        public readonly record struct RenderMeasurement(long BytesWritten, int FlushCount);
+
+        private sealed class CountingByteWriter : IBufferWriter<byte>
+        {
+            private readonly byte[] _buffer;
+            private int _index;
+
+            public CountingByteWriter(int capacity)
+            {
+                _buffer = new byte[capacity];
+            }
+
+            public long BytesWritten => _index;
+
+            public int FlushCount { get; private set; }
+
+            public void Advance(int count) => _index += count;
+
+            public Memory<byte> GetMemory(int sizeHint = 0) => _buffer.AsMemory(_index);
+
+            public Span<byte> GetSpan(int sizeHint = 0) => _buffer.AsSpan(_index);
+
+            public ValueTask FlushAsync()
+            {
+                FlushCount++;
+                return default;
+            }
+
+            public void Reset()
+            {
+                _index = 0;
+                FlushCount = 0;
+            }
+        }
+
+        private sealed class CountingStream : Stream
+        {
+            public long BytesWritten { get; private set; }
+
+            public int FlushCount { get; private set; }
+
+            public override bool CanRead => false;
+
+            public override bool CanSeek => false;
+
+            public override bool CanWrite => true;
+
+            public override long Length => BytesWritten;
+
+            public override long Position
+            {
+                get => BytesWritten;
+                set => throw new NotSupportedException();
+            }
+
+            public override void Flush() => FlushCount++;
+
+            public override Task FlushAsync(CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                FlushCount++;
+                return Task.CompletedTask;
+            }
+
+            public override void Write(byte[] buffer, int offset, int count) => BytesWritten += count;
+
+            public override Task WriteAsync(
+                byte[] buffer,
+                int offset,
+                int count,
+                CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                BytesWritten += count;
+                return Task.CompletedTask;
+            }
+
+            public override ValueTask WriteAsync(
+                ReadOnlyMemory<byte> buffer,
+                CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                BytesWritten += buffer.Length;
+                return default;
+            }
+
+            public void Reset()
+            {
+                BytesWritten = 0;
+                FlushCount = 0;
+            }
+
+            public override int Read(byte[] buffer, int offset, int count) =>
+                throw new NotSupportedException();
+
+            public override long Seek(long offset, SeekOrigin origin) =>
+                throw new NotSupportedException();
+
+            public override void SetLength(long value) =>
+                throw new NotSupportedException();
+        }
+    }
+}

--- a/Fluid.Benchmarks/Utf8OutputBenchmarks.cs
+++ b/Fluid.Benchmarks/Utf8OutputBenchmarks.cs
@@ -114,13 +114,10 @@ namespace Fluid.Benchmarks
         {
             _byteWriter.Reset();
 
-            await using (var output = new Utf8FluidOutput(_byteWriter))
-            {
-                await _template.RenderAsync(
-                    output,
-                    BenchmarkScenario.Encoder,
-                    BenchmarkScenario.CreateContext());
-            }
+            await _template.RenderAsync(
+                _byteWriter,
+                BenchmarkScenario.Encoder,
+                BenchmarkScenario.CreateContext());
 
             await _byteWriter.FlushAsync();
             return new RenderMeasurement(_byteWriter.BytesWritten, _byteWriter.FlushCount);

--- a/Fluid.Tests/Utf8FluidOutputTests.cs
+++ b/Fluid.Tests/Utf8FluidOutputTests.cs
@@ -91,11 +91,38 @@ namespace Fluid.Tests
             var template = _parser.Parse("<p>{{ value }}|{{ value | raw }}</p>");
             var context = new TemplateContext().SetValue("value", "<\ud83d\ude80>");
             var writer = new ArrayBufferWriter<byte>();
-            await using var output = new Utf8FluidOutput(writer, minimumCharBufferSize: 4);
 
-            await template.RenderAsync(output, HtmlEncoder.Default, context);
+            await template.RenderAsync(writer, HtmlEncoder.Default, context);
 
             Assert.Equal("<p>&lt;&#x1F680;&gt;|<\ud83d\ude80></p>", Decode(writer));
+        }
+
+        [Fact]
+        public async Task RenderAsyncFinalizesEncodingWithoutOwningDestination()
+        {
+            var template = _parser.Parse("{{ value | raw }}");
+            var writer = new DisposableByteWriter();
+
+            await template.RenderAsync(
+                writer,
+                NullEncoder.Default,
+                new TemplateContext().SetValue("value", "\ud83d"));
+
+            Assert.Equal("\ufffd", writer.ToString());
+            Assert.False(writer.IsDisposed);
+        }
+
+        [Fact]
+        public async Task RenderAsyncReportsCancellationRaisedDuringFinalization()
+        {
+            using var cancellation = new CancellationTokenSource();
+            var writer = new CancellationOnSecondGetSpanWriter(cancellation);
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                _parser.Parse("value").RenderAsync(
+                    writer,
+                    NullEncoder.Default,
+                    new TemplateContext { CancellationToken = cancellation.Token }).AsTask());
         }
 
         [Fact]
@@ -170,9 +197,8 @@ namespace Fluid.Tests
             context.SetValue("items", new[] { "\ud83d\ude80", "\u4e16\u754c" });
             var template = _parser.Parse("{% render 'item' for items as item %}");
             var writer = new ArrayBufferWriter<byte>();
-            await using var output = new Utf8FluidOutput(writer);
 
-            await template.RenderAsync(output, NullEncoder.Default, context);
+            await template.RenderAsync(writer, NullEncoder.Default, context);
 
             Assert.Equal("[\ud83d\ude80][\u4e16\u754c]", Decode(writer));
         }
@@ -182,17 +208,16 @@ namespace Fluid.Tests
         {
             var template = _parser.Parse("{{ value }}");
             var writer = new ArrayBufferWriter<byte>();
-            await using var output = new Utf8FluidOutput(writer);
 
             await template.RenderAsync(
-                output,
+                writer,
                 NullEncoder.Default,
                 new TemplateContext { MaxOutputSize = 2 }.SetValue("value", "\ud83d\ude80"));
 
             Assert.Equal(4, writer.WrittenCount);
             await Assert.ThrowsAsync<InvalidOperationException>(() =>
                 template.RenderAsync(
-                    new Utf8FluidOutput(new ArrayBufferWriter<byte>()),
+                    new ArrayBufferWriter<byte>(),
                     NullEncoder.Default,
                     new TemplateContext { MaxOutputSize = 1 }.SetValue("value", "\ud83d\ude80")).AsTask());
         }
@@ -257,6 +282,40 @@ namespace Fluid.Tests
             public bool IsDisposed { get; private set; }
 
             public void Dispose() => IsDisposed = true;
+        }
+
+        private sealed class CancellationOnSecondGetSpanWriter : IBufferWriter<byte>
+        {
+            private readonly ArrayBufferWriter<byte> _inner = new();
+            private readonly CancellationTokenSource _cancellation;
+            private int _getSpanCount;
+
+            public CancellationOnSecondGetSpanWriter(CancellationTokenSource cancellation)
+            {
+                _cancellation = cancellation;
+            }
+
+            public void Advance(int count) => _inner.Advance(count);
+
+            public Memory<byte> GetMemory(int sizeHint = 0)
+            {
+                BeforeGetBuffer();
+                return _inner.GetMemory(sizeHint);
+            }
+
+            public Span<byte> GetSpan(int sizeHint = 0)
+            {
+                BeforeGetBuffer();
+                return _inner.GetSpan(sizeHint);
+            }
+
+            private void BeforeGetBuffer()
+            {
+                if (++_getSpanCount == 2)
+                {
+                    _cancellation.Cancel();
+                }
+            }
         }
     }
 }

--- a/Fluid.Tests/Utf8FluidOutputTests.cs
+++ b/Fluid.Tests/Utf8FluidOutputTests.cs
@@ -1,0 +1,262 @@
+using Fluid.Tests.Mocks;
+using Fluid.Utils;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Fluid.Tests
+{
+    public class Utf8FluidOutputTests
+    {
+#if COMPILED
+        private static readonly FluidParser _parser = new FluidParser().Compile();
+#else
+        private static readonly FluidParser _parser = new FluidParser();
+#endif
+
+        [Fact]
+        public async Task WritesAsciiBmpAndNonBmpUnicode()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            await using var output = new Utf8FluidOutput(writer);
+
+            output.Write("ASCII | \u4e16\u754c | \ud83d\ude80");
+            await output.FlushAsync();
+
+            Assert.Equal("ASCII | \u4e16\u754c | \ud83d\ude80", Decode(writer));
+        }
+
+        [Fact]
+        public async Task PreservesSurrogatePairsAcrossWrites()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            await using var output = new Utf8FluidOutput(writer);
+
+            output.Write("\ud83d");
+            await output.FlushAsync();
+            output.Write("\ude80");
+            await output.FlushAsync();
+
+            Assert.Equal("\ud83d\ude80", Decode(writer));
+        }
+
+        [Fact]
+        public async Task ContinuesWritingAfterIntermediateFlush()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            await using var output = new Utf8FluidOutput(writer);
+
+            output.Write("\u4e16\u754c");
+            await output.FlushAsync();
+            output.Write("\ud83d\ude80");
+            await output.FlushAsync();
+
+            Assert.Equal("\u4e16\u754c\ud83d\ude80", Decode(writer));
+        }
+
+        [Fact]
+        public async Task ReplacesMalformedSurrogatesLikeStandardUtf8()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            var output = new Utf8FluidOutput(writer);
+
+            output.Write("\ud83dX\ude80");
+            await output.DisposeAsync();
+
+            Assert.Equal("\ufffdX\ufffd", Decode(writer));
+        }
+
+        [Fact]
+        public async Task EncodesCharactersWrittenThroughBufferWriter()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            await using var output = new Utf8FluidOutput(writer, minimumCharBufferSize: 2);
+
+            "Fluid \ud83d\ude80".AsSpan().CopyTo(output.GetSpan(8));
+            output.Advance(8);
+            await output.FlushAsync();
+
+            Assert.Equal("Fluid \ud83d\ude80", Decode(writer));
+        }
+
+        [Fact]
+        public async Task RendersLiteralsEncodedValuesAndRawValuesWithCorrectSemantics()
+        {
+            var template = _parser.Parse("<p>{{ value }}|{{ value | raw }}</p>");
+            var context = new TemplateContext().SetValue("value", "<\ud83d\ude80>");
+            var writer = new ArrayBufferWriter<byte>();
+            await using var output = new Utf8FluidOutput(writer, minimumCharBufferSize: 4);
+
+            await template.RenderAsync(output, HtmlEncoder.Default, context);
+
+            Assert.Equal("<p>&lt;&#x1F680;&gt;|<\ud83d\ude80></p>", Decode(writer));
+        }
+
+        [Fact]
+        public async Task TranscodesAcrossTinyDestinationSegments()
+        {
+            var writer = new SegmentedByteWriter(segmentSize: 4);
+            await using var output = new Utf8FluidOutput(writer);
+
+            output.Write("a\u00e9\u4e16\ud83d\ude80z");
+            await output.FlushAsync();
+
+            Assert.Equal("a\u00e9\u4e16\ud83d\ude80z", writer.ToString());
+            Assert.True(writer.AdvanceCount > 1);
+        }
+
+        [Fact]
+        public async Task FlushHonorsCancellation()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            using var cancellation = new CancellationTokenSource();
+            var output = new Utf8FluidOutput(writer, cancellationToken: cancellation.Token);
+            output.Write("value");
+            cancellation.Cancel();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() => output.FlushAsync().AsTask());
+            await output.DisposeAsync();
+        }
+
+        [Fact]
+        public async Task DisposalSkipsBufferedEncodingAfterCancellation()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            using var cancellation = new CancellationTokenSource();
+            var output = new Utf8FluidOutput(
+                writer,
+                minimumCharBufferSize: 4,
+                cancellationToken: cancellation.Token);
+            "data".AsSpan().CopyTo(output.GetSpan(4));
+            output.Advance(4);
+
+            cancellation.Cancel();
+            await output.DisposeAsync();
+
+            Assert.Equal(0, writer.WrittenCount);
+        }
+
+        [Fact]
+        public async Task PipeBackpressureIsAwaitedOnlyAtTheTransportBoundary()
+        {
+            var pipe = new Pipe(new PipeOptions(
+                pauseWriterThreshold: 1,
+                resumeWriterThreshold: 1,
+                useSynchronizationContext: false));
+            await using var output = new Utf8FluidOutput(pipe.Writer);
+            output.Write(new string('x', 32));
+
+            await output.FlushAsync();
+            var transportFlush = pipe.Writer.FlushAsync();
+            Assert.False(transportFlush.IsCompletedSuccessfully);
+
+            var read = await pipe.Reader.ReadAsync();
+            Assert.Equal(32, read.Buffer.Length);
+            pipe.Reader.AdvanceTo(read.Buffer.End);
+            Assert.False((await transportFlush).IsCanceled);
+        }
+
+        [Fact]
+        public async Task NestedRenderUsesOneContinuousUtf8Output()
+        {
+            var fileProvider = new MockFileProvider().Add("item.liquid", "[{{ item }}]");
+            var context = new TemplateContext(new TemplateOptions { FileProvider = fileProvider });
+            context.SetValue("items", new[] { "\ud83d\ude80", "\u4e16\u754c" });
+            var template = _parser.Parse("{% render 'item' for items as item %}");
+            var writer = new ArrayBufferWriter<byte>();
+            await using var output = new Utf8FluidOutput(writer);
+
+            await template.RenderAsync(output, NullEncoder.Default, context);
+
+            Assert.Equal("[\ud83d\ude80][\u4e16\u754c]", Decode(writer));
+        }
+
+        [Fact]
+        public async Task MaxOutputSizeRemainsAUtf16CharacterLimit()
+        {
+            var template = _parser.Parse("{{ value }}");
+            var writer = new ArrayBufferWriter<byte>();
+            await using var output = new Utf8FluidOutput(writer);
+
+            await template.RenderAsync(
+                output,
+                NullEncoder.Default,
+                new TemplateContext { MaxOutputSize = 2 }.SetValue("value", "\ud83d\ude80"));
+
+            Assert.Equal(4, writer.WrittenCount);
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                template.RenderAsync(
+                    new Utf8FluidOutput(new ArrayBufferWriter<byte>()),
+                    NullEncoder.Default,
+                    new TemplateContext { MaxOutputSize = 1 }.SetValue("value", "\ud83d\ude80")).AsTask());
+        }
+
+        [Fact]
+        public async Task DisposalFinalizesEncodingWithoutOwningDestination()
+        {
+            var writer = new DisposableByteWriter();
+            var output = new Utf8FluidOutput(writer);
+            output.Write("\ud83d");
+
+            await output.DisposeAsync();
+
+            Assert.Equal("\ufffd", writer.ToString());
+            Assert.False(writer.IsDisposed);
+            Assert.Throws<ObjectDisposedException>(() => output.Write("x"));
+        }
+
+        private static string Decode(ArrayBufferWriter<byte> writer) =>
+            Encoding.UTF8.GetString(writer.WrittenSpan);
+
+        private class SegmentedByteWriter : IBufferWriter<byte>
+        {
+            private readonly int _segmentSize;
+            private readonly List<byte> _bytes = new();
+            private byte[] _current;
+
+            public SegmentedByteWriter(int segmentSize)
+            {
+                _segmentSize = segmentSize;
+            }
+
+            public int AdvanceCount { get; private set; }
+
+            public void Advance(int count)
+            {
+                AdvanceCount++;
+                for (var i = 0; i < count; i++)
+                {
+                    _bytes.Add(_current[i]);
+                }
+            }
+
+            public Memory<byte> GetMemory(int sizeHint = 0)
+            {
+                _current = new byte[Math.Max(_segmentSize, sizeHint)];
+                return _current;
+            }
+
+            public Span<byte> GetSpan(int sizeHint = 0) => GetMemory(sizeHint).Span;
+
+            public override string ToString() => Encoding.UTF8.GetString(_bytes.ToArray());
+        }
+
+        private sealed class DisposableByteWriter : SegmentedByteWriter, IDisposable
+        {
+            public DisposableByteWriter()
+                : base(4)
+            {
+            }
+
+            public bool IsDisposed { get; private set; }
+
+            public void Dispose() => IsDisposed = true;
+        }
+    }
+}

--- a/Fluid/FluidOutputExtensions.cs
+++ b/Fluid/FluidOutputExtensions.cs
@@ -62,6 +62,39 @@ namespace Fluid
             await output.FlushAsync();
         }
 
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// Renders a template as UTF-8 directly to a byte buffer writer.
+        /// </summary>
+        /// <remarks>
+        /// The destination remains owned by the caller. This method does not flush or complete
+        /// asynchronous transport destinations such as pipe writers.
+        /// </remarks>
+        public static async ValueTask RenderAsync(
+            this IFluidTemplate template,
+            IBufferWriter<byte> writer,
+            TextEncoder encoder,
+            TemplateContext context)
+        {
+            ArgumentNullException.ThrowIfNull(template);
+            ArgumentNullException.ThrowIfNull(writer);
+            ArgumentNullException.ThrowIfNull(encoder);
+            ArgumentNullException.ThrowIfNull(context);
+
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            await using (var output = new Utf8FluidOutput(
+                writer,
+                cancellationToken: context.CancellationToken))
+            {
+                var limitedOutput = LimitedFluidOutput.Create(output, context.MaxOutputSize);
+                await FluidTemplateRenderer.RenderAsync(template, limitedOutput, encoder, context);
+            }
+
+            context.CancellationToken.ThrowIfCancellationRequested();
+        }
+#endif
+
         public static async ValueTask WriteToAsync(this FluidValue value, TextWriter writer, TextEncoder encoder, CultureInfo cultureInfo)
         {
             ArgumentNullException.ThrowIfNull(value);

--- a/Fluid/Utils/Utf8FluidOutput.cs
+++ b/Fluid/Utils/Utf8FluidOutput.cs
@@ -1,0 +1,263 @@
+#if NET8_0_OR_GREATER
+using System.Buffers;
+using System.Text;
+
+namespace Fluid.Utils
+{
+    /// <summary>
+    /// Transcodes Fluid's character output directly to UTF-8 in an <see cref="IBufferWriter{Byte}"/>.
+    /// </summary>
+    /// <remarks>
+    /// The destination remains owned by the caller. In particular, this type does not flush or
+    /// complete a pipe; callers should flush the destination after the outer render completes.
+    /// </remarks>
+    public sealed class Utf8FluidOutput : IFluidOutput, IDisposable, IAsyncDisposable
+    {
+        private const int MinimumUtf8BufferSize = 4;
+        private static readonly UTF8Encoding Utf8 = new UTF8Encoding(
+            encoderShouldEmitUTF8Identifier: false,
+            throwOnInvalidBytes: false);
+
+        private readonly IBufferWriter<byte> _writer;
+        private readonly Encoder _encoder;
+        private readonly ArrayPool<char> _pool;
+        private readonly int _minimumCharBufferSize;
+        private readonly CancellationToken _cancellationToken;
+        private char[] _charBuffer;
+        private int _charIndex;
+        private int _availableChars;
+        private bool _hasWrittenChars;
+        private bool _disposed;
+
+        public Utf8FluidOutput(
+            IBufferWriter<byte> writer,
+            int minimumCharBufferSize = 1024,
+            ArrayPool<char> pool = null,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(writer);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(minimumCharBufferSize);
+
+            _writer = writer;
+            _encoder = Utf8.GetEncoder();
+            _pool = pool ?? ArrayPool<char>.Shared;
+            _minimumCharBufferSize = minimumCharBufferSize;
+            _cancellationToken = cancellationToken;
+        }
+
+        public void Advance(int count)
+        {
+            ThrowIfDisposed();
+
+            if ((uint)count > (uint)_availableChars)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            _availableChars = 0;
+            if (count != 0)
+            {
+                _charIndex += count;
+            }
+        }
+
+        public Memory<char> GetMemory(int sizeHint = 0)
+        {
+            EnsureCharBuffer(sizeHint);
+            return _charBuffer.AsMemory(_charIndex);
+        }
+
+        public Span<char> GetSpan(int sizeHint = 0)
+        {
+            EnsureCharBuffer(sizeHint);
+            return _charBuffer.AsSpan(_charIndex);
+        }
+
+        public void Write(string value)
+        {
+            ThrowIfDisposed();
+
+            if (!string.IsNullOrEmpty(value))
+            {
+                Write(value.AsSpan());
+            }
+        }
+
+        public void Write(char[] buffer, int index, int count)
+        {
+            ArgumentNullException.ThrowIfNull(buffer);
+            ThrowIfDisposed();
+
+            if (count != 0)
+            {
+                Write(buffer.AsSpan(index, count));
+            }
+        }
+
+        public ValueTask FlushAsync()
+        {
+            ThrowIfDisposed();
+            _cancellationToken.ThrowIfCancellationRequested();
+            FlushCharBuffer();
+            return default;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            try
+            {
+                if (!_cancellationToken.IsCancellationRequested)
+                {
+                    FlushCharBuffer();
+                    FinishEncoding();
+                }
+            }
+            finally
+            {
+                DisposeCore();
+            }
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Dispose();
+            return default;
+        }
+
+        private void Encode(ReadOnlySpan<char> source, bool flush)
+        {
+            _cancellationToken.ThrowIfCancellationRequested();
+
+            if (!flush)
+            {
+                _hasWrittenChars = true;
+            }
+
+            bool completed;
+            do
+            {
+                var destination = _writer.GetSpan(MinimumUtf8BufferSize);
+                _encoder.Convert(
+                    source,
+                    destination,
+                    flush,
+                    out var charsUsed,
+                    out var bytesUsed,
+                    out completed);
+
+                if (bytesUsed != 0)
+                {
+                    _writer.Advance(bytesUsed);
+                }
+
+                source = source.Slice(charsUsed);
+
+                if (!completed && charsUsed == 0 && bytesUsed == 0)
+                {
+                    throw new InvalidOperationException("The UTF-8 destination did not provide enough writable memory.");
+                }
+            }
+            while (!completed);
+        }
+
+        private void FinishEncoding()
+        {
+            if (_hasWrittenChars)
+            {
+                Encode(ReadOnlySpan<char>.Empty, flush: true);
+                _encoder.Reset();
+                _hasWrittenChars = false;
+            }
+        }
+
+        private void EnsureCharBuffer(int sizeHint)
+        {
+            ThrowIfDisposed();
+            ArgumentOutOfRangeException.ThrowIfNegative(sizeHint);
+
+            if (sizeHint == 0)
+            {
+                sizeHint = 1;
+            }
+
+            if (_charBuffer != null && _charBuffer.Length - _charIndex >= sizeHint)
+            {
+                _availableChars = _charBuffer.Length - _charIndex;
+                return;
+            }
+
+            FlushCharBuffer();
+
+            var required = Math.Max(sizeHint, _minimumCharBufferSize);
+            if (_charBuffer == null || _charBuffer.Length < required)
+            {
+                var replacement = _pool.Rent(required);
+                if (_charBuffer != null)
+                {
+                    _pool.Return(_charBuffer);
+                }
+
+                _charBuffer = replacement;
+            }
+
+            _availableChars = _charBuffer.Length - _charIndex;
+        }
+
+        private void Write(ReadOnlySpan<char> value)
+        {
+            if (_charBuffer == null)
+            {
+                Encode(value, flush: false);
+                return;
+            }
+
+            if (value.Length >= _charBuffer.Length)
+            {
+                FlushCharBuffer();
+                Encode(value, flush: false);
+                return;
+            }
+
+            if (_charBuffer.Length - _charIndex < value.Length)
+            {
+                FlushCharBuffer();
+            }
+
+            value.CopyTo(_charBuffer.AsSpan(_charIndex));
+            _charIndex += value.Length;
+        }
+
+        private void FlushCharBuffer()
+        {
+            if (_charIndex != 0)
+            {
+                Encode(_charBuffer.AsSpan(0, _charIndex), flush: false);
+                _charIndex = 0;
+            }
+        }
+
+        private void DisposeCore()
+        {
+            _disposed = true;
+            _charIndex = 0;
+            _availableChars = 0;
+
+            if (_charBuffer != null)
+            {
+                _pool.Return(_charBuffer);
+                _charBuffer = null;
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+        }
+    }
+}
+#endif

--- a/README.md
+++ b/README.md
@@ -1693,6 +1693,24 @@ These instances are meant to be reused. This is why there is a separation betwee
 
 Instantiating a `FluidParser` instance is expensive, do it once and reuse the instance. This can be registered as a singleton if you use dependency injection, but in most cases a `static` instance makes sense since it's rare to customize these.
 
+### Render directly to UTF-8
+
+On .NET 8 and later, `Utf8FluidOutput` writes directly to an `IBufferWriter<byte>` without accumulating the rendered response as UTF-16 or adding an ASP.NET Core dependency to Fluid:
+
+```csharp
+await using (var output = new Utf8FluidOutput(
+    response.BodyWriter,
+    cancellationToken: requestAborted))
+{
+    await template.RenderAsync(output, HtmlEncoder.Default, context);
+}
+
+// Disposal finalizes UTF-8 encoder state. The destination remains caller-owned.
+await response.BodyWriter.FlushAsync(requestAborted);
+```
+
+`Utf8FluidOutput.FlushAsync` transcodes buffered characters but preserves encoder state so surrogate pairs remain valid across intermediate template flushes. Disposal finalizes that state, including an unmatched surrogate, but does not flush or complete the destination. This keeps pipe backpressure asynchronous and under the transport owner's control. Because `IFluidOutput` writes synchronously, transport flushing is not attempted in the middle of a render. `MaxOutputSize` continues to count UTF-16 characters, not encoded bytes.
+
 ### Benchmarks
 
 A benchmark application is provided in the source code to compare Fluid, [Scriban](https://github.com/scriban/scriban), [DotLiquid](https://github.com/dotliquid/dotliquid), [Liquid.NET](https://github.com/mikebridge/Liquid.NET), and [Handlebars.NET](https://github.com/Handlebars-Net/Handlebars.Net).

--- a/README.md
+++ b/README.md
@@ -1698,18 +1698,13 @@ Instantiating a `FluidParser` instance is expensive, do it once and reuse the in
 On .NET 8 and later, `Utf8FluidOutput` writes directly to an `IBufferWriter<byte>` without accumulating the rendered response as UTF-16 or adding an ASP.NET Core dependency to Fluid:
 
 ```csharp
-await using (var output = new Utf8FluidOutput(
-    response.BodyWriter,
-    cancellationToken: requestAborted))
-{
-    await template.RenderAsync(output, HtmlEncoder.Default, context);
-}
+await template.RenderAsync(response.BodyWriter, HtmlEncoder.Default, context);
 
-// Disposal finalizes UTF-8 encoder state. The destination remains caller-owned.
+// The destination remains caller-owned.
 await response.BodyWriter.FlushAsync(requestAborted);
 ```
 
-`Utf8FluidOutput.FlushAsync` transcodes buffered characters but preserves encoder state so surrogate pairs remain valid across intermediate template flushes. Disposal finalizes that state, including an unmatched surrogate, but does not flush or complete the destination. This keeps pipe backpressure asynchronous and under the transport owner's control. Because `IFluidOutput` writes synchronously, transport flushing is not attempted in the middle of a render. `MaxOutputSize` continues to count UTF-16 characters, not encoded bytes.
+The `RenderAsync` overload creates and disposes `Utf8FluidOutput`, ensuring its UTF-8 encoder state is finalized. The destination remains caller-owned and is not flushed or completed. Create `Utf8FluidOutput` directly when multiple templates need to share one character stream. Its `FlushAsync` method transcodes buffered characters while preserving encoder state so surrogate pairs remain valid across intermediate template flushes. Because `IFluidOutput` writes synchronously, transport flushing is not attempted in the middle of a render. `MaxOutputSize` continues to count UTF-16 characters, not encoded bytes.
 
 ### Benchmarks
 


### PR DESCRIPTION
Fluid's byte-oriented consumers currently render through UTF-16 `TextWriter` buffers before transcoding responses to UTF-8. This adds a measured direct UTF-8 path that preserves Fluid's existing character-oriented rendering contract.

## Approach

- Add a .NET 8+ `Utf8FluidOutput` that transcodes directly into `IBufferWriter<byte>` without adding ASP.NET Core or pipeline dependencies to Fluid core.
- Add an `IFluidTemplate.RenderAsync(IBufferWriter<byte>, TextEncoder, TemplateContext)` overload that manages encoder finalization while leaving destination ownership, flushing, and completion to the caller.
- Preserve `MaxOutputSize` as a UTF-16 character limit and preserve encoder state across intermediate template flushes, including nested renders and split surrogate pairs.
- Keep `MinimalApis.LiquidViews` unchanged because its existing `PipeWriterFluidOutput` has different threshold streaming and backpressure behavior.

## Performance

BenchmarkDotNet on Apple M4 Pro with .NET 10, 10 iterations and 5 warmups:

| Workload | TextWriter to UTF-8 | Direct UTF-8 | Allocations |
| --- | ---: | ---: | ---: |
| Small ASCII | 270.47 ns | 92.58 ns | 5,696 B to 432 B |
| Product template | 40.150 us | 37.339 us | 80,280 B to 75,016 B |
| Unicode and HTML encoding | 365.71 ns | 215.38 ns | 5,728 B to 464 B |
| Large 256 KiB output | 70.349 us | 62.865 us | 530,176 B to 524,912 B |

Both paths produced identical byte counts and used one transport flush per operation.

## Validation

- Full Release interpreted suite: 2,825 tests, 0 failures, 20 existing skips.
- Full Release compiled grammar suite: 2,825 tests, 0 failures, 20 existing skips.
- Release build across Fluid's `netstandard2.0`, `net8.0`, `net9.0`, and `net10.0` targets.
- Coverage includes ASCII, BMP and non-BMP Unicode, malformed and split surrogates, HTML expansion, raw values and literals, tiny byte segments, cancellation, nested renders, character limits, and destination ownership.