### PR TITLE
Optimize synchronous render statements

### DIFF
--- a/Fluid.Benchmarks/AstSyncPathBenchmarks.cs
+++ b/Fluid.Benchmarks/AstSyncPathBenchmarks.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Fluid.Ast;
+using Fluid.Values;
+
+namespace Fluid.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class AstSyncPathBenchmarks
+    {
+        private const int ItemCount = 100;
+
+        private readonly CountingFluidOutput _output = new();
+        private readonly TemplateContext _forContext;
+        private readonly TemplateContext _renderContext;
+        private readonly TemplateContext _includeContext;
+        private readonly ForStatement _for;
+        private readonly ForStatement _forAsync;
+        private readonly RenderStatement _render;
+        private readonly RenderStatement _renderAsync;
+        private readonly IncludeStatement _include;
+        private readonly IncludeStatement _includeAsync;
+
+        public AstSyncPathBenchmarks()
+        {
+            var values = new FluidValue[ItemCount];
+            for (var i = 0; i < values.Length; i++)
+            {
+                values[i] = NumberValue.Create(i);
+            }
+
+            var source = new LiteralExpression(new ArrayValue(values));
+            _forContext = new TemplateContext();
+            _for = new ForStatement(
+                [new TextSpanStatement("x")],
+                "item",
+                source,
+                limit: null,
+                offset: null,
+                reversed: false);
+            _forAsync = new ForStatement(
+                [new SuspendingStatement()],
+                "item",
+                source,
+                limit: null,
+                offset: null,
+                reversed: false);
+
+            var parser = new FluidParser();
+            _renderContext = CreateTemplateContext(parser, out var renderPath);
+            _includeContext = CreateTemplateContext(parser, out var includePath);
+
+            _render = new RenderStatement(parser, renderPath);
+            _renderAsync = new RenderStatement(parser, renderPath + "-async");
+            _include = new IncludeStatement(parser, new LiteralExpression(new StringValue(includePath)));
+            _includeAsync = new IncludeStatement(parser, new LiteralExpression(new StringValue(includePath + "-async")));
+
+            WarmTemplateCaches();
+        }
+
+        [Benchmark]
+        public ValueTask<Completion> For() => Run(_for, _forContext);
+
+        [Benchmark]
+        public ValueTask<Completion> ForAsync() => Run(_forAsync, _forContext);
+
+        [Benchmark]
+        public ValueTask<Completion> Render() => Run(_render, _renderContext);
+
+        [Benchmark]
+        public ValueTask<Completion> RenderAsync() => Run(_renderAsync, _renderContext);
+
+        [Benchmark]
+        public ValueTask<Completion> Include() => Run(_include, _includeContext);
+
+        [Benchmark]
+        public ValueTask<Completion> IncludeAsync() => Run(_includeAsync, _includeContext);
+
+        private ValueTask<Completion> Run(Statement statement, TemplateContext context)
+        {
+            _output.Reset();
+            return statement.WriteToAsync(_output, NullEncoder.Default, context);
+        }
+
+        private static TemplateContext CreateTemplateContext(FluidParser parser, out string path)
+        {
+            path = Guid.NewGuid().ToString("N");
+            var provider = new BenchmarkTemplateFileProvider()
+                .Add(path, "x")
+                .Add(path + "-async", "");
+            var options = new TemplateOptions
+            {
+                FileProvider = provider,
+                TemplateParsed = (templatePath, template) =>
+                    templatePath.EndsWith("-async", StringComparison.Ordinal)
+                        ? new SuspendingTemplate()
+                        : template
+            };
+
+            return new TemplateContext(options);
+        }
+
+        private void WarmTemplateCaches()
+        {
+            Run(_render, _renderContext).GetAwaiter().GetResult();
+            Run(_renderAsync, _renderContext).GetAwaiter().GetResult();
+            Run(_include, _includeContext).GetAwaiter().GetResult();
+            Run(_includeAsync, _includeContext).GetAwaiter().GetResult();
+        }
+
+        private sealed class SuspendingStatement : Statement
+        {
+            public override async ValueTask<Completion> WriteToAsync(
+                IFluidOutput output,
+                TextEncoder encoder,
+                TemplateContext context)
+            {
+                await Task.Yield();
+                output.Write("x");
+                return Completion.Normal;
+            }
+
+            protected override Statement Accept(AstVisitor visitor) => this;
+        }
+
+        private sealed class SuspendingTemplate : IFluidTemplate
+        {
+            public async ValueTask RenderAsync(
+                IFluidOutput output,
+                TextEncoder encoder,
+                TemplateContext context)
+            {
+                await Task.Yield();
+                output.Write("x");
+            }
+        }
+
+        private sealed class BenchmarkTemplateFileProvider : ITemplateFileProvider
+        {
+            private readonly Dictionary<string, byte[]> _files = new(StringComparer.Ordinal);
+
+            public BenchmarkTemplateFileProvider Add(string path, string content)
+            {
+                _files[path] = Encoding.UTF8.GetBytes(content);
+                return this;
+            }
+
+            public ValueTask<TemplateSourceInfo> GetFileInfoAsync(
+                string subpath,
+                TemplateContext context,
+                CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!_files.TryGetValue(subpath, out var content))
+                {
+                    return default;
+                }
+
+                return new ValueTask<TemplateSourceInfo>(
+                    new TemplateSourceInfo(
+                        DateTimeOffset.UnixEpoch,
+                        _ => new ValueTask<Stream>(new MemoryStream(content, writable: false))));
+            }
+        }
+
+        private sealed class CountingFluidOutput : IFluidOutput
+        {
+            private char[] _buffer = new char[128];
+
+            public int Written { get; private set; }
+
+            public void Advance(int count) => Written += count;
+
+            public Memory<char> GetMemory(int sizeHint = 0)
+            {
+                EnsureCapacity(sizeHint);
+                return _buffer.AsMemory(Written);
+            }
+
+            public Span<char> GetSpan(int sizeHint = 0)
+            {
+                EnsureCapacity(sizeHint);
+                return _buffer.AsSpan(Written);
+            }
+
+            public void Write(string value)
+            {
+                EnsureCapacity(value.Length);
+                value.CopyTo(0, _buffer, Written, value.Length);
+                Written += value.Length;
+            }
+
+            public void Write(char[] buffer, int index, int count)
+            {
+                EnsureCapacity(count);
+                buffer.AsSpan(index, count).CopyTo(_buffer.AsSpan(Written));
+                Written += count;
+            }
+
+            public ValueTask FlushAsync() => default;
+
+            public void Reset() => Written = 0;
+
+            private void EnsureCapacity(int sizeHint)
+            {
+                var required = Written + Math.Max(sizeHint, 1);
+                if (required > _buffer.Length)
+                {
+                    Array.Resize(ref _buffer, Math.Max(required, _buffer.Length * 2));
+                }
+            }
+        }
+    }
+}

--- a/Fluid.Tests/RenderStatementSyncTests.cs
+++ b/Fluid.Tests/RenderStatementSyncTests.cs
@@ -1,0 +1,231 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluid.Ast;
+using Fluid.Tests.Mocks;
+using Fluid.Values;
+using Xunit;
+
+namespace Fluid.Tests
+{
+    public class RenderStatementSyncTests
+    {
+#if COMPILED
+        private static readonly FluidParser _parser = new FluidParser().Compile();
+#else
+        private static readonly FluidParser _parser = new FluidParser();
+#endif
+
+        [Fact]
+        public void SynchronousRender_CompletesSynchronouslyAndRestoresScope()
+        {
+            var nested = new SynchronousTemplate();
+            var context = CreateContext(nested);
+            var rootScope = context.LocalScope;
+            var statement = new RenderStatement(_parser, "snippet");
+
+            var task = statement.WriteToAsync(new TestFluidOutput(), HtmlEncoder.Default, context);
+
+            Assert.True(task.IsCompletedSuccessfully);
+            Assert.Equal(Completion.Normal, task.Result);
+            Assert.NotNull(nested.ObservedScope);
+            Assert.NotSame(rootScope, nested.ObservedScope);
+            Assert.Same(rootScope, context.LocalScope);
+        }
+
+        [Fact]
+        public async Task SuspendedFileLoad_DoesNotEnterScopeEarly()
+        {
+            var provider = new ControlledFileProvider();
+            var context = new TemplateContext(new TemplateOptions { FileProvider = provider });
+            var rootScope = context.LocalScope;
+            var statement = new RenderStatement(_parser, "snippet");
+
+            var task = statement.WriteToAsync(new TestFluidOutput(), HtmlEncoder.Default, context);
+
+            Assert.False(task.IsCompletedSuccessfully);
+            Assert.Same(rootScope, context.LocalScope);
+
+            provider.SetResult("x");
+
+            Assert.Equal(Completion.Normal, await task);
+            Assert.Same(rootScope, context.LocalScope);
+        }
+
+        [Fact]
+        public async Task SuspendedRender_RestoresScopeAfterCompletion()
+        {
+            var nested = new ControlledTemplate();
+            var context = CreateContext(nested);
+            var rootScope = context.LocalScope;
+            var statement = new RenderStatement(_parser, "snippet");
+
+            var task = statement.WriteToAsync(new TestFluidOutput(), HtmlEncoder.Default, context);
+
+            Assert.False(task.IsCompletedSuccessfully);
+            Assert.NotSame(rootScope, context.LocalScope);
+
+            nested.SetResult();
+
+            Assert.Equal(Completion.Normal, await task);
+            Assert.Same(rootScope, context.LocalScope);
+        }
+
+        [Fact]
+        public void SynchronousRenderException_RestoresScope()
+        {
+            var context = CreateContext(new SynchronousThrowingTemplate());
+            var rootScope = context.LocalScope;
+            var statement = new RenderStatement(_parser, "snippet");
+
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => statement.WriteToAsync(new TestFluidOutput(), HtmlEncoder.Default, context));
+
+            Assert.Equal("render failed", exception.Message);
+            Assert.Same(rootScope, context.LocalScope);
+        }
+
+        [Fact]
+        public async Task SuspendedRenderException_RestoresScope()
+        {
+            var nested = new ControlledTemplate();
+            var context = CreateContext(nested);
+            var rootScope = context.LocalScope;
+            var statement = new RenderStatement(_parser, "snippet");
+
+            var task = statement.WriteToAsync(new TestFluidOutput(), HtmlEncoder.Default, context);
+            nested.SetException(new InvalidOperationException("render failed"));
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => task.AsTask());
+
+            Assert.Equal("render failed", exception.Message);
+            Assert.Same(rootScope, context.LocalScope);
+        }
+
+        [Fact]
+        public async Task SuspendedRenderCancellation_RestoresScope()
+        {
+            var nested = new ControlledTemplate();
+            var context = CreateContext(nested);
+            var rootScope = context.LocalScope;
+            var statement = new RenderStatement(_parser, "snippet");
+
+            var task = statement.WriteToAsync(new TestFluidOutput(), HtmlEncoder.Default, context);
+            nested.SetCanceled();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task.AsTask());
+            Assert.Same(rootScope, context.LocalScope);
+        }
+
+        [Theory]
+        [InlineData("break")]
+        [InlineData("continue")]
+        public void NestedCompletion_DoesNotEscapeRender(string completion)
+        {
+            var provider = new MockFileProvider()
+                .Add("flow.liquid", $"{{% {completion} %}}");
+            var context = new TemplateContext(new TemplateOptions { FileProvider = provider })
+                .SetValue("items", new[] { 1, 2 });
+            var template = _parser.Parse(
+                "{% for item in items %}a{% render 'flow' %}b{% endfor %}");
+
+            Assert.Equal("abab", template.Render(context));
+        }
+
+        private static TemplateContext CreateContext(IFluidTemplate nested)
+        {
+            var provider = new MockFileProvider().Add("snippet.liquid", "");
+            return new TemplateContext(new TemplateOptions
+            {
+                FileProvider = provider,
+                TemplateParsed = (_, _) => nested
+            });
+        }
+
+        private sealed class SynchronousTemplate : IFluidTemplate
+        {
+            public Scope ObservedScope { get; private set; }
+
+            public ValueTask RenderAsync(
+                IFluidOutput output,
+                TextEncoder encoder,
+                TemplateContext context)
+            {
+                ObservedScope = context.LocalScope;
+                return default;
+            }
+        }
+
+        private sealed class SynchronousThrowingTemplate : IFluidTemplate
+        {
+            public ValueTask RenderAsync(
+                IFluidOutput output,
+                TextEncoder encoder,
+                TemplateContext context) =>
+                throw new InvalidOperationException("render failed");
+        }
+
+        private sealed class ControlledTemplate : IFluidTemplate
+        {
+            private readonly TaskCompletionSource _completion =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public ValueTask RenderAsync(
+                IFluidOutput output,
+                TextEncoder encoder,
+                TemplateContext context) =>
+                new(_completion.Task);
+
+            public void SetResult() => _completion.SetResult();
+
+            public void SetException(Exception exception) => _completion.SetException(exception);
+
+            public void SetCanceled() => _completion.SetCanceled();
+        }
+
+        private sealed class ControlledFileProvider : ITemplateFileProvider
+        {
+            private readonly TaskCompletionSource<TemplateSourceInfo> _completion =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public ValueTask<TemplateSourceInfo> GetFileInfoAsync(
+                string subpath,
+                TemplateContext context,
+                CancellationToken cancellationToken) =>
+                new(_completion.Task);
+
+            public void SetResult(string content)
+            {
+                var bytes = Encoding.UTF8.GetBytes(content);
+                _completion.SetResult(
+                    new TemplateSourceInfo(
+                        DateTimeOffset.UnixEpoch,
+                        _ => new ValueTask<Stream>(new MemoryStream(bytes, writable: false))));
+            }
+        }
+
+        private sealed class TestFluidOutput : IFluidOutput
+        {
+            public void Advance(int count)
+            {
+            }
+
+            public Memory<char> GetMemory(int sizeHint = 0) => Memory<char>.Empty;
+
+            public Span<char> GetSpan(int sizeHint = 0) => Span<char>.Empty;
+
+            public void Write(string value)
+            {
+            }
+
+            public void Write(char[] buffer, int index, int count)
+            {
+            }
+
+            public ValueTask FlushAsync() => default;
+        }
+    }
+}

--- a/Fluid/Ast/RenderStatement.cs
+++ b/Fluid/Ast/RenderStatement.cs
@@ -31,7 +31,88 @@ namespace Fluid.Ast
         public Expression For { get; }
         public string Alias { get; }
 
-        public override async ValueTask<Completion> WriteToAsync(IFluidOutput output, TextEncoder encoder, TemplateContext context)
+        public override ValueTask<Completion> WriteToAsync(IFluidOutput output, TextEncoder encoder, TemplateContext context)
+        {
+            if (With != null || For != null || AssignStatements.Count > 0)
+            {
+                return WriteToAsyncCore(output, encoder, context);
+            }
+
+            context.IncrementSteps();
+
+            var task = TemplateLoader.LoadAsync(
+                Parser,
+                Path,
+                context,
+                context.Options.DefaultFileExtension);
+
+            if (task.IsCompletedSuccessfully)
+            {
+                return RenderLoadedTemplate(task.Result.Template, output, encoder, context);
+            }
+
+            return AwaitedLoad(task, output, encoder, context);
+
+            static async ValueTask<Completion> AwaitedLoad(
+                ValueTask<TemplateLoader.LoadedTemplate> task,
+                IFluidOutput output,
+                TextEncoder encoder,
+                TemplateContext context)
+            {
+                var loadedTemplate = await task;
+                return await RenderLoadedTemplate(loadedTemplate.Template, output, encoder, context);
+            }
+        }
+
+        private static ValueTask<Completion> RenderLoadedTemplate(
+            IFluidTemplate template,
+            IFluidOutput output,
+            TextEncoder encoder,
+            TemplateContext context)
+        {
+            context.EnterChildScope();
+            var previousScope = context.LocalScope;
+
+            try
+            {
+                context.IsolateCurrentScope();
+
+                var task = FluidTemplateRenderer.RenderAsync(template, output, encoder, context);
+                if (task.IsCompletedSuccessfully)
+                {
+                    context.LocalScope = previousScope;
+                    context.ReleaseScope();
+                    return NormalCompletion;
+                }
+
+                return AwaitedRender(task, previousScope, context);
+            }
+            catch
+            {
+                context.LocalScope = previousScope;
+                context.ReleaseScope();
+                throw;
+            }
+
+            static async ValueTask<Completion> AwaitedRender(
+                ValueTask task,
+                Scope previousScope,
+                TemplateContext context)
+            {
+                try
+                {
+                    await task;
+                    return Completion.Normal;
+                }
+                finally
+                {
+                    context.LocalScope = previousScope;
+                    context.ReleaseScope();
+                }
+            }
+        }
+
+        private async ValueTask<Completion> WriteToAsyncCore(IFluidOutput output, TextEncoder encoder, TemplateContext context)
         {
             context.IncrementSteps();
 


### PR DESCRIPTION
No-argument `{% render %}` calls currently pay for an async state machine even when template loading and nested rendering both complete synchronously. This change keeps that common path synchronous and only transitions to static awaited helpers at the first actual suspension.

## Changes

- Add a sync-first path for no-argument `RenderStatement` execution while preserving isolated scope cleanup on success, exceptions, and cancellation.
- Keep render forms with `with`, `for`, or keyword assignments on the existing path to avoid expanding complexity without measured benefit.
- Add focused coverage for synchronous completion, suspended file loading and rendering, faults, cancellation, scope restoration, and nested break/continue behavior.
- Add BenchmarkDotNet cases for synchronous and deliberately suspending `for`, `render`, and `include` workloads.

## Performance

BenchmarkDotNet ShortRun on .NET 10.0.10, Apple M4 Pro:

| Workload | Before | After | Allocated before | Allocated after |
|---|---:|---:|---:|---:|
| Synchronous render | 88.57 ns | 63.60 ns | 256 B | 256 B |
| Suspended render | 1,649.42 ns | 1,688.33 ns | 632 B | 504 B |

The synchronous path improves by 28.2%. Suspended-render timing was within ShortRun variability while allocations decreased by 20.3%. Experimental sync-first paths for `ForStatement` and `IncludeStatement` were rejected and removed because they regressed their common synchronous workloads.

## Validation

- Focused interpreted and compiled tests: 14 passed in each mode
- Full interpreted suite: 2,794 tests, 0 failed, 20 skipped
- Full compiled suite: 2,794 tests, 0 failed, 20 skipped
- Release `Fluid` build for all target frameworks: succeeded