### PR TITLE
Simplify scope management

### DIFF
--- a/Fluid.Benchmarks/RenderScenarioBenchmarks.cs
+++ b/Fluid.Benchmarks/RenderScenarioBenchmarks.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 
 namespace Fluid.Benchmarks
@@ -19,6 +22,7 @@ namespace Fluid.Benchmarks
 
         private readonly TemplateOptions _ordinalOptions = new TemplateOptions();
         private readonly TemplateOptions _camelCaseOptions = new TemplateOptions();
+        private readonly TemplateOptions _partialOptions = new TemplateOptions();
 
         private readonly IFluidTemplate _polymorphicTemplate;
         private readonly IFluidTemplate _monomorphicTemplate;
@@ -27,6 +31,8 @@ namespace Fluid.Benchmarks
         private readonly IFluidTemplate _wideScopeTemplate;
         private readonly IFluidTemplate _pascalCaseTemplate;
         private readonly IFluidTemplate _decimalPriceTemplate;
+        private readonly IFluidTemplate _renderScopeTemplate;
+        private readonly IFluidTemplate _includeScopeTemplate;
 
         private readonly List<object> _mixedItems = new(ItemCount);
         private readonly List<object> _uniformItems = new(ItemCount);
@@ -99,6 +105,14 @@ namespace Fluid.Benchmarks
 
             _parser.TryParse("{% for p in products %}{{ p.Price }}{% endfor %}", out _decimalPriceTemplate);
 
+            var partialBytes = Encoding.UTF8.GetBytes("{{ value }}{{ root }}{{ outer }}");
+            _partialOptions.FileProvider = new DelegateTemplateFileProvider(
+                (_, _, _) => new ValueTask<TemplateSourceInfo>(new TemplateSourceInfo(
+                    DateTimeOffset.UnixEpoch,
+                    _ => new ValueTask<Stream>(new MemoryStream(partialBytes, writable: false)))));
+            _parser.TryParse("{% assign outer = 'hidden' %}{% render 'partial', value: root %}", out _renderScopeTemplate);
+            _parser.TryParse("{% assign outer = 'hidden' %}{% include 'partial', value: root %}", out _includeScopeTemplate);
+
             CheckAll();
         }
 
@@ -111,6 +125,8 @@ namespace Fluid.Benchmarks
             Verify(nameof(WideScope), WideScope(), "123456");
             Verify(nameof(PascalCaseMemberNames), PascalCaseMemberNames(), "N0");
             Verify(nameof(NonInternedNumbers), NonInternedNumbers(), "19.99");
+            Verify(nameof(IsolatedRenderScope), IsolatedRenderScope(), "RR");
+            Verify(nameof(WriteThroughIncludeScope), WriteThroughIncludeScope(), "RRhidden");
 
             static void Verify(string name, string result, string expected)
             {
@@ -179,6 +195,22 @@ namespace Fluid.Benchmarks
         {
             var context = new TemplateContext(_ordinalOptions).SetValue("products", _pricedProducts);
             return _decimalPriceTemplate.Render(context);
+        }
+
+        /// <summary>An isolated partial render with a caller expression and named argument.</summary>
+        [Benchmark]
+        public string IsolatedRenderScope()
+        {
+            var context = new TemplateContext(_partialOptions).SetValue("root", "R");
+            return _renderScopeTemplate.Render(context);
+        }
+
+        /// <summary>A write-through include scope with a temporary named argument.</summary>
+        [Benchmark]
+        public string WriteThroughIncludeScope()
+        {
+            var context = new TemplateContext(_partialOptions).SetValue("root", "R");
+            return _includeScopeTemplate.Render(context);
         }
     }
 }

--- a/Fluid.Tests/IncludeStatementTests.cs
+++ b/Fluid.Tests/IncludeStatementTests.cs
@@ -360,7 +360,7 @@ shape: ''";
 
             var options = new TemplateOptions() { FileProvider = fileProvider };
             var context = new TemplateContext(options);
-            options.Scope.SetValue("global_variable", new StringValue("global value"));
+            options.GlobalValues.SetValue("global_variable", new StringValue("global value"));
             context.SetValue("product", new { title = "Draft 151cm" });
             _parser.TryParse("{% render 'snippet' %}", out var template);
             var result = template.Render(context);

--- a/Fluid.Tests/SourceGeneration/SourceGenerationTests.cs
+++ b/Fluid.Tests/SourceGeneration/SourceGenerationTests.cs
@@ -192,6 +192,46 @@ namespace Fluid.Tests
             Assert.Equal("hi", generatedWriter.ToString());
         }
 
+        [Fact]
+        public async Task GeneratedRender_UsesContextRootWithoutCallerLocals()
+        {
+            var provider = new MockFileProvider()
+                .Add("partial", "{{ input }}|{{ outer }}|{{ global }}");
+
+            var parser = new FluidParser();
+            var template = parser.Parse("{% assign outer = 'hidden' %}{% render 'partial' %}");
+            var source = template.Compile(new SourceGenerationOptions
+            {
+                Namespace = "Fluid.Tests.Generated",
+                ClassName = "T" + Guid.NewGuid().ToString("N"),
+                FileProvider = provider
+            });
+
+            var generated = CompileToAssembly(source.SourceCode);
+            var type = generated.GetType(source.FullTypeName, throwOnError: true);
+            var instance = (IFluidTemplate)Activator.CreateInstance(type, nonPublic: true);
+
+            var options = new TemplateOptions { FileProvider = provider };
+            options.GlobalValues.SetValue("global", new Fluid.Values.StringValue("global"));
+
+            var runtimeContext = new TemplateContext(options).SetValue("input", "root");
+            var runtimeWriter = new StringWriter();
+            using (runtimeContext.EnterScope())
+            {
+                await template.RenderAsync(runtimeWriter, HtmlEncoder.Default, runtimeContext);
+            }
+
+            var generatedContext = new TemplateContext(options).SetValue("input", "root");
+            var generatedWriter = new StringWriter();
+            using (generatedContext.EnterScope())
+            {
+                await instance.RenderAsync(generatedWriter, HtmlEncoder.Default, generatedContext);
+            }
+
+            Assert.Equal("root||global", runtimeWriter.ToString());
+            Assert.Equal(runtimeWriter.ToString(), generatedWriter.ToString());
+        }
+
         private static Assembly CompileToAssembly(string source)
         {
             var syntaxTree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest));

--- a/Fluid.Tests/TemplateContextTests.cs
+++ b/Fluid.Tests/TemplateContextTests.cs
@@ -36,8 +36,8 @@ namespace Fluid.Tests
             _parser.TryParse("{{ p.NaMe }}", out var template, out var error);
 
             var options = new TemplateOptions();
-            options.Scope.SetValue("o1", new StringValue("o1"));
-            options.Scope.SetValue("o2", new StringValue("o2"));
+            options.GlobalValues.SetValue("o1", new StringValue("o1"));
+            options.GlobalValues.SetValue("o2", new StringValue("o2"));
 
             var context = new TemplateContext(options);
             context.SetValue("o2", "new o2");
@@ -136,18 +136,17 @@ namespace Fluid.Tests
         }
 
         [Fact]
-        public async Task ShouldNotReleaseScopeAsynchronously()
+        public async Task ShouldRestoreScopeAsynchronously()
         {
             var parser = new FluidParser();
 
             parser.RegisterEmptyBlock("sleep", async (statements, writer, encoder, context) =>
             {
-                context.EnterChildScope();
+                using var scope = context.EnterScope(ScopeBehavior.Local);
                 context.IncrementSteps();
                 context.SetValue("id", "0");
                 await Task.Delay(100);
                 await statements.RenderStatementsAsync(writer, encoder, context);
-                context.ReleaseScope();
                 return Completion.Normal;
             });
 
@@ -189,6 +188,67 @@ namespace Fluid.Tests
             context.SetValue("Case", "mixed");
 
             Assert.Equal("lowerupper", context.GetValue("case").ToStringValue() + context.GetValue("CASE").ToStringValue());
+        }
+
+        [Fact]
+        public void ChildScopeShouldInheritComparerFromEmptyParent()
+        {
+            var context = new TemplateContext(new TemplateOptions
+            {
+                ModelNamesComparer = StringComparer.OrdinalIgnoreCase
+            });
+
+            using var scope = context.EnterScope();
+            context.SetValue("PageState", "insert");
+
+            Assert.Equal("insert", context.GetValue("pageState").ToStringValue());
+        }
+
+        [Fact]
+        public void ScopeBehaviorsShouldControlLookupAndAssignment()
+        {
+            var options = new TemplateOptions();
+            options.GlobalValues.SetValue("global", new StringValue("global"));
+
+            var context = new TemplateContext(options);
+            context.SetValue("root", "root");
+
+            using (context.EnterScope(ScopeBehavior.Local))
+            {
+                context.SetValue("outer", "outer");
+
+                using (context.EnterScope(ScopeBehavior.Isolated))
+                {
+                    Assert.Equal("root", context.GetValue("root").ToStringValue());
+                    Assert.Equal("global", context.GetValue("global").ToStringValue());
+                    Assert.True(context.GetValue("outer").IsNil());
+                }
+
+                using (context.EnterScope(ScopeBehavior.WriteThrough))
+                {
+                    context.LocalScope.SetOwnValue("temporary", new StringValue("temporary"));
+                    context.SetValue("persisted", "persisted");
+                }
+
+                Assert.True(context.GetValue("temporary").IsNil());
+                Assert.Equal("persisted", context.GetValue("persisted").ToStringValue());
+            }
+
+            Assert.True(context.GetValue("outer").IsNil());
+            Assert.True(context.GetValue("persisted").IsNil());
+        }
+
+        [Fact]
+        public void ScopeLeasesMustBeDisposedInReverseOrder()
+        {
+            var context = new TemplateContext();
+            var outer = context.EnterScope();
+            var inner = context.EnterScope();
+
+            Assert.Throws<InvalidOperationException>(() => outer.Dispose());
+
+            inner.Dispose();
+            outer.Dispose();
         }
 
         [Fact]

--- a/Fluid.ViewEngine/FluidViewParser.cs
+++ b/Fluid.ViewEngine/FluidViewParser.cs
@@ -96,9 +96,8 @@ namespace Fluid.ViewEngine
 
                 context.IncrementSteps();
 
-                try
                 {
-                    context.EnterChildScope();
+                    using var scope = context.EnterScope(ScopeBehavior.Local);
 
                     if (!relativePartialPath.EndsWith(Constants.ViewExtension, StringComparison.OrdinalIgnoreCase))
                     {
@@ -116,10 +115,6 @@ namespace Fluid.ViewEngine
                     }
 
                     await renderer.RenderPartialAsync(output, relativePartialPath, context);
-                }
-                finally
-                {
-                    context.ReleaseScope();
                 }
 
                 return Completion.Normal;

--- a/Fluid/Ast/ForStatement.cs
+++ b/Fluid/Ast/ForStatement.cs
@@ -144,9 +144,8 @@ namespace Fluid.Ast
 
             var parentLoop = context.LocalScope.GetValue("forloop");
 
-            context.EnterForLoopScope();
+            using var scope = context.EnterScope(ScopeBehavior.WriteThrough);
 
-            try
             {
                 var endIndexExclusive = startIndex + count;
 
@@ -231,10 +230,6 @@ namespace Fluid.Ast
                 {
                     context.SetValue(continueOffsetLiteral, endIndexExclusive);
                 }
-            }
-            finally
-            {
-                context.ReleaseScope();
             }
 
             return Completion.Normal;
@@ -384,7 +379,7 @@ namespace Fluid.Ast
             context.WriteLine("}");
 
             context.WriteLine($"var parentLoop = {context.ContextName}.LocalScope.GetValue(\"forloop\");");
-            context.WriteLine($"{context.ContextName}.EnterForLoopScope();");
+            context.WriteLine($"using var scope = {context.ContextName}.EnterScope(ScopeBehavior.WriteThrough);");
             context.WriteLine("try");
             context.WriteLine("{");
             using (context.Indent())
@@ -448,7 +443,6 @@ namespace Fluid.Ast
             context.WriteLine("{");
             using (context.Indent())
             {
-                context.WriteLine($"{context.ContextName}.ReleaseScope();");
             }
             context.WriteLine("}");
 

--- a/Fluid/Ast/FromStatement.cs
+++ b/Fluid/Ast/FromStatement.cs
@@ -37,9 +37,8 @@ namespace Fluid.Ast
             var parentScope = context.LocalScope;
 
             // Create a dedicated scope so we can list all macros defined in this template
-            context.EnterChildScope();
+            using var scope = context.EnterScope(ScopeBehavior.Local);
 
-            try
             {
                 await template.RenderAsync(NullFluidOutput.Instance, encoder, context);
 
@@ -56,19 +55,16 @@ namespace Fluid.Ast
                 }
                 else
                 {
-                    foreach (var property in context.LocalScope.Properties)
+                    var values = context.LocalScope.GetOwnValues();
+                    while (values.MoveNext())
                     {
-                        var value = context.LocalScope.GetValue(property);
-                        if (value is FunctionValue)
+                        var property = values.Current;
+                        if (property.Value is FunctionValue)
                         {
-                            parentScope.SetValue(property, value);
+                            parentScope.SetValue(property.Key, property.Value);
                         }
                     }
                 }
-            }
-            finally
-            {
-                context.ReleaseScope();
             }
 
             return Completion.Normal;

--- a/Fluid/Ast/IncludeStatement.cs
+++ b/Fluid/Ast/IncludeStatement.cs
@@ -44,118 +44,86 @@ namespace Fluid.Ast
             // Unlike render, include shares scope with the parent template.
             // Use a for-loop scope which passes through variable assignments to the parent.
             // This allows variables assigned inside the include to persist in the outer scope.
-            context.EnterForLoopScope();
+            using var scope = context.EnterScope(ScopeBehavior.WriteThrough);
 
-            // Track keyword argument names so we can clean them up after
-            List<string> keywordArgNames = null;
-
-            try
+            if (With != null)
             {
-                if (With != null)
+                var with = await With.EvaluateAsync(context);
+
+                // The bound variable is local to this include
+                context.LocalScope.SetOwnValue(Alias ?? identifier, with);
+
+                // Keyword arguments are local to the include
+                if (AssignStatements.Count > 0)
                 {
-                    var with = await With.EvaluateAsync(context);
-
-                    // The bound variable is local to this include
-                    context.LocalScope.SetOwnValue(Alias ?? identifier, with);
-
-                    // Keyword arguments are local to the include
-                    if (AssignStatements.Count > 0)
-                    {
-                        keywordArgNames = new List<string>(AssignStatements.Count);
-                        for (var i = 0; i < AssignStatements.Count; i++)
-                        {
-                            var stmt = AssignStatements[i];
-                            keywordArgNames.Add(stmt.Identifier);
-                            context.LocalScope.SetOwnValue(stmt.Identifier, await stmt.Value.EvaluateAsync(context));
-                        }
-                    }
-
-                    return await RenderStatementsAsync(template, output, encoder, context);
-                }
-                else if (AssignStatements.Count > 0)
-                {
-                    // Keyword arguments are local to the include - they should go out of scope after
-                    keywordArgNames = new List<string>(AssignStatements.Count);
                     for (var i = 0; i < AssignStatements.Count; i++)
                     {
                         var stmt = AssignStatements[i];
-                        keywordArgNames.Add(stmt.Identifier);
                         context.LocalScope.SetOwnValue(stmt.Identifier, await stmt.Value.EvaluateAsync(context));
                     }
-
-                    return await RenderStatementsAsync(template, output, encoder, context);
                 }
-                else if (For != null)
-                {
-                    try
-                    {
-                        var forloop = new ForLoopValue();
 
-                        var evaluatedFor = await For.EvaluateAsync(context);
-
-                        // Fast-path: avoid re-enumerating already materialized arrays.
-                        IReadOnlyList<FluidValue> list = evaluatedFor is ArrayValue array
-                            ? array.Values
-                            : await evaluatedFor.EnumerateAsync(context).ToListAsync(context.CancellationToken);
-
-                        var length = forloop.Length = list.Count;
-
-                        context.LocalScope.SetOwnValue("forloop", forloop);
-
-                        for (var i = 0; i < length; i++)
-                        {
-                            context.IncrementSteps();
-
-                            var item = list[i];
-
-                            context.LocalScope.SetOwnValue(Alias ?? identifier, item);
-
-                            // Set helper variables
-                            forloop.Index = i + 1;
-                            forloop.Index0 = i;
-                            forloop.RIndex = length - i;
-                            forloop.RIndex0 = length - i - 1;
-                            forloop.First = i == 0;
-                            forloop.Last = i == length - 1;
-
-                            var completion = await RenderStatementsAsync(template, output, encoder, context);
-
-                            if (completion == Completion.Break)
-                            {
-                                break;
-                            }
-
-                            // Restore the forloop property after every statement in case it replaced it,
-                            // for instance if it contains a nested for loop
-                            context.LocalScope.SetOwnValue("forloop", forloop);
-                        }
-                    }
-                    finally
-                    {
-                        context.LocalScope.DeleteOwn("forloop");
-                    }
-
-                    return Completion.Normal;
-                }
-                else
-                {
-                    // no with, for or assignments, e.g. {% include 'products' %}
-                    return await RenderStatementsAsync(template, output, encoder, context);
-                }
+                return await RenderStatementsAsync(template, output, encoder, context);
             }
-            finally
+            else if (AssignStatements.Count > 0)
             {
-                // Clean up keyword arguments from local scope
-                if (keywordArgNames != null)
+                // Keyword arguments are local to the include - they should go out of scope after
+                for (var i = 0; i < AssignStatements.Count; i++)
                 {
-                    foreach (var name in keywordArgNames)
-                    {
-                        context.LocalScope.DeleteOwn(name);
-                    }
+                    var stmt = AssignStatements[i];
+                    context.LocalScope.SetOwnValue(stmt.Identifier, await stmt.Value.EvaluateAsync(context));
                 }
 
-                context.ReleaseScope();
+                return await RenderStatementsAsync(template, output, encoder, context);
             }
+            else if (For != null)
+            {
+                var forloop = new ForLoopValue();
+
+                var evaluatedFor = await For.EvaluateAsync(context);
+
+                // Fast-path: avoid re-enumerating already materialized arrays.
+                IReadOnlyList<FluidValue> list = evaluatedFor is ArrayValue array
+                    ? array.Values
+                    : await evaluatedFor.EnumerateAsync(context).ToListAsync(context.CancellationToken);
+
+                var length = forloop.Length = list.Count;
+
+                context.LocalScope.SetOwnValue("forloop", forloop);
+
+                for (var i = 0; i < length; i++)
+                {
+                    context.IncrementSteps();
+
+                    var item = list[i];
+
+                    context.LocalScope.SetOwnValue(Alias ?? identifier, item);
+
+                    // Set helper variables
+                    forloop.Index = i + 1;
+                    forloop.Index0 = i;
+                    forloop.RIndex = length - i;
+                    forloop.RIndex0 = length - i - 1;
+                    forloop.First = i == 0;
+                    forloop.Last = i == length - 1;
+
+                    var completion = await RenderStatementsAsync(template, output, encoder, context);
+
+                    if (completion == Completion.Break)
+                    {
+                        break;
+                    }
+
+                    // Restore the forloop property after every statement in case it replaced it,
+                    // for instance if it contains a nested for loop
+                    context.LocalScope.SetOwnValue("forloop", forloop);
+                }
+
+                return Completion.Normal;
+            }
+
+            // no with, for or assignments, e.g. {% include 'products' %}
+            return await RenderStatementsAsync(template, output, encoder, context);
         }
 
         /// <summary>

--- a/Fluid/Ast/MacroStatement.cs
+++ b/Fluid/Ast/MacroStatement.cs
@@ -34,9 +34,8 @@ namespace Fluid.Ast
                 using var macroBuffer = new BufferFluidOutput();
                 var macroOutput = LimitedFluidOutput.Create(macroBuffer, context.MaxOutputSize);
 
-                context.EnterChildScope();
+                using var scope = context.EnterScope(ScopeBehavior.Local);
 
-                try
                 {
                     // Initialize the local context with the default values
                     foreach (var a in defaultValues)
@@ -82,10 +81,6 @@ namespace Fluid.Ast
                     // Don't encode the result
                     return new StringValue(result, false);
                 }
-                finally
-                {
-                    context.ReleaseScope();
-                }
             });
 
             context.SetValue(Identifier, f);
@@ -124,7 +119,7 @@ namespace Fluid.Ast
                 context.WriteLine("using var sw = new StringWriter();");
                 context.WriteLine("await using var macroBuffer = new TextWriterFluidOutput(sw, 16 * 1024, leaveOpen: true);");
                 context.WriteLine($"var macroOutput = LimitedFluidOutput.Create(macroBuffer, {context.ContextName}.MaxOutputSize);");
-                context.WriteLine($"{context.ContextName}.EnterChildScope();");
+                context.WriteLine($"using var scope = {context.ContextName}.EnterScope(ScopeBehavior.Local);");
                 context.WriteLine("try");
                 context.WriteLine("{");
                 using (context.Indent())
@@ -199,7 +194,6 @@ namespace Fluid.Ast
                 context.WriteLine("{");
                 using (context.Indent())
                 {
-                    context.WriteLine($"{context.ContextName}.ReleaseScope();");
                 }
                 context.WriteLine("}");
             }

--- a/Fluid/Ast/RenderStatement.cs
+++ b/Fluid/Ast/RenderStatement.cs
@@ -5,7 +5,7 @@ using Fluid.SourceGeneration;
 namespace Fluid.Ast
 {
     /// <summary>
-    /// The render tag can only access immutable environments, which means the scope of the context that was passed to the main template, the options' scope, and the model.
+    /// The render tag can only access immutable environments, which means the scope of the context that was passed to the main template, global values, and the model.
     /// </summary>
 #pragma warning disable CA1001 // Types that own disposable fields should be disposable
     public sealed class RenderStatement : Statement, ISourceable
@@ -45,103 +45,63 @@ namespace Fluid.Ast
 
             var identifier = System.IO.Path.GetFileNameWithoutExtension(relativePath);
 
-            context.EnterChildScope();
-            var previousScope = context.LocalScope;
+            FluidValue withValue = null;
+            IReadOnlyList<FluidValue> list = null;
 
-            try
+            if (With != null)
             {
-                if (With != null)
+                withValue = await With.EvaluateAsync(context);
+            }
+            else if (For != null)
+            {
+                var evaluatedFor = await For.EvaluateAsync(context);
+                list = evaluatedFor is ArrayValue array
+                    ? array.Values
+                    : await evaluatedFor.EnumerateAsync(context).ToListAsync(context.CancellationToken);
+            }
+
+            // Liquid evaluates named argument expressions in the caller before creating the isolated context.
+            var assignedValues = await EvaluateAssignStatementsAsync(AssignStatements, context);
+
+            using var scope = context.EnterScope(ScopeBehavior.Isolated);
+
+            if (With != null)
+            {
+                context.SetValue(Alias ?? identifier, withValue);
+                ApplyAssignStatements(assignedValues, context);
+                await template.RenderAsync(output, encoder, context);
+            }
+            else if (For != null)
+            {
+                ApplyAssignStatements(assignedValues, context);
+                var forloop = new ForLoopValue { IsRenderLoop = true };
+                var length = forloop.Length = list.Count;
+
+                context.SetValue("forloop", forloop);
+
+                for (var i = 0; i < length; i++)
                 {
-                    var with = await With.EvaluateAsync(context);
+                    context.IncrementSteps();
 
-                    context.LocalScope = new Scope(context.RootScope);
-                    previousScope.CopyTo(context.LocalScope);
+                    context.SetValue(Alias ?? identifier, list[i]);
 
-                    context.SetValue(Alias ?? identifier, with);
-
-                    // Evaluate assign statements in the new scope if present
-                    if (AssignStatements.Count > 0)
-                    {
-                        await EvaluateAssignStatementsAsync(AssignStatements, context);
-                    }
+                    forloop.Index = i + 1;
+                    forloop.Index0 = i;
+                    forloop.RIndex = length - i;
+                    forloop.RIndex0 = length - i - 1;
+                    forloop.First = i == 0;
+                    forloop.Last = i == length - 1;
 
                     await template.RenderAsync(output, encoder, context);
-                }
-                else if (For != null)
-                {
-                    try
-                    {
-                        var forloop = new ForLoopValue { IsRenderLoop = true };
 
-                        var evaluatedFor = await For.EvaluateAsync(context);
-
-                        // Fast-path: avoid re-enumerating already materialized arrays.
-                        IReadOnlyList<FluidValue> list = evaluatedFor is ArrayValue array
-                            ? array.Values
-                            : await evaluatedFor.EnumerateAsync(context).ToListAsync(context.CancellationToken);
-
-                        context.LocalScope = new Scope(context.RootScope);
-                        previousScope.CopyTo(context.LocalScope);
-
-                        // Evaluate assign statements in the new scope before the loop if present
-                        if (AssignStatements.Count > 0)
-                        {
-                            await EvaluateAssignStatementsAsync(AssignStatements, context);
-                        }
-
-                        var length = forloop.Length = list.Count;
-
-                        context.SetValue("forloop", forloop);
-
-                        for (var i = 0; i < length; i++)
-                        {
-                            context.IncrementSteps();
-
-                            var item = list[i];
-
-                            context.SetValue(Alias ?? identifier, item);
-
-                            // Set helper variables
-                            forloop.Index = i + 1;
-                            forloop.Index0 = i;
-                            forloop.RIndex = length - i;
-                            forloop.RIndex0 = length - i - 1;
-                            forloop.First = i == 0;
-                            forloop.Last = i == length - 1;
-
-                            await template.RenderAsync(output, encoder, context);
-
-                            // Restore the forloop property after every statement in case it replaced it,
-                            // for instance if it contains a nested for loop
-                            context.SetValue("forloop", forloop);
-                        }
-                    }
-                    finally
-                    {
-                        context.LocalScope.Delete("forloop");
-                    }
-                }
-                else if (AssignStatements.Count > 0)
-                {
-                    await EvaluateAssignStatementsAsync(AssignStatements, context);
-
-                    context.LocalScope = new Scope(context.RootScope);
-                    previousScope.CopyTo(context.LocalScope);
-
-                    await template.RenderAsync(output, encoder, context);
-                }
-                else
-                {
-                    context.LocalScope = new Scope(context.RootScope);
-                    previousScope.CopyTo(context.LocalScope);
-
-                    await template.RenderAsync(output, encoder, context);
+                    // A nested loop can replace this name.
+                    context.SetValue("forloop", forloop);
                 }
             }
-            finally
+            else
             {
-                context.LocalScope = previousScope;
-                context.ReleaseScope();
+                ApplyAssignStatements(assignedValues, context);
+                await template.RenderAsync(output, encoder, context);
             }
 
             return Completion.Normal;
@@ -151,10 +111,10 @@ namespace Fluid.Ast
 
         public void WriteTo(SourceGenerationContext context)
         {
+            var assignedValueNames = new string[AssignStatements.Count];
+
             void EmitEvaluateAssignStatements()
             {
-                var assignedValueNames = new string[AssignStatements.Count];
-
                 for (var i = 0; i < AssignStatements.Count; i++)
                 {
                     var assignStatement = AssignStatements[i];
@@ -172,7 +132,10 @@ namespace Fluid.Ast
                     }
                     context.WriteLine("}");
                 }
+            }
 
+            void EmitApplyAssignStatements()
+            {
                 for (var i = 0; i < AssignStatements.Count; i++)
                 {
                     var assignStatement = AssignStatements[i];
@@ -189,141 +152,93 @@ namespace Fluid.Ast
             // Use the same default identifier logic as runtime (file name without extension).
             context.WriteLine($"var identifier = System.IO.Path.GetFileNameWithoutExtension({SourceGenerationContext.ToCSharpStringLiteral(Path)});");
 
-            context.WriteLine($"{context.ContextName}.EnterChildScope();");
-            context.WriteLine($"var previousScope = {context.ContextName}.LocalScope;");
-            context.WriteLine("var rootScope = previousScope;");
-            context.WriteLine("while (rootScope.Parent != null)");
-            context.WriteLine("{");
-            using (context.Indent())
+            if (With != null)
             {
-                context.WriteLine("rootScope = rootScope.Parent;");
+                var withExpr = context.GetExpressionMethodName(With);
+                context.WriteLine($"var withValue = await {withExpr}({context.ContextName});");
             }
-            context.WriteLine("}");
-
-            context.WriteLine("try");
-            context.WriteLine("{");
-            using (context.Indent())
+            else if (For != null)
             {
-                if (With != null)
+                var forExpr = context.GetExpressionMethodName(For);
+                context.WriteLine($"var evaluatedFor = await {forExpr}({context.ContextName});");
+                context.WriteLine("IReadOnlyList<FluidValue> list = evaluatedFor is ArrayValue array");
+                using (context.Indent())
                 {
-                    var withExpr = context.GetExpressionMethodName(With);
-                    context.WriteLine($"var withValue = await {withExpr}({context.ContextName});");
-
-                    context.WriteLine($"{context.ContextName}.LocalScope = new Scope(rootScope);");
-                    context.WriteLine($"previousScope.CopyTo({context.ContextName}.LocalScope);");
-
-                    if (!string.IsNullOrEmpty(Alias))
-                    {
-                        context.WriteLine($"{context.ContextName}.SetValue({SourceGenerationContext.ToCSharpStringLiteral(Alias)}, withValue);");
-                    }
-                    else
-                    {
-                        context.WriteLine($"{context.ContextName}.SetValue(identifier, withValue);");
-                    }
-
-                    if (AssignStatements.Count > 0)
-                    {
-                        EmitEvaluateAssignStatements();
-                    }
-
-                    context.WriteLine($"await template.RenderAsync({context.WriterName}, {context.EncoderName}, {context.ContextName});");
+                    context.WriteLine("? array.Values");
+                    context.WriteLine($": await evaluatedFor.EnumerateAsync({context.ContextName}).ToListAsync({context.ContextName}.CancellationToken);");
                 }
-                else if (For != null)
+            }
+
+            EmitEvaluateAssignStatements();
+            context.WriteLine($"using var scope = {context.ContextName}.EnterScope(ScopeBehavior.Isolated);");
+
+            if (With != null)
+            {
+                if (!string.IsNullOrEmpty(Alias))
                 {
-                    var forExpr = context.GetExpressionMethodName(For);
-
-                    context.WriteLine("try");
-                    context.WriteLine("{");
-                    using (context.Indent())
-                    {
-                        context.WriteLine("var forloop = new ForLoopValue { IsRenderLoop = true };");
-                        context.WriteLine($"var evaluatedFor = await {forExpr}({context.ContextName});");
-                        context.WriteLine("IReadOnlyList<FluidValue> list = evaluatedFor is ArrayValue array");
-                        using (context.Indent())
-                        {
-                            context.WriteLine("? array.Values");
-                            context.WriteLine($": await evaluatedFor.EnumerateAsync({context.ContextName}).ToListAsync({context.ContextName}.CancellationToken);");
-                        }
-
-                        context.WriteLine($"{context.ContextName}.LocalScope = new Scope(rootScope);");
-                        context.WriteLine($"previousScope.CopyTo({context.ContextName}.LocalScope);");
-
-                        if (AssignStatements.Count > 0)
-                        {
-                            EmitEvaluateAssignStatements();
-                        }
-
-                        context.WriteLine("var length = forloop.Length = list.Count;");
-                        context.WriteLine($"{context.ContextName}.SetValue(\"forloop\", forloop);");
-
-                        context.WriteLine("for (var i = 0; i < length; i++)");
-                        context.WriteLine("{");
-                        using (context.Indent())
-                        {
-                            context.WriteLine($"{context.ContextName}.IncrementSteps();");
-                            context.WriteLine("var item = list[i];");
-
-                            if (!string.IsNullOrEmpty(Alias))
-                            {
-                                context.WriteLine($"{context.ContextName}.SetValue({SourceGenerationContext.ToCSharpStringLiteral(Alias)}, item);");
-                            }
-                            else
-                            {
-                                context.WriteLine($"{context.ContextName}.SetValue(identifier, item);");
-                            }
-
-                            context.WriteLine("forloop.Index = i + 1;");
-                            context.WriteLine("forloop.Index0 = i;");
-                            context.WriteLine("forloop.RIndex = length - i;");
-                            context.WriteLine("forloop.RIndex0 = length - i - 1;");
-                            context.WriteLine("forloop.First = i == 0;");
-                            context.WriteLine("forloop.Last = i == length - 1;");
-
-                            context.WriteLine($"await template.RenderAsync({context.WriterName}, {context.EncoderName}, {context.ContextName});");
-                            context.WriteLine($"{context.ContextName}.SetValue(\"forloop\", forloop);");
-                        }
-                        context.WriteLine("}");
-                    }
-                    context.WriteLine("}");
-                    context.WriteLine("finally");
-                    context.WriteLine("{");
-                    using (context.Indent())
-                    {
-                        context.WriteLine($"{context.ContextName}.LocalScope.Delete(\"forloop\");");
-                    }
-                    context.WriteLine("}");
-                }
-                else if (AssignStatements.Count > 0)
-                {
-                    EmitEvaluateAssignStatements();
-
-                    context.WriteLine($"{context.ContextName}.LocalScope = new Scope(rootScope);");
-                    context.WriteLine($"previousScope.CopyTo({context.ContextName}.LocalScope);");
-                    context.WriteLine($"await template.RenderAsync({context.WriterName}, {context.EncoderName}, {context.ContextName});");
+                    context.WriteLine($"{context.ContextName}.SetValue({SourceGenerationContext.ToCSharpStringLiteral(Alias)}, withValue);");
                 }
                 else
                 {
-                    context.WriteLine($"{context.ContextName}.LocalScope = new Scope(rootScope);");
-                    context.WriteLine($"previousScope.CopyTo({context.ContextName}.LocalScope);");
-                    context.WriteLine($"await template.RenderAsync({context.WriterName}, {context.EncoderName}, {context.ContextName});");
+                    context.WriteLine($"{context.ContextName}.SetValue(identifier, withValue);");
                 }
+
+                EmitApplyAssignStatements();
+                context.WriteLine($"await template.RenderAsync({context.WriterName}, {context.EncoderName}, {context.ContextName});");
             }
-            context.WriteLine("}");
-            context.WriteLine("finally");
-            context.WriteLine("{");
-            using (context.Indent())
+            else if (For != null)
             {
-                context.WriteLine($"{context.ContextName}.LocalScope = previousScope;");
-                context.WriteLine($"{context.ContextName}.ReleaseScope();");
+                EmitApplyAssignStatements();
+                context.WriteLine("var forloop = new ForLoopValue { IsRenderLoop = true };");
+                context.WriteLine("var length = forloop.Length = list.Count;");
+                context.WriteLine($"{context.ContextName}.SetValue(\"forloop\", forloop);");
+
+                context.WriteLine("for (var i = 0; i < length; i++)");
+                context.WriteLine("{");
+                using (context.Indent())
+                {
+                    context.WriteLine($"{context.ContextName}.IncrementSteps();");
+                    context.WriteLine("var item = list[i];");
+
+                    if (!string.IsNullOrEmpty(Alias))
+                    {
+                        context.WriteLine($"{context.ContextName}.SetValue({SourceGenerationContext.ToCSharpStringLiteral(Alias)}, item);");
+                    }
+                    else
+                    {
+                        context.WriteLine($"{context.ContextName}.SetValue(identifier, item);");
+                    }
+
+                    context.WriteLine("forloop.Index = i + 1;");
+                    context.WriteLine("forloop.Index0 = i;");
+                    context.WriteLine("forloop.RIndex = length - i;");
+                    context.WriteLine("forloop.RIndex0 = length - i - 1;");
+                    context.WriteLine("forloop.First = i == 0;");
+                    context.WriteLine("forloop.Last = i == length - 1;");
+                    context.WriteLine($"await template.RenderAsync({context.WriterName}, {context.EncoderName}, {context.ContextName});");
+                    context.WriteLine($"{context.ContextName}.SetValue(\"forloop\", forloop);");
+                }
+                context.WriteLine("}");
             }
-            context.WriteLine("}");
+            else
+            {
+                EmitApplyAssignStatements();
+                context.WriteLine($"await template.RenderAsync({context.WriterName}, {context.EncoderName}, {context.ContextName});");
+            }
 
             context.WriteLine("return Completion.Normal;");
         }
 
-        private static async ValueTask EvaluateAssignStatementsAsync(IReadOnlyList<AssignStatement> assignStatements, TemplateContext context)
+        private static async ValueTask<KeyValuePair<string, FluidValue>[]> EvaluateAssignStatementsAsync(
+            IReadOnlyList<AssignStatement> assignStatements,
+            TemplateContext context)
         {
             var length = assignStatements.Count;
+            if (length == 0)
+            {
+                return [];
+            }
+
             var evaluatedValues = new KeyValuePair<string, FluidValue>[length];
 
             for (var i = 0; i < length; i++)
@@ -341,9 +256,16 @@ namespace Fluid.Ast
                 evaluatedValues[i] = new KeyValuePair<string, FluidValue>(assignStatement.Identifier, value);
             }
 
-            for (var i = 0; i < length; i++)
+            return evaluatedValues;
+        }
+
+        private static void ApplyAssignStatements(
+            KeyValuePair<string, FluidValue>[] assignedValues,
+            TemplateContext context)
+        {
+            for (var i = 0; i < assignedValues.Length; i++)
             {
-                var entry = evaluatedValues[i];
+                var entry = assignedValues[i];
                 context.SetValue(entry.Key, entry.Value);
             }
         }

--- a/Fluid/Ast/TableRowStatement.cs
+++ b/Fluid/Ast/TableRowStatement.cs
@@ -84,9 +84,8 @@ namespace Fluid.Ast
                 }
             }
 
-            context.EnterForLoopScope();
+            using var scope = context.EnterScope(ScopeBehavior.WriteThrough);
 
-            try
             {
                 var tablerowloop = new TableRowLoopValue(count, cols);
                 context.LocalScope.SetOwnValue("tablerowloop", tablerowloop);
@@ -147,10 +146,6 @@ namespace Fluid.Ast
 
                 // Output final row closing
                 output.Write("</tr>\n");
-            }
-            finally
-            {
-                context.ReleaseScope();
             }
 
             return Completion.Normal;

--- a/Fluid/FluidTemplateExtensions.String.cs
+++ b/Fluid/FluidTemplateExtensions.String.cs
@@ -47,10 +47,9 @@ namespace Fluid
             context.CancellationToken.ThrowIfCancellationRequested();
 
             // Mirror the TextWriter-based overload: evaluate in a child scope so the provided TemplateContext is immutable.
-            if (isolateContext)
-            {
-                context.EnterChildScope();
-            }
+            var scope = isolateContext
+                ? context.EnterScope(ScopeBehavior.Local)
+                : default;
 
             try
             {
@@ -70,7 +69,7 @@ namespace Fluid
             {
                 if (isolateContext)
                 {
-                    context.ReleaseScope();
+                    scope.Dispose();
                 }
             }
         }

--- a/Fluid/FluidTemplateExtensions.cs
+++ b/Fluid/FluidTemplateExtensions.cs
@@ -51,10 +51,9 @@ namespace Fluid
             context.CancellationToken.ThrowIfCancellationRequested();
 
             // A template is evaluated in a child scope such that the provided TemplateContext is immutable
-            if (isolateContext)
-            {
-                context.EnterChildScope();
-            }
+            var scope = isolateContext
+                ? context.EnterScope(ScopeBehavior.Local)
+                : default;
 
             var bufferSize = context.Options?.OutputBufferSize ?? 0;
             if (bufferSize <= 0)
@@ -79,7 +78,7 @@ namespace Fluid
             {
                 if (isolateContext)
                 {
-                    context.ReleaseScope();
+                    scope.Dispose();
                 }
             }
         }

--- a/Fluid/Scope.cs
+++ b/Fluid/Scope.cs
@@ -21,8 +21,7 @@ namespace Fluid
 
         private Dictionary<string, FluidValue> _properties;
 
-        // The comparer this scope's storage uses, or null while the scope is still empty. Mirrors the
-        // previous behaviour of creating the dictionary with the parent's comparer when it has one.
+        // The comparer this scope's storage uses, or null while the scope is still empty.
         private StringComparer _storageComparer;
 
         // Both built-in comparers can be compared without a virtual call, which matters most on a miss,
@@ -32,30 +31,26 @@ namespace Fluid
         private StringComparison _storageComparison;
         private bool _storageComparisonIsDirect;
 
-        private readonly bool _forLoopScope;
         private readonly StringComparer _stringComparer;
+        private readonly Scope _assignmentTarget;
 
-        public Scope() : this(null, false, null)
+        public Scope() : this(null, null, null, null)
         {
         }
 
-        public Scope(Scope parent) : this(parent, false, null)
+        public Scope(Scope parent) : this(parent, null, null, null)
         {
         }
 
-        public Scope(Scope parent, bool forLoopScope, StringComparer stringComparer = null)
+        internal Scope(Scope parent, Scope assignmentTarget, StringComparer stringComparer, Scope previous)
         {
-            if (forLoopScope) ArgumentNullException.ThrowIfNull(parent);
-
-            // For loops are also ordinal by default
-            _stringComparer = stringComparer ?? StringComparer.Ordinal;
-
+            _stringComparer = stringComparer ?? parent?._stringComparer ?? StringComparer.Ordinal;
             Parent = parent;
-
-            // A ForLoop scope reads and writes its values in the parent scope.
-            // Internal accessors to the inner properties grant access to the local properties.
-            _forLoopScope = forLoopScope;
+            Previous = previous;
+            _assignmentTarget = assignmentTarget;
         }
+
+        internal Scope AssignmentScope => _assignmentTarget ?? this;
 
         /// <summary>
         /// Gets the own properties of the scope
@@ -93,7 +88,9 @@ namespace Fluid
         /// <summary>
         /// Gets the parent scope if any.
         /// </summary>
-        public Scope Parent { get; private set; }
+        public Scope Parent { get; }
+
+        internal Scope Previous { get; }
 
         /// <summary>
         /// Returns the value with the specified name in the chain of scopes, or undefined
@@ -150,13 +147,13 @@ namespace Fluid
         /// <param name="name">The name of the value to delete.</param>
         public void Delete(string name)
         {
-            if (!_forLoopScope)
+            if (_assignmentTarget is null)
             {
                 DeleteOwn(name);
             }
             else
             {
-                Parent.Delete(name);
+                _assignmentTarget.DeleteOwn(name);
             }
         }
 
@@ -204,13 +201,13 @@ namespace Fluid
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetValue(string name, FluidValue value)
         {
-            if (!_forLoopScope)
+            if (_assignmentTarget is null)
             {
                 SetOwnValue(name, value);
             }
             else
             {
-                Parent.SetValue(name, value);
+                _assignmentTarget.SetOwnValue(name, value);
             }
         }
 
@@ -235,7 +232,7 @@ namespace Fluid
 
             if (comparer is null)
             {
-                _storageComparer = comparer = Parent?._storageComparer ?? _stringComparer;
+                _storageComparer = comparer = _stringComparer;
 
                 if (ReferenceEquals(comparer, StringComparer.Ordinal))
                 {
@@ -300,6 +297,50 @@ namespace Fluid
             for (var i = 0; i < _inlineCount; i++)
             {
                 scope.SetValue(GetInlineName(i), GetInlineValue(i));
+            }
+        }
+
+        internal OwnValueEnumerator GetOwnValues() => new(this);
+
+        internal struct OwnValueEnumerator
+        {
+            private readonly Scope _scope;
+            private Dictionary<string, FluidValue>.Enumerator _dictionaryEnumerator;
+            private int _index;
+
+            internal OwnValueEnumerator(Scope scope)
+            {
+                _scope = scope;
+                _dictionaryEnumerator = scope._properties?.GetEnumerator() ?? default;
+                _index = -1;
+                Current = default;
+            }
+
+            internal KeyValuePair<string, FluidValue> Current { get; private set; }
+
+            internal bool MoveNext()
+            {
+                if (_scope._properties != null)
+                {
+                    if (_dictionaryEnumerator.MoveNext())
+                    {
+                        Current = _dictionaryEnumerator.Current;
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                _index++;
+                if (_index >= _scope._inlineCount)
+                {
+                    return false;
+                }
+
+                Current = new KeyValuePair<string, FluidValue>(
+                    _scope.GetInlineName(_index),
+                    _scope.GetInlineValue(_index));
+                return true;
             }
         }
 

--- a/Fluid/ScopeBehavior.cs
+++ b/Fluid/ScopeBehavior.cs
@@ -1,0 +1,25 @@
+namespace Fluid
+{
+    /// <summary>
+    /// Controls variable lookup and assignment for a scope entered through
+    /// <see cref="TemplateContext.EnterScope(ScopeBehavior)"/>.
+    /// </summary>
+    public enum ScopeBehavior
+    {
+        /// <summary>
+        /// Reads parent values and keeps assignments in the new scope.
+        /// </summary>
+        Local,
+
+        /// <summary>
+        /// Reads parent values, keeps explicitly local values in the new scope, and writes normal
+        /// assignments to the nearest non-write-through scope.
+        /// </summary>
+        WriteThrough,
+
+        /// <summary>
+        /// Reads only values from the context root and global values, and keeps assignments local.
+        /// </summary>
+        Isolated,
+    }
+}

--- a/Fluid/TemplateContext.cs
+++ b/Fluid/TemplateContext.cs
@@ -11,6 +11,7 @@ namespace Fluid
     {
         protected int _recursion;
         protected int _steps;
+        private Scope _localScope;
 
         /// <summary>
         /// Initializes a new instance of <see cref="TemplateContext"/>.
@@ -48,8 +49,8 @@ namespace Fluid
             modelNamesComparer ??= options.ModelNamesComparer;
 
             Options = options;
-            LocalScope = new Scope(options.Scope, forLoopScope: false, modelNamesComparer);
-            RootScope = LocalScope;
+            _localScope = new Scope(options.GlobalValues, null, modelNamesComparer, null);
+            RootScope = _localScope;
             CultureInfo = options.CultureInfo;
             MoneyOptions = options.MoneyOptions;
             TimeZone = options.TimeZone;
@@ -178,9 +179,9 @@ namespace Fluid
         }
 
         /// <summary>
-        /// Gets or sets the current scope.
+        /// Gets the current scope.
         /// </summary>
-        public Scope LocalScope { get; set; }
+        public Scope LocalScope => _localScope;
 
         /// <summary>
         /// Gets or sets the root scope.
@@ -215,59 +216,71 @@ namespace Fluid
         public TemplateOptions.UndefinedDelegate Undefined { get; set; }
 
         /// <summary>
-        /// Creates a new isolated child scope. After than any value added to this content object will be released once
-        /// <see cref="ReleaseScope" /> is called. The previous scope is linked such that its values are still available.
+        /// Enters a scope with the specified lookup and assignment behavior.
         /// </summary>
-        public void EnterChildScope()
+        public ScopeLease EnterScope(ScopeBehavior behavior = ScopeBehavior.Local)
         {
-            if (Options.MaxRecursion > 0 && _recursion++ > Options.MaxRecursion)
+            return new ScopeLease(this, EnterScopeCore(behavior));
+        }
+
+        private Scope EnterScopeCore(ScopeBehavior behavior)
+        {
+            if (behavior != ScopeBehavior.Local &&
+                behavior != ScopeBehavior.WriteThrough &&
+                behavior != ScopeBehavior.Isolated)
+            {
+                throw new ArgumentOutOfRangeException(nameof(behavior));
+            }
+
+            if (Options.MaxRecursion > 0 && _recursion >= Options.MaxRecursion)
             {
                 ExceptionHelper.ThrowMaximumRecursionException();
-                return;
             }
 
-            LocalScope = new Scope(LocalScope);
+            _recursion++;
+
+            var previous = _localScope;
+            var parent = behavior == ScopeBehavior.Isolated ? RootScope : previous;
+            var assignmentTarget = behavior == ScopeBehavior.WriteThrough
+                ? previous.AssignmentScope
+                : null;
+
+            return _localScope = new Scope(parent, assignmentTarget, ModelNamesComparer, previous);
         }
 
-        /// <summary>
-        /// Creates a new for loop scope. After than any value added to this content object will be released once
-        /// <see cref="ReleaseScope" /> is called. The previous scope is linked such that its values are still available.
-        /// </summary>
-        public void EnterForLoopScope()
+        private void ReleaseScopeCore(Scope scope)
         {
-            if (Options.MaxRecursion > 0 && _recursion++ > Options.MaxRecursion)
+            if (!ReferenceEquals(_localScope, scope))
             {
-                ExceptionHelper.ThrowMaximumRecursionException();
-                return;
+                ExceptionHelper.ThrowInvalidOperationException("Scopes must be released in reverse order");
             }
 
-            LocalScope = new Scope(LocalScope, forLoopScope: true);
+            _recursion--;
+            _localScope = scope.Previous;
         }
 
         /// <summary>
-        /// Exits the current scope that has been created by <see cref="EnterChildScope" />
+        /// Restores the previous scope when disposed.
         /// </summary>
-        public void ReleaseScope()
+        public readonly struct ScopeLease : IDisposable
         {
-            if (_recursion > 0)
+            private readonly TemplateContext _context;
+            private readonly Scope _scope;
+
+            internal ScopeLease(TemplateContext context, Scope scope)
             {
-                _recursion--;
+                _context = context;
+                _scope = scope;
             }
 
-            LocalScope = LocalScope.Parent;
-
-            if (LocalScope == null)
+            /// <summary>
+            /// Restores the scope that was active before this lease was created.
+            /// </summary>
+            public void Dispose()
             {
-                ExceptionHelper.ThrowInvalidOperationException("ReleaseScope invoked without corresponding EnterChildScope");
-                return;
+                _context?.ReleaseScopeCore(_scope);
             }
         }
-
-        /// <summary>
-        /// Gets the names of the values.
-        /// </summary>
-        [Obsolete("Use LocalScope.Properties instead.")]
-        public IEnumerable<string> ValueNames => LocalScope.Properties;
 
         /// <summary>
         /// Gets a value from the context.
@@ -275,7 +288,7 @@ namespace Fluid
         /// <param name="name">The name of the value.</param>
         public FluidValue GetValue(string name)
         {
-            return LocalScope.GetValue(name);
+            return _localScope.GetValue(name);
         }
 
         /// <summary>
@@ -286,7 +299,7 @@ namespace Fluid
         /// <returns></returns>
         public TemplateContext SetValue(string name, FluidValue value)
         {
-            LocalScope.SetValue(name, value);
+            _localScope.SetValue(name, value);
             return this;
         }
     }

--- a/Fluid/TemplateOptions.cs
+++ b/Fluid/TemplateOptions.cs
@@ -159,9 +159,9 @@ namespace Fluid
         public FilterCollection Filters { get; } = new FilterCollection();
 
         /// <summary>
-        /// Gets a scope that is available in all the templates.
+        /// Gets values that are available in all templates rendered with these options.
         /// </summary>
-        public Scope Scope { get; } = new Scope();
+        public Scope GlobalValues { get; } = new Scope();
 
         /// <summary>
         /// Gets the list of value converters.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,15 @@ An `IFluidTemplate` instance is thread-safe and can be cached and reused by mult
 
 A `TemplateContext` instance is __not__ thread-safe, and a new instance should be created every time an `IFluidTemplate` instance is used.
 
+Values registered in `TemplateOptions.GlobalValues` are shared by every context created from those options. Values set directly on a `TemplateContext` belong to that rendering. Custom tags that need temporary values should use a scope lease:
+
+```csharp
+using var scope = context.EnterScope(ScopeBehavior.Local);
+context.SetValue("temporary", value);
+```
+
+`Local` scopes inherit values and keep assignments local. `WriteThrough` scopes keep values assigned with `LocalScope.SetOwnValue` temporary while normal assignments update the caller, which matches `include` and loop behavior. `Isolated` scopes can only read the context's initial values and `GlobalValues`, which matches the `render` tag.
+
 <br>
 
 ## NativeAOT and trimming


### PR DESCRIPTION
Fluid's scope behavior was encoded through loop-specific flags, mutable scope replacement, and manual enter/release pairs. This made the public API difficult to reason about and forced `render` and `include` to perform unnecessary allocation and cleanup work.

This change introduces explicit `Local`, `WriteThrough`, and `Isolated` scope behaviors through disposable scope leases. It removes the legacy scope mutation APIs, renames shared option values to `GlobalValues`, and updates loops, macros, partials, includes, renders, and view rendering to use the new model.

`render` now evaluates caller expressions before entering one isolated frame instead of creating and copying multiple scopes. The source-generated path follows the same semantics, including context-root and global-value visibility. `include` uses a write-through frame whose temporary bindings disappear when the lease is disposed, removing keyword tracking and individual cleanup.

The focused benchmarks measured:

- Isolated render allocations: 792 B to 728 B
- Write-through include: 209.8 ns to 192.4 ns
- Write-through include allocations: 712 B to 696 B

This is intentionally a breaking API cleanup: `EnterChildScope`, `EnterForLoopScope`, `ReleaseScope`, mutable `LocalScope`, `TemplateOptions.Scope`, `ValueNames`, and the loop-specific `Scope` constructor are removed rather than retained as obsolete compatibility aliases.