### PR TITLE
Document wildcard macro imports

### DIFF
--- a/Fluid.Tests/FromStatementTests.cs
+++ b/Fluid.Tests/FromStatementTests.cs
@@ -126,6 +126,31 @@ public class FromStatementTests
     }
 
     [Fact]
+    public async Task FromStatement_WithoutImportList_ShouldOnlyImportAllMacros()
+    {
+        var fileProvider = new MockFileProvider();
+        fileProvider.Add("_Macros.liquid", @"
+        {%- assign imported_value = 'should not escape' -%}
+        SHOULD_NOT_RENDER
+        {%- macro hello_world() -%}
+        Hello world!
+        {%- endmacro -%}
+        {%- macro hello(name) -%}
+        Hello {{ name }}!
+        {%- endmacro -%}
+        ");
+
+        var source = "{% from '_Macros' %}{{ hello_world() }} {{ hello('John') }}|{{ imported_value }}";
+        _parser.TryParse(source, out var template, out var error);
+        Assert.True(template != null, error);
+
+        var options = new TemplateOptions { FileProvider = fileProvider };
+        var result = await template.RenderAsync(new TemplateContext(options));
+
+        Assert.Equal("Hello world! Hello John!|", result);
+    }
+
+    [Fact]
     public async Task FromStatement_ShouldLoadMacrosAsynchronously()
     {
         var sourceLoader = new AsyncTemplateFileProvider()

--- a/README.md
+++ b/README.md
@@ -1527,12 +1527,25 @@ Now `field` is available as a local property of the template and can be invoked 
 
 Macros defined in an external template **must** be imported before they can be invoked.
 
+Omit the import list to import every macro defined by the template:
+
+```
+{% from 'forms' %}
+
+{{ field('user') }}
+{{ field('pass', type='password') }}
+```
+
+Use an explicit import list to import only selected macros:
+
 ```
 {% from 'forms' import field %}
 
 {{ field('user') }}
 {{ field('pass', type='password') }}
 ```
+
+The import-all form is the equivalent of a wildcard import; no wildcard token is required. Both forms evaluate the external template without rendering its output and copy only macros, not its assigned variables. An imported macro replaces a same-named value in the current scope, so prefer selective imports when name collisions are possible. Use `include` to render external template content and `from` to load its macros.
 
 ### Extensibility
 


### PR DESCRIPTION
Issue #551 left users without a documented way to import every macro from an external template. Fluid already supports `{% from 'file' %}` as the wildcard-equivalent, but the README only showed selective imports.

## Changes

- Document import-all and selective external macro syntax.
- Clarify that imports copy macros only, suppress template output, and can replace same-named caller values.
- Add a regression proving import-all loads multiple macros without leaking assigned variables or rendered content.

## Testing

- `dotnet test --no-restore --filter "FullyQualifiedName~Fluid.Tests.FromStatementTests"`
- `dotnet test --no-restore /p:Compiled=true --filter "FullyQualifiedName~Fluid.Tests.FromStatementTests"`

Fixes: #551