### PR TITLE
Optimize string render buffering

### DIFF
--- a/Fluid.Benchmarks/Program.cs
+++ b/Fluid.Benchmarks/Program.cs
@@ -8,6 +8,12 @@ namespace Fluid.Benchmarks
     {
         static void Main(string[] args)
         {
+            if (args.Length > 0 && args[0].Equals("string-buffer-metrics", StringComparison.OrdinalIgnoreCase))
+            {
+                StringBufferBenchmarks.PrintMeasurements();
+                return;
+            }
+
             // Steady-state loop for sampling profilers (for instance `ultra profile -- Fluid.Benchmarks.exe profile render 25`).
             // BenchmarkDotNet spawns short-lived child processes, which a profiler can't follow.
             if (args.Length > 0 && args[0].Equals("profile", StringComparison.OrdinalIgnoreCase))

--- a/Fluid.Benchmarks/StringBufferBenchmarks.cs
+++ b/Fluid.Benchmarks/StringBufferBenchmarks.cs
@@ -1,0 +1,364 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Fluid.Benchmarks
+{
+    [MemoryDiagnoser]
+    [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+    [CategoriesColumn]
+    [ShortRunJob]
+    public class StringBufferBenchmarks
+    {
+        private const int MaximumSegmentCapacity = 32 * 1024;
+        private static readonly Func<int, object> CreateParentBuffer =
+            static capacity => new ParentBuffer(capacity);
+        private static readonly Func<int, object> CreateSegmentedBuffer =
+            CreateBufferFactory();
+        private static readonly Scenario[] Scenarios =
+        [
+            Scenario.Create("Tiny64", 64, 16, 32),
+            Scenario.Create("Typical1K", 1_024, 64, 512),
+            Scenario.Create("Typical16K", 16 * 1024, 128, 8 * 1024),
+            Scenario.Create("Underestimated16K", 16 * 1024, 1_024, 64),
+            Scenario.Create("Large100K", 100 * 1024, 4 * 1024, 512),
+            Scenario.Create("Large1M", 1024 * 1024, 4 * 1024, 512),
+            Scenario.Create("Fragmented100K", 100 * 1024, 1, 512)
+        ];
+
+        private int _learnedCapacity = 256;
+
+        [ParamsSource(nameof(ScenarioValues))]
+        public Scenario RenderScenario { get; set; }
+
+        public IEnumerable<Scenario> ScenarioValues => Scenarios;
+
+        [Benchmark(Baseline = true)]
+        [BenchmarkCategory("StringBuffer")]
+        public string ParentContiguous()
+        {
+            var output = CreateParentBuffer(16 * 1024);
+            try
+            {
+                WriteScenario((IFluidOutput)output);
+                return output.ToString();
+            }
+            finally
+            {
+                ((IDisposable)output).Dispose();
+            }
+        }
+
+        [Benchmark]
+        [BenchmarkCategory("StringBuffer")]
+        public string SegmentedFixed256() => RenderSegmented(256);
+
+        [Benchmark]
+        [BenchmarkCategory("StringBuffer")]
+        public string SegmentedStaticEstimate() =>
+            RenderSegmented(RenderScenario.ProductionStaticEstimate);
+
+        [Benchmark]
+        [BenchmarkCategory("StringBuffer")]
+        public string SegmentedLearnedCapacity()
+        {
+            var result = RenderSegmented(_learnedCapacity);
+            _learnedCapacity = Math.Min(
+                MaximumSegmentCapacity,
+                Math.Max(256, result.Length));
+            return result;
+        }
+
+        public static void PrintMeasurements()
+        {
+            Console.WriteLine("| Scenario | Strategy | Chars | Growth-copy chars | Char rentals | Max rental | LOH-sized rental |");
+            Console.WriteLine("| --- | --- | ---: | ---: | ---: | ---: | --- |");
+
+            foreach (var scenario in Scenarios)
+            {
+                using (var parent = new ParentBuffer(16 * 1024))
+                {
+                    WriteScenario(parent, scenario);
+                    _ = parent.ToString();
+                    Console.WriteLine(
+                        $"| {scenario} | Parent contiguous | {scenario.OutputLength} | " +
+                        $"{parent.GrowthCopyCount} | {parent.RentCount} | {parent.MaximumRental} | " +
+                        $"{(parent.MaximumRental * sizeof(char) >= 85_000 ? "yes" : "no")} |");
+                }
+
+                PrintSegmentedMetrics(scenario, 256, "Segmented fixed 256");
+                PrintSegmentedMetrics(
+                    scenario,
+                    scenario.ProductionStaticEstimate,
+                    "Segmented static estimate");
+            }
+        }
+
+        private static void PrintSegmentedMetrics(Scenario scenario, int initialCapacity, string strategy)
+        {
+            var metrics = MeasureSegmented(scenario, initialCapacity);
+            Console.WriteLine(
+                $"| {scenario} | {strategy} | {scenario.OutputLength} | {metrics.GrowthCopies} | " +
+                $"{metrics.RentCount} | {metrics.MaximumRental} | " +
+                $"{(metrics.MaximumRental * sizeof(char) >= 85_000 ? "yes" : "no")} |");
+        }
+
+        private string RenderSegmented(int initialCapacity)
+        {
+            var output = CreateSegmentedBuffer(initialCapacity);
+            try
+            {
+                WriteScenario((IFluidOutput)output);
+                return output.ToString();
+            }
+            finally
+            {
+                ((IDisposable)output).Dispose();
+            }
+        }
+
+        private void WriteScenario(IFluidOutput output) => WriteScenario(output, RenderScenario);
+
+        private static void WriteScenario(IFluidOutput output, Scenario scenario)
+        {
+            foreach (var fragment in scenario.Fragments)
+            {
+                output.Write(fragment);
+            }
+        }
+
+        private static Func<int, object> CreateBufferFactory()
+        {
+            var type = typeof(FluidParser).Assembly.GetType(
+                "Fluid.Utils.BufferFluidOutput",
+                throwOnError: true);
+            var constructor = type.GetConstructor(
+                BindingFlags.Instance | BindingFlags.Public,
+                binder: null,
+                [typeof(int)],
+                modifiers: null);
+            var capacity = Expression.Parameter(typeof(int), "capacity");
+            var create = Expression.New(constructor, capacity);
+            return Expression.Lambda<Func<int, object>>(
+                Expression.Convert(create, typeof(object)),
+                capacity).Compile();
+        }
+
+        private static BufferMetrics MeasureSegmented(Scenario scenario, int initialCapacity)
+        {
+            var capacity = PooledCapacity(initialCapacity);
+            var index = 0;
+            var hasSegments = false;
+            var rents = 1;
+            var maximumRental = capacity;
+            long growthCopies = 0;
+
+            foreach (var fragment in scenario.Fragments)
+            {
+                var remainingValue = fragment.Length;
+                if (index == 0 && !hasSegments && remainingValue > capacity)
+                {
+                    var newCapacity = Math.Min(remainingValue, MaximumSegmentCapacity);
+                    if (newCapacity > capacity)
+                    {
+                        capacity = PooledCapacity(newCapacity);
+                        rents++;
+                        maximumRental = Math.Max(maximumRental, capacity);
+                    }
+                }
+                else if (!hasSegments &&
+                    remainingValue > capacity - index &&
+                    index <= MaximumSegmentCapacity - remainingValue)
+                {
+                    var newCapacity = NextCapacity(capacity, index + remainingValue);
+                    growthCopies += index;
+                    capacity = PooledCapacity(newCapacity);
+                    rents++;
+                    maximumRental = Math.Max(maximumRental, capacity);
+                }
+
+                while (remainingValue > 0)
+                {
+                    var remainingCapacity = capacity - index;
+                    if (remainingCapacity == 0)
+                    {
+                        hasSegments = true;
+                        capacity = PooledCapacity(NextCapacity(
+                            capacity,
+                            Math.Min(remainingValue, MaximumSegmentCapacity)));
+                        rents++;
+                        maximumRental = Math.Max(maximumRental, capacity);
+                        index = 0;
+                        remainingCapacity = capacity;
+                    }
+
+                    var count = Math.Min(remainingValue, remainingCapacity);
+                    index += count;
+                    remainingValue -= count;
+                }
+            }
+
+            return new BufferMetrics(growthCopies, rents, maximumRental);
+        }
+
+        private static int NextCapacity(int currentCapacity, int sizeHint)
+        {
+            if (sizeHint > MaximumSegmentCapacity)
+            {
+                return sizeHint;
+            }
+
+            var growth = currentCapacity <= MaximumSegmentCapacity / 4
+                ? currentCapacity * 4
+                : MaximumSegmentCapacity;
+            return Math.Max(sizeHint, growth);
+        }
+
+        private static int PooledCapacity(int requested)
+        {
+            var capacity = 16;
+            while (capacity < requested)
+            {
+                capacity *= 2;
+            }
+
+            return capacity;
+        }
+
+        public sealed class Scenario
+        {
+            private Scenario(
+                string name,
+                int outputLength,
+                int rootLiteralLength,
+                string[] fragments)
+            {
+                Name = name;
+                OutputLength = outputLength;
+                var headroom = Math.Min(rootLiteralLength, 4 * 1024);
+                ProductionStaticEstimate = Math.Max(
+                    256,
+                    Math.Min(MaximumSegmentCapacity, rootLiteralLength + headroom));
+                Fragments = fragments;
+            }
+
+            public string Name { get; }
+
+            public int OutputLength { get; }
+
+            public int ProductionStaticEstimate { get; }
+
+            public string[] Fragments { get; }
+
+            public static Scenario Create(
+                string name,
+                int outputLength,
+                int fragmentLength,
+                int rootLiteralLength)
+            {
+                var fragments = new string[(outputLength + fragmentLength - 1) / fragmentLength];
+                var remaining = outputLength;
+                for (var i = 0; i < fragments.Length; i++)
+                {
+                    var length = Math.Min(fragmentLength, remaining);
+                    fragments[i] = new string((char)('a' + i % 26), length);
+                    remaining -= length;
+                }
+
+                return new Scenario(name, outputLength, rootLiteralLength, fragments);
+            }
+
+            public override string ToString() => Name;
+        }
+
+        private readonly record struct BufferMetrics(
+            long GrowthCopies,
+            int RentCount,
+            int MaximumRental);
+
+        private sealed class ParentBuffer : IFluidOutput, IDisposable
+        {
+            private char[] _buffer;
+            private int _index;
+
+            public ParentBuffer(int initialCapacity)
+            {
+                _buffer = ArrayPool<char>.Shared.Rent(initialCapacity);
+                RentCount = 1;
+                MaximumRental = initialCapacity;
+            }
+
+            public long GrowthCopyCount { get; private set; }
+
+            public int RentCount { get; private set; }
+
+            public int MaximumRental { get; private set; }
+
+            public void Advance(int count) => _index += count;
+
+            public Memory<char> GetMemory(int sizeHint = 0)
+            {
+                EnsureCapacity(sizeHint);
+                return _buffer.AsMemory(_index);
+            }
+
+            public Span<char> GetSpan(int sizeHint = 0)
+            {
+                EnsureCapacity(sizeHint);
+                return _buffer.AsSpan(_index);
+            }
+
+            public void Write(string value)
+            {
+                EnsureCapacity(value.Length);
+                value.AsSpan().CopyTo(_buffer.AsSpan(_index));
+                _index += value.Length;
+            }
+
+            public void Write(char[] buffer, int index, int count)
+            {
+                EnsureCapacity(count);
+                buffer.AsSpan(index, count).CopyTo(_buffer.AsSpan(_index));
+                _index += count;
+            }
+
+            public ValueTask FlushAsync() => default;
+
+            public override string ToString() =>
+                _index == 0 ? string.Empty : new string(_buffer, 0, _index);
+
+            public void Dispose()
+            {
+                ArrayPool<char>.Shared.Return(_buffer);
+                _buffer = null;
+            }
+
+            private void EnsureCapacity(int additionalCapacity)
+            {
+                if (additionalCapacity == 0)
+                {
+                    additionalCapacity = 1;
+                }
+
+                if (_buffer.Length - _index >= additionalCapacity)
+                {
+                    return;
+                }
+
+                var newCapacity = Math.Max(_buffer.Length * 2, _index + additionalCapacity);
+                var newBuffer = ArrayPool<char>.Shared.Rent(newCapacity);
+                _buffer.AsSpan(0, _index).CopyTo(newBuffer);
+                GrowthCopyCount += _index;
+                RentCount++;
+                MaximumRental = Math.Max(MaximumRental, newCapacity);
+                ArrayPool<char>.Shared.Return(_buffer);
+                _buffer = newBuffer;
+            }
+        }
+    }
+}

--- a/Fluid.Tests/BufferFluidOutputTests.cs
+++ b/Fluid.Tests/BufferFluidOutputTests.cs
@@ -1,0 +1,324 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Text.Encodings.Web;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluid.Ast;
+using Fluid.Parser;
+using Xunit;
+
+namespace Fluid.Tests
+{
+    public class BufferFluidOutputTests
+    {
+        [Fact]
+        public void EmptyOutputReturnsEmptyString()
+        {
+            using var output = CreateOutput(1);
+
+            Assert.Equal(string.Empty, output.ToString());
+        }
+
+        [Fact]
+        public void SupportsSpanMemoryAndAdvanceAcrossGrowthBoundaries()
+        {
+            using var output = CreateOutput(4);
+
+            output.Write("abc");
+            var span = output.GetSpan(2);
+            "de".AsSpan().CopyTo(span);
+            output.Advance(2);
+
+            var memory = output.GetMemory(5);
+            "fghij".AsMemory().CopyTo(memory);
+            output.Advance(5);
+
+            Assert.Equal("abcdefghij", output.ToString());
+        }
+
+        [Fact]
+        public void SupportsMixedStringArrayAndBufferWriterWrites()
+        {
+            using var output = CreateOutput(3);
+            var chars = "23456".ToCharArray();
+
+            output.Write("01");
+            output.Write(chars, 0, chars.Length);
+            var span = output.GetSpan();
+            span[0] = '7';
+            output.Advance(1);
+            var memory = output.GetMemory(2);
+            memory.Span[0] = '8';
+            memory.Span[1] = '9';
+            output.Advance(2);
+
+            Assert.Equal("0123456789", output.ToString());
+        }
+
+        [Theory]
+        [InlineData(255)]
+        [InlineData(256)]
+        [InlineData(257)]
+        [InlineData(32 * 1024 - 1)]
+        [InlineData(32 * 1024)]
+        [InlineData(32 * 1024 + 1)]
+        public void PreservesContentAtSegmentBoundaries(int length)
+        {
+            using var output = CreateOutput(256);
+            var expected = CreatePattern(length);
+
+            for (var offset = 0; offset < expected.Length; offset += 113)
+            {
+                output.Write(expected, offset, Math.Min(113, expected.Length - offset));
+            }
+
+            Assert.Equal(new string(expected), output.ToString());
+        }
+
+        [Fact]
+        public void RejectsInvalidBufferWriterOperations()
+        {
+            using var output = CreateOutput(4);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => output.GetSpan(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => output.GetMemory(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => output.Advance(-1));
+            var available = output.GetSpan().Length;
+            Assert.Throws<ArgumentOutOfRangeException>(() => output.Advance(available + 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => output.Write(['a'], 1, 1));
+        }
+
+        [Fact]
+        public void DisposesEverySegmentAfterFailure()
+        {
+            Assert.Throws<OperationCanceledException>((Action)(() =>
+            {
+                using var output = CreateOutput(8);
+                output.Write(new string('x', 100_000));
+                output.GetSpan(100_000);
+                throw new OperationCanceledException();
+            }));
+
+            using var subsequent = CreateOutput(8);
+            subsequent.Write("still usable");
+            Assert.Equal("still usable", subsequent.ToString());
+        }
+
+        [Fact]
+        public async Task RendersLargeAndHighlyFragmentedOutputExactly()
+        {
+            const int count = 1_000_000;
+            var template = new CallbackTemplate(output =>
+            {
+                for (var i = 0; i < count; i++)
+                {
+                    var span = output.GetSpan(1);
+                    span[0] = (char)('a' + i % 26);
+                    output.Advance(1);
+                }
+            });
+
+            var result = await template.RenderAsync();
+
+            Assert.Equal(count, result.Length);
+            Assert.Equal(CreatePatternString(count), result);
+        }
+
+        [Fact]
+        public async Task EnforcesMaximumOutputSizeForMixedWrites()
+        {
+            var template = new FluidTemplate(new CallbackStatement(output =>
+            {
+                output.Write("1234");
+                var span = output.GetSpan(4);
+                "5678".AsSpan().CopyTo(span);
+                output.Advance(4);
+                output.Write("9");
+            }));
+            var context = new TemplateContext { MaxOutputSize = 8 };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await template.RenderAsync(context));
+        }
+
+        [Fact]
+        public async Task ExceptionAndCancellationDoNotAffectSubsequentRenders()
+        {
+            var throwing = new CallbackTemplate(output =>
+            {
+                output.Write(new string('x', 100_000));
+                throw new InvalidOperationException("Expected failure.");
+            });
+            var cts = new CancellationTokenSource();
+            var cancelling = new CallbackTemplate(output =>
+            {
+                output.Write(new string('y', 100_000));
+                cts.Cancel();
+            });
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await throwing.RenderAsync());
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await cancelling.RenderAsync(
+                    new TemplateContext { CancellationToken = cts.Token }));
+
+            Assert.Equal("ok", await new FluidParser().Parse("ok").RenderAsync());
+        }
+
+        [Fact]
+        public async Task ConcurrentRendersOfOneTemplateWithDifferentSizesAreIsolated()
+        {
+            var template = new FluidParser().Parse("prefix:{{ value }}:suffix");
+            var sizes = new[] { 0, 1, 99, 1_024, 16_384, 100_000, 1_000_000 };
+
+            var tasks = Enumerable.Range(0, 32).Select(async index =>
+            {
+                var size = sizes[index % sizes.Length];
+                var value = CreatePatternString(size);
+                var context = new TemplateContext().SetValue("value", value);
+                var result = await template.RenderAsync(context);
+                Assert.Equal("prefix:" + value + ":suffix", result);
+            });
+
+            await Task.WhenAll(tasks);
+        }
+
+        [Fact]
+        public async Task CustomTemplatesPreserveConfiguredInitialCapacity()
+        {
+            var observedCapacity = 0;
+            var template = new CallbackTemplate(output =>
+            {
+                var field = output.GetType().GetField(
+                    "_buffer",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                observedCapacity = ((char[])field.GetValue(output)).Length;
+                output.Write("ok");
+            });
+            var context = new TemplateContext(
+                new TemplateOptions { OutputBufferSize = 40 * 1024 });
+
+            Assert.Equal("ok", await template.RenderAsync(context));
+            Assert.True(observedCapacity >= 40 * 1024);
+        }
+
+        [Fact]
+        public async Task FluidTemplatesPreserveExplicitDefaultSizedCapacity()
+        {
+            var observedCapacity = 0;
+            var template = new FluidTemplate(new CallbackStatement(output =>
+            {
+                var field = output.GetType().GetField(
+                    "_buffer",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                observedCapacity = ((char[])field.GetValue(output)).Length;
+                output.Write("ok");
+            }));
+            var context = new TemplateContext(
+                new TemplateOptions { OutputBufferSize = 16 * 1024 });
+
+            Assert.Equal("ok", await template.RenderAsync(context));
+            Assert.True(observedCapacity >= 16 * 1024);
+        }
+
+        private static IFluidOutputHandle CreateOutput(int initialCapacity)
+        {
+            var type = typeof(FluidParser).Assembly.GetType(
+                "Fluid.Utils.BufferFluidOutput",
+                throwOnError: true);
+            var output = Activator.CreateInstance(
+                type,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                binder: null,
+                args: [initialCapacity],
+                culture: null);
+
+            return new FluidOutputHandle((IFluidOutput)output, (IDisposable)output);
+        }
+
+        private static char[] CreatePattern(int length)
+        {
+            var result = new char[length];
+            for (var i = 0; i < result.Length; i++)
+            {
+                result[i] = (char)('a' + i % 26);
+            }
+
+            return result;
+        }
+
+        private static string CreatePatternString(int length) => new(CreatePattern(length));
+
+        private interface IFluidOutputHandle : IFluidOutput, IDisposable
+        {
+        }
+
+        private sealed class FluidOutputHandle : IFluidOutputHandle
+        {
+            private readonly IFluidOutput _output;
+            private readonly IDisposable _disposable;
+
+            public FluidOutputHandle(IFluidOutput output, IDisposable disposable)
+            {
+                _output = output;
+                _disposable = disposable;
+            }
+
+            public void Advance(int count) => _output.Advance(count);
+
+            public Memory<char> GetMemory(int sizeHint = 0) => _output.GetMemory(sizeHint);
+
+            public Span<char> GetSpan(int sizeHint = 0) => _output.GetSpan(sizeHint);
+
+            public void Write(string value) => _output.Write(value);
+
+            public void Write(char[] buffer, int index, int count) => _output.Write(buffer, index, count);
+
+            public ValueTask FlushAsync() => _output.FlushAsync();
+
+            public void Dispose() => _disposable.Dispose();
+
+            public override string ToString() => _output.ToString();
+        }
+
+        private sealed class CallbackTemplate : IFluidTemplate
+        {
+            private readonly Action<IFluidOutput> _render;
+
+            public CallbackTemplate(Action<IFluidOutput> render)
+            {
+                _render = render;
+            }
+
+            public ValueTask RenderAsync(
+                IFluidOutput output,
+                TextEncoder encoder,
+                TemplateContext context)
+            {
+                _render(output);
+                return default;
+            }
+        }
+
+        private sealed class CallbackStatement : Statement
+        {
+            private readonly Action<IFluidOutput> _render;
+
+            public CallbackStatement(Action<IFluidOutput> render)
+            {
+                _render = render;
+            }
+
+            public override ValueTask<Completion> WriteToAsync(
+                IFluidOutput output,
+                TextEncoder encoder,
+                TemplateContext context)
+            {
+                _render(output);
+                return NormalCompletion;
+            }
+        }
+
+    }
+}

--- a/Fluid/FluidTemplateExtensions.String.cs
+++ b/Fluid/FluidTemplateExtensions.String.cs
@@ -1,4 +1,5 @@
 using Fluid.Utils;
+using Fluid.Parser;
 using System.Runtime.CompilerServices;
 using System.Text.Encodings.Web;
 
@@ -53,11 +54,14 @@ namespace Fluid
 
             try
             {
-                var initialCapacity = context.Options?.OutputBufferSize ?? 0;
-                if (initialCapacity <= 0)
-                {
-                    initialCapacity = 16 * 1024;
-                }
+                var configuredCapacity = context.Options?.OutputBufferSize ?? 0;
+                var initialCapacity = template is FluidTemplate fluidTemplate &&
+                    ReferenceEquals(context.Options, TemplateOptions.Default) &&
+                    configuredCapacity == 16 * 1024
+                        ? fluidTemplate.EstimatedOutputSize
+                        : configuredCapacity > 0
+                            ? configuredCapacity
+                            : 16 * 1024;
 
                 using var output = new BufferFluidOutput(initialCapacity);
                 await template.RenderAsync(output, encoder, context);

--- a/Fluid/Parser/FluidTemplate.cs
+++ b/Fluid/Parser/FluidTemplate.cs
@@ -9,14 +9,18 @@ namespace Fluid.Parser
         public FluidTemplate(params Statement[] statements)
         {
             Statements = statements ?? [];
+            EstimatedOutputSize = EstimateOutputSize(Statements);
         }
 
         public FluidTemplate(IReadOnlyList<Statement> statements)
         {
             Statements = statements ?? throw new ArgumentNullException(nameof(statements));
+            EstimatedOutputSize = EstimateOutputSize(Statements);
         }
 
         public IReadOnlyList<Statement> Statements { get; }
+
+        internal int EstimatedOutputSize { get; }
 
         public ValueTask RenderAsync(IFluidOutput output, TextEncoder encoder, TemplateContext context)
         {
@@ -63,6 +67,34 @@ namespace Fluid.Parser
 
             context.CancellationToken.ThrowIfCancellationRequested();
             await output.FlushAsync();
+        }
+
+        private static int EstimateOutputSize(IReadOnlyList<Statement> statements)
+        {
+            var length = 0;
+            var hasDynamicOutput = false;
+            for (var i = 0; i < statements.Count && length < BufferFluidOutput.MaximumSegmentCapacity; i++)
+            {
+                if (statements[i] is TextSpanStatement text)
+                {
+                    length += Math.Min(
+                        text.Text.Length,
+                        BufferFluidOutput.MaximumSegmentCapacity - length);
+                }
+                else
+                {
+                    hasDynamicOutput = true;
+                }
+            }
+
+            if (hasDynamicOutput && length > 0)
+            {
+                length += Math.Min(
+                    Math.Min(length, 4 * 1024),
+                    BufferFluidOutput.MaximumSegmentCapacity - length);
+            }
+
+            return Math.Max(BufferFluidOutput.DefaultInitialCapacity, length);
         }
     }
 }

--- a/Fluid/Utils/BufferFluidOutput.cs
+++ b/Fluid/Utils/BufferFluidOutput.cs
@@ -9,10 +9,15 @@ namespace Fluid.Utils
     /// </summary>
     internal sealed class BufferFluidOutput : IFluidOutput, IDisposable
     {
+        internal const int DefaultInitialCapacity = 256;
+        internal const int MaximumContiguousCapacity = 32 * 1024;
+        internal const int MaximumSegmentCapacity = 32 * 1024;
+
         private char[] _buffer;
+        private Segment[] _segments;
         private int _index;
 
-        public BufferFluidOutput(int initialCapacity = 256)
+        public BufferFluidOutput(int initialCapacity = DefaultInitialCapacity)
         {
             if (initialCapacity < 0)
             {
@@ -54,9 +59,14 @@ namespace Fluid.Utils
                 return;
             }
 
-            EnsureCapacity(value.Length);
-            value.CopyTo(0, _buffer, _index, value.Length);
-            _index += value.Length;
+            if (value.Length <= _buffer.Length - _index)
+            {
+                value.CopyTo(0, _buffer, _index, value.Length);
+                _index += value.Length;
+                return;
+            }
+
+            WriteSlow(value.AsSpan());
         }
 
         public void Write(char[] buffer, int index, int count)
@@ -68,9 +78,14 @@ namespace Fluid.Utils
                 return;
             }
 
-            EnsureCapacity(count);
-            buffer.AsSpan(index, count).CopyTo(_buffer.AsSpan(_index));
-            _index += count;
+            if (count <= _buffer.Length - _index)
+            {
+                buffer.AsSpan(index, count).CopyTo(_buffer.AsSpan(_index));
+                _index += count;
+                return;
+            }
+
+            WriteSlow(buffer.AsSpan(index, count));
         }
 
         public ValueTask FlushAsync() => default;
@@ -83,11 +98,54 @@ namespace Fluid.Utils
                 _buffer = null;
                 ArrayPool<char>.Shared.Return(buffer);
             }
+
+            var segments = _segments;
+            if (segments != null)
+            {
+                var segmentCount = segments[0].Length;
+                for (var i = 1; i <= segmentCount; i++)
+                {
+                    ArrayPool<char>.Shared.Return(segments[i].Buffer);
+                }
+
+                _segments = null;
+                ArrayPool<Segment>.Shared.Return(segments, clearArray: true);
+            }
         }
 
         public override string ToString()
         {
-            return _index == 0 ? string.Empty : new string(_buffer, 0, _index);
+            var segmentCount = _segments?[0].Length ?? 0;
+            var length = _index;
+            for (var i = 1; i <= segmentCount; i++)
+            {
+                length += _segments[i].Length;
+            }
+
+            if (length == 0)
+            {
+                return string.Empty;
+            }
+
+            if (segmentCount == 0)
+            {
+                return new string(_buffer, 0, _index);
+            }
+
+#if NET6_0_OR_GREATER
+            return string.Create(length, this, static (destination, output) => output.CopyTo(destination));
+#else
+            unsafe
+            {
+                var result = new string('\0', length);
+                fixed (char* destination = result)
+                {
+                    CopyTo(new Span<char>(destination, length));
+                }
+
+                return result;
+            }
+#endif
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -105,21 +163,155 @@ namespace Fluid.Utils
 
             if (_buffer.Length - _index < additionalCapacity)
             {
-                Grow(additionalCapacity);
+                if (_segments == null &&
+                    _index <= MaximumContiguousCapacity - additionalCapacity)
+                {
+                    GrowContiguous(additionalCapacity);
+                }
+                else
+                {
+                    AddSegment(additionalCapacity);
+                }
             }
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void Grow(int additionalCapacity)
+        private void GrowContiguous(int sizeHint)
         {
-            // At least double, or enough for the requested capacity
-            var newCapacity = Math.Max(_buffer.Length * 2, _index + additionalCapacity);
-
-            var newBuffer = ArrayPool<char>.Shared.Rent(newCapacity);
-            _buffer.AsSpan(0, _index).CopyTo(newBuffer);
-
-            ArrayPool<char>.Shared.Return(_buffer);
+            var oldBuffer = _buffer;
+            var newBuffer = ArrayPool<char>.Shared.Rent(
+                GetNextCapacity(oldBuffer.Length, _index + sizeHint));
+            oldBuffer.AsSpan(0, _index).CopyTo(newBuffer);
             _buffer = newBuffer;
+            ArrayPool<char>.Shared.Return(oldBuffer);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void AddSegment(int sizeHint)
+        {
+            if (_index == 0 && _segments == null)
+            {
+                var emptyBuffer = _buffer;
+                _buffer = ArrayPool<char>.Shared.Rent(
+                    GetNextCapacity(emptyBuffer.Length, sizeHint));
+                ArrayPool<char>.Shared.Return(emptyBuffer);
+                return;
+            }
+
+            var committedBuffer = _buffer;
+            var newBuffer = ArrayPool<char>.Shared.Rent(
+                GetNextCapacity(committedBuffer.Length, sizeHint));
+            try
+            {
+                AddCommittedSegment(committedBuffer, _index);
+            }
+            catch
+            {
+                ArrayPool<char>.Shared.Return(newBuffer);
+                throw;
+            }
+
+            _buffer = newBuffer;
+            _index = 0;
+        }
+
+        private void AddCommittedSegment(char[] buffer, int length)
+        {
+            var segments = _segments;
+            if (segments == null)
+            {
+                segments = ArrayPool<Segment>.Shared.Rent(4);
+                _segments = segments;
+            }
+
+            var segmentCount = segments[0].Length;
+            if (segmentCount + 1 == segments.Length)
+            {
+                var newSegments = ArrayPool<Segment>.Shared.Rent(segments.Length * 2);
+                segments.AsSpan().CopyTo(newSegments);
+                ArrayPool<Segment>.Shared.Return(segments, clearArray: true);
+                _segments = segments = newSegments;
+            }
+
+            segments[++segmentCount] = new Segment(buffer, length);
+            segments[0] = new Segment(null, segmentCount);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void WriteSlow(ReadOnlySpan<char> value)
+        {
+            if (_index == 0 && _segments == null && value.Length > _buffer.Length)
+            {
+                var emptyBuffer = _buffer;
+                var capacity = Math.Min(value.Length, MaximumSegmentCapacity);
+                if (capacity > emptyBuffer.Length)
+                {
+                    _buffer = ArrayPool<char>.Shared.Rent(capacity);
+                    ArrayPool<char>.Shared.Return(emptyBuffer);
+                }
+            }
+            else if (_segments == null &&
+                value.Length > _buffer.Length - _index &&
+                _index <= MaximumContiguousCapacity - value.Length)
+            {
+                GrowContiguous(value.Length);
+            }
+
+            while (!value.IsEmpty)
+            {
+                var remaining = _buffer.Length - _index;
+                if (remaining == 0)
+                {
+                    AddSegment(Math.Min(value.Length, MaximumSegmentCapacity));
+                    remaining = _buffer.Length;
+                }
+
+                var count = Math.Min(value.Length, remaining);
+                value.Slice(0, count).CopyTo(_buffer.AsSpan(_index));
+                _index += count;
+                value = value.Slice(count);
+            }
+        }
+
+        private void CopyTo(Span<char> destination)
+        {
+            var offset = 0;
+            var segmentCount = _segments[0].Length;
+            for (var i = 1; i <= segmentCount; i++)
+            {
+                var segment = _segments[i];
+                segment.Buffer.AsSpan(0, segment.Length).CopyTo(destination.Slice(offset));
+                offset += segment.Length;
+            }
+
+            _buffer.AsSpan(0, _index).CopyTo(destination.Slice(offset));
+        }
+
+        private static int GetNextCapacity(int currentCapacity, int sizeHint)
+        {
+            if (sizeHint > MaximumSegmentCapacity)
+            {
+                return sizeHint;
+            }
+
+            var growth = currentCapacity <= MaximumSegmentCapacity / 4
+                ? currentCapacity * 4
+                : MaximumSegmentCapacity;
+
+            return Math.Max(sizeHint, growth);
+        }
+
+        private readonly struct Segment
+        {
+            public Segment(char[] buffer, int length)
+            {
+                Buffer = buffer;
+                Length = length;
+            }
+
+            public char[] Buffer { get; }
+
+            public int Length { get; }
         }
     }
 }


### PR DESCRIPTION
String-returning renders currently rent a 16K character buffer unconditionally and repeatedly copy the full accumulated output when it grows. This wastes pooled memory for small renders and creates avoidable large/LOH-sized rentals for large output.

This change keeps a small contiguous fast path, uses a bounded static-literal estimate for default parsed templates, and switches output above 32K to pooled 32K segments. Segmented output is copied exactly once into the required final string, while explicit `OutputBufferSize` values retain their existing behavior.

BenchmarkDotNet results on .NET 10.0.11 / Apple M4 Pro:

| Scenario | Change |
| --- | ---: |
| Tiny 64 chars | +6% |
| Typical 1K | -11% |
| Typical 16K | flat |
| Underestimated 16K | +11% |
| Large 100K | -12% |
| Large 1M | -29% |
| Fragmented 100K | -2% |

For 1M output, growth-copy volume falls from 1,032,192 to 20,480 characters and the largest pooled rental falls from 1,048,576 to 32,768 characters, eliminating avoidable LOH-sized pooled buffers. Learned per-template sizing was evaluated but rejected because its small stable-size gains did not justify shared mutable state and size-variance risks.

Tests cover all `IBufferWriter<char>` operations, growth boundaries, mixed writes, exact and empty output, exceptions and cancellation, output limits, concurrent rendering, explicit capacities, and large fragmented output. Both interpreted and compiled full suites pass, along with the Release solution build.