### PR TITLE
Reduce include argument allocations

### DIFF
--- a/Fluid.Benchmarks/IncludeScopeBenchmarks.cs
+++ b/Fluid.Benchmarks/IncludeScopeBenchmarks.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Fluid.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class IncludeScopeBenchmarks
+    {
+        private readonly CountingFluidOutput _output = new();
+        private readonly TemplateContext _context;
+        private readonly IFluidTemplate _oneKeywordArgument;
+        private readonly IFluidTemplate _multipleKeywordArguments;
+        private readonly IFluidTemplate _nestedIncludes;
+        private readonly IFluidTemplate _repeatedIncludes;
+
+        public IncludeScopeBenchmarks()
+        {
+            var parser = new FluidParser();
+            var options = new TemplateOptions
+            {
+                FileProvider = new InMemoryTemplateFileProvider(
+                    ("value.liquid", "{{ value }}"),
+                    ("arguments.liquid", "{{ first }}{{ second }}{{ third }}"),
+                    ("outer.liquid", "{% include 'value', value: value %}"))
+            };
+
+            _context = new TemplateContext(options)
+                .SetValue("value", "v");
+
+            _oneKeywordArgument = parser.Parse("{% include 'value', value: value %}");
+            _multipleKeywordArguments = parser.Parse(
+                "{% include 'arguments', first: value, second: value, third: value %}");
+            _nestedIncludes = parser.Parse("{% include 'outer', value: value %}");
+            _repeatedIncludes = parser.Parse(
+                "{% include 'value', value: value %}" +
+                "{% include 'value', value: value %}" +
+                "{% include 'value', value: value %}" +
+                "{% include 'value', value: value %}");
+
+            WarmUp();
+        }
+
+        [Benchmark]
+        public ValueTask OneKeywordArgument()
+        {
+            _output.Reset();
+            return _oneKeywordArgument.RenderAsync(_output, NullEncoder.Default, _context);
+        }
+
+        [Benchmark]
+        public ValueTask MultipleKeywordArguments()
+        {
+            _output.Reset();
+            return _multipleKeywordArguments.RenderAsync(_output, NullEncoder.Default, _context);
+        }
+
+        [Benchmark]
+        public ValueTask NestedIncludes()
+        {
+            _output.Reset();
+            return _nestedIncludes.RenderAsync(_output, NullEncoder.Default, _context);
+        }
+
+        [Benchmark]
+        public ValueTask RepeatedIncludes()
+        {
+            _output.Reset();
+            return _repeatedIncludes.RenderAsync(_output, NullEncoder.Default, _context);
+        }
+
+        private void WarmUp()
+        {
+            OneKeywordArgument().GetAwaiter().GetResult();
+            MultipleKeywordArguments().GetAwaiter().GetResult();
+            NestedIncludes().GetAwaiter().GetResult();
+            RepeatedIncludes().GetAwaiter().GetResult();
+        }
+
+        private sealed class CountingFluidOutput : IFluidOutput
+        {
+            private char[] _buffer = new char[64];
+
+            public int Written { get; private set; }
+
+            public void Advance(int count) => Written += count;
+
+            public Memory<char> GetMemory(int sizeHint = 0)
+            {
+                EnsureCapacity(sizeHint);
+                return _buffer.AsMemory(Written);
+            }
+
+            public Span<char> GetSpan(int sizeHint = 0)
+            {
+                EnsureCapacity(sizeHint);
+                return _buffer.AsSpan(Written);
+            }
+
+            public void Write(string value)
+            {
+                EnsureCapacity(value.Length);
+                value.CopyTo(0, _buffer, Written, value.Length);
+                Written += value.Length;
+            }
+
+            public void Write(char[] buffer, int index, int count)
+            {
+                EnsureCapacity(count);
+                buffer.AsSpan(index, count).CopyTo(_buffer.AsSpan(Written));
+                Written += count;
+            }
+
+            public ValueTask FlushAsync() => default;
+
+            public void Reset() => Written = 0;
+
+            private void EnsureCapacity(int sizeHint)
+            {
+                var required = Written + Math.Max(sizeHint, 1);
+                if (required > _buffer.Length)
+                {
+                    Array.Resize(ref _buffer, Math.Max(required, _buffer.Length * 2));
+                }
+            }
+        }
+
+        private sealed class InMemoryTemplateFileProvider : ITemplateFileProvider
+        {
+            private readonly Dictionary<string, byte[]> _templates = new(StringComparer.Ordinal);
+
+            public InMemoryTemplateFileProvider(params (string Path, string Content)[] templates)
+            {
+                foreach (var template in templates)
+                {
+                    _templates[template.Path] = Encoding.UTF8.GetBytes(template.Content);
+                }
+            }
+
+            public ValueTask<TemplateSourceInfo> GetFileInfoAsync(
+                string subpath,
+                TemplateContext context,
+                CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (!_templates.TryGetValue(subpath, out var content))
+                {
+                    return default;
+                }
+
+                return new ValueTask<TemplateSourceInfo>(
+                    new TemplateSourceInfo(
+                        DateTimeOffset.UnixEpoch,
+                        _ => new ValueTask<Stream>(new MemoryStream(content, writable: false))));
+            }
+        }
+    }
+}

--- a/Fluid.Tests/IncludeStatementAllocationTests.cs
+++ b/Fluid.Tests/IncludeStatementAllocationTests.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Encodings.Web;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluid.Ast;
+using Fluid.Tests.Mocks;
+using Fluid.Values;
+using Xunit;
+
+namespace Fluid.Tests
+{
+    public class IncludeStatementAllocationTests
+    {
+#if COMPILED
+        private static readonly FluidParser _parser = new FluidParser().Compile();
+#else
+        private static readonly FluidParser _parser = new FluidParser();
+#endif
+
+        [Fact]
+        public void IncludeArguments_AreRemovedWhileAssignmentsPersist()
+        {
+            var provider = new MockFileProvider()
+                .Add("snippet.liquid", "{{ argument }}{% assign persisted = argument %}");
+            var context = new TemplateContext(new TemplateOptions { FileProvider = provider });
+            var template = _parser.Parse(
+                "{% include 'snippet', argument: 'inner' %}|{{ argument }}|{{ persisted }}");
+
+            Assert.Equal("inner||inner", template.Render(context));
+            Assert.IsType<UndefinedValue>(context.GetValue("argument"));
+        }
+
+        [Fact]
+        public void IncludeDuplicateArguments_PreserveEvaluationAndCleanupOrder()
+        {
+            var provider = new MockFileProvider()
+                .Add("snippet.liquid", "{{ value }}");
+            var context = new TemplateContext(new TemplateOptions { FileProvider = provider });
+            var template = _parser.Parse(
+                "{% include 'snippet', value: 'first', value: value %}|{{ value }}");
+
+            Assert.Equal("first|", template.Render(context));
+            Assert.IsType<UndefinedValue>(context.GetValue("value"));
+        }
+
+        [Fact]
+        public void NestedIncludeArguments_RestoreTheOuterIncludeValue()
+        {
+            var provider = new MockFileProvider()
+                .Add("outer.liquid", "{{ value }}|{% include 'inner', value: 'inner' %}|{{ value }}")
+                .Add("inner.liquid", "{{ value }}");
+            var context = new TemplateContext(new TemplateOptions { FileProvider = provider });
+            var template = _parser.Parse(
+                "{% include 'outer', value: 'outer' %}|{{ value }}");
+
+            Assert.Equal("outer|inner|outer|", template.Render(context));
+            Assert.IsType<UndefinedValue>(context.GetValue("value"));
+        }
+
+        [Fact]
+        public async Task IncludeBindingsAndArguments_RestoreExistingValues()
+        {
+            var provider = new MockFileProvider()
+                .Add("snippet.liquid", "{{ item }}|{{ value }}");
+            var context = new TemplateContext(new TemplateOptions { FileProvider = provider })
+                .SetValue("item", "outer-item")
+                .SetValue("value", "outer-value");
+            var include = new IncludeStatement(
+                _parser,
+                new LiteralExpression(new StringValue("snippet")),
+                with: new LiteralExpression(new StringValue("inner-item")),
+                alias: "item",
+                assignStatements: new List<AssignStatement>
+                {
+                    new("value", new LiteralExpression(new StringValue("inner-value")))
+                });
+            var writer = new StringWriter();
+
+            await include.WriteToAsync(writer, NullEncoder.Default, context);
+
+            Assert.Equal("inner-item|inner-value", writer.ToString());
+            Assert.Equal("outer-item", context.GetValue("item").ToStringValue());
+            Assert.Equal("outer-value", context.GetValue("value").ToStringValue());
+        }
+
+        [Theory]
+        [InlineData("break", "before|")]
+        [InlineData("continue", "beforebefore|")]
+        public void IncludeArguments_AreRemovedOnLoopCompletion(string completion, string expected)
+        {
+            var provider = new MockFileProvider()
+                .Add("flow.liquid", $"{{% {completion} %}}");
+            var context = new TemplateContext(new TemplateOptions { FileProvider = provider })
+                .SetValue("items", new[] { 1, 2 });
+            var template = _parser.Parse(
+                "{% for item in items %}before{% include 'flow', argument: 'inner' %}after{% endfor %}|{{ argument }}");
+
+            Assert.Equal(expected, template.Render(context));
+            Assert.IsType<UndefinedValue>(context.GetValue("argument"));
+        }
+
+        [Fact]
+        public async Task IncludeArguments_AreRemovedWhenFallbackTemplateThrows()
+        {
+            var provider = new MockFileProvider()
+                .Add("snippet.liquid", "");
+            var options = new TemplateOptions
+            {
+                FileProvider = provider,
+                TemplateParsed = (_, _) => new ThrowingTemplate()
+            };
+            var context = new TemplateContext(options)
+                .SetValue("existing", "outer");
+            var rootScope = context.LocalScope;
+            var template = _parser.Parse(
+                "{% include 'snippet', argument: 'inner', existing: 'inner' %}");
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => template.RenderAsync(new TestFluidOutput(), HtmlEncoder.Default, context).AsTask());
+
+            Assert.Equal("render failed", exception.Message);
+            Assert.Same(rootScope, context.LocalScope);
+            Assert.IsType<UndefinedValue>(context.GetValue("argument"));
+            Assert.Equal("outer", context.GetValue("existing").ToStringValue());
+        }
+
+        [Fact]
+        public async Task IncludeArguments_AreRemovedWhenArgumentEvaluationThrows()
+        {
+            var provider = new MockFileProvider()
+                .Add("snippet.liquid", "");
+            var context = new TemplateContext(new TemplateOptions { FileProvider = provider })
+                .SetValue("existing", "outer");
+            var rootScope = context.LocalScope;
+            var include = new IncludeStatement(
+                _parser,
+                new LiteralExpression(new StringValue("snippet")),
+                assignStatements: new List<AssignStatement>
+                {
+                    new("argument", new LiteralExpression(new StringValue("inner"))),
+                    new("existing", new ThrowingExpression())
+                });
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => include.WriteToAsync(new TestFluidOutput(), HtmlEncoder.Default, context).AsTask());
+
+            Assert.Equal("evaluation failed", exception.Message);
+            Assert.Same(rootScope, context.LocalScope);
+            Assert.IsType<UndefinedValue>(context.GetValue("argument"));
+            Assert.Equal("outer", context.GetValue("existing").ToStringValue());
+        }
+
+        [Fact]
+        public async Task IncludeArguments_AreRemovedWhenFallbackTemplateIsCanceled()
+        {
+            var provider = new MockFileProvider()
+                .Add("snippet.liquid", "");
+            var options = new TemplateOptions
+            {
+                FileProvider = provider,
+                TemplateParsed = (_, _) => new CanceledTemplate()
+            };
+            var context = new TemplateContext(options);
+            var rootScope = context.LocalScope;
+            var template = _parser.Parse(
+                "{% include 'snippet', argument: 'inner' %}");
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => template.RenderAsync(new TestFluidOutput(), HtmlEncoder.Default, context).AsTask());
+
+            Assert.Same(rootScope, context.LocalScope);
+            Assert.IsType<UndefinedValue>(context.GetValue("argument"));
+        }
+
+        private sealed class ThrowingTemplate : IFluidTemplate
+        {
+            public ValueTask RenderAsync(IFluidOutput output, TextEncoder encoder, TemplateContext context) =>
+                new(Task.FromException(new InvalidOperationException("render failed")));
+        }
+
+        private sealed class CanceledTemplate : IFluidTemplate
+        {
+            public ValueTask RenderAsync(IFluidOutput output, TextEncoder encoder, TemplateContext context) =>
+                new(Task.FromCanceled(new CancellationToken(canceled: true)));
+        }
+
+        private sealed class ThrowingExpression : Expression
+        {
+            public override ValueTask<FluidValue> EvaluateAsync(TemplateContext context) =>
+                new(Task.FromException<FluidValue>(new InvalidOperationException("evaluation failed")));
+        }
+
+        private sealed class TestFluidOutput : IFluidOutput
+        {
+            public void Advance(int count)
+            {
+            }
+
+            public Memory<char> GetMemory(int sizeHint = 0) => Memory<char>.Empty;
+
+            public Span<char> GetSpan(int sizeHint = 0) => Span<char>.Empty;
+
+            public void Write(string value)
+            {
+            }
+
+            public void Write(char[] buffer, int index, int count)
+            {
+            }
+
+            public ValueTask FlushAsync() => default;
+        }
+    }
+}

--- a/Fluid/Ast/IncludeStatement.cs
+++ b/Fluid/Ast/IncludeStatement.cs
@@ -46,9 +46,6 @@ namespace Fluid.Ast
             // This allows variables assigned inside the include to persist in the outer scope.
             context.EnterForLoopScope();
 
-            // Track keyword argument names so we can clean them up after
-            List<string> keywordArgNames = null;
-
             try
             {
                 if (With != null)
@@ -61,11 +58,9 @@ namespace Fluid.Ast
                     // Keyword arguments are local to the include
                     if (AssignStatements.Count > 0)
                     {
-                        keywordArgNames = new List<string>(AssignStatements.Count);
                         for (var i = 0; i < AssignStatements.Count; i++)
                         {
                             var stmt = AssignStatements[i];
-                            keywordArgNames.Add(stmt.Identifier);
                             context.LocalScope.SetOwnValue(stmt.Identifier, await stmt.Value.EvaluateAsync(context));
                         }
                     }
@@ -75,11 +70,9 @@ namespace Fluid.Ast
                 else if (AssignStatements.Count > 0)
                 {
                     // Keyword arguments are local to the include - they should go out of scope after
-                    keywordArgNames = new List<string>(AssignStatements.Count);
                     for (var i = 0; i < AssignStatements.Count; i++)
                     {
                         var stmt = AssignStatements[i];
-                        keywordArgNames.Add(stmt.Identifier);
                         context.LocalScope.SetOwnValue(stmt.Identifier, await stmt.Value.EvaluateAsync(context));
                     }
 
@@ -146,12 +139,9 @@ namespace Fluid.Ast
             finally
             {
                 // Clean up keyword arguments from local scope
-                if (keywordArgNames != null)
+                for (var i = 0; i < AssignStatements.Count; i++)
                 {
-                    foreach (var name in keywordArgNames)
-                    {
-                        context.LocalScope.DeleteOwn(name);
-                    }
+                    context.LocalScope.DeleteOwn(AssignStatements[i].Identifier);
                 }
 
                 context.ReleaseScope();


### PR DESCRIPTION
Include keyword arguments currently allocate a temporary list solely to remember identifiers for cleanup. This removes that per-include collection while preserving include scope semantics.

The cleanup path now iterates the existing parsed assignment statements directly. Targeted coverage verifies duplicate identifiers, nested includes, existing-value collisions, break/continue, evaluation and rendering exceptions, cancellation, and fallback non-statement-list templates in interpreted and compiled parser modes.

Focused benchmarks show deterministic allocation reductions:

| Scenario | Before | After | Saved |
|---|---:|---:|---:|
| One keyword argument | 424 B | 360 B | 64 B (15.1%) |
| Multiple keyword arguments | 456 B | 376 B | 80 B (17.5%) |
| Nested includes | 848 B | 720 B | 128 B (15.1%) |
| Four repeated includes | 1,696 B | 1,440 B | 256 B (15.1%) |

Validation includes the full interpreted and compiled test suites plus Release builds for all Fluid target frameworks.