### PR TITLE
Backport compatible fixes and features to release/2.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
       with:
         dotnet-version: |
           8.0.x
+          10.0.x
         global-json-file: global.json
 
     - name: Test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,6 +26,7 @@ jobs:
       with:
         dotnet-version: |
           8.0.x
+          10.0.x
         global-json-file: global.json
 
     - name: Version

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,7 @@ name: PR Checks
 on:
 
   pull_request:
-    branches: [ main, 'releases/**' ]
+    branches: [ main, 'release/**' ]
     paths-ignore:
     - 'doc/**'
     - 'readme.md'

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.5" />
     <PackageVersion Include="DotLiquid" Version="2.3.197" />
     <PackageVersion Include="Liquid.NET" Version="0.10.0" />
-    <PackageVersion Include="Scriban" Version="6.5.0" />
+    <PackageVersion Include="Scriban" Version="7.2.6" />
     <PackageVersion Include="Handlebars.Net" Version="2.1.6" />
 
     <!-- Testing -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
     <!-- Common to all TFMs -->
     <PackageVersion Include="Parlot" Version="1.5.2" />
     <PackageVersion Include="TimeZoneConverter" Version="7.2.0" />
-
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
     <!-- Benchmarks -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.5" />
     <PackageVersion Include="DotLiquid" Version="2.3.197" />

--- a/Fluid.Benchmarks/Fluid.Benchmarks.csproj
+++ b/Fluid.Benchmarks/Fluid.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <NoWarn>$(NoWarn);NU5104</NoWarn>
     <!-- Ignore vulnerable packages imported for benchmarking only -->
     <NoWarn>$(NoWarn);NU1903</NoWarn>

--- a/Fluid.MinimalApisSample/Fluid.MinimalApisSample.csproj
+++ b/Fluid.MinimalApisSample/Fluid.MinimalApisSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <OutputType>Exe</OutputType>
     <NoWarn>$(NoWarn);NU5104</NoWarn>

--- a/Fluid.MvcSample/Fluid.MvcSample.csproj
+++ b/Fluid.MvcSample/Fluid.MvcSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <NoWarn>$(NoWarn);NU5104</NoWarn>
     <IsPackable>false</IsPackable>

--- a/Fluid.MvcViewEngine/Fluid.MvcViewEngine.csproj
+++ b/Fluid.MvcViewEngine/Fluid.MvcViewEngine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PackageIcon>logo_64x64.png</PackageIcon>
     <IsPackable>true</IsPackable>
@@ -26,6 +26,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)'=='net9.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net10.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Fluid.SourceGenerator/Fluid.SourceGenerator.csproj
+++ b/Fluid.SourceGenerator/Fluid.SourceGenerator.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <IsPackable>true</IsPackable>
+    <OutputItemType>Analyzer</OutputItemType>
+    <NoWarn>$(NoWarn);NU1604;RS1036;RS2008</NoWarn>
+    <IncludeBuildOutput>true</IncludeBuildOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/Fluid.SourceGenerator/Fluid.SourceGenerator.csproj
+++ b/Fluid.SourceGenerator/Fluid.SourceGenerator.csproj
@@ -8,11 +8,20 @@
     <IsPackable>true</IsPackable>
     <OutputItemType>Analyzer</OutputItemType>
     <NoWarn>$(NoWarn);NU1604;RS1036;RS2008</NoWarn>
-    <IncludeBuildOutput>true</IncludeBuildOutput>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(TargetPath)"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
   </ItemGroup>
 
 </Project>

--- a/Fluid.SourceGenerator/MemberAccessorGenerator.cs
+++ b/Fluid.SourceGenerator/MemberAccessorGenerator.cs
@@ -1,0 +1,834 @@
+using System.Collections.Immutable;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Fluid.SourceGenerator;
+
+[Generator]
+public sealed class MemberAccessorGenerator : IIncrementalGenerator
+{
+    private const string RegisterAttributeType = "Fluid.FluidRegisterAttribute";
+    private const string TemplateOptionsType = "Fluid.TemplateOptions";
+
+    private static readonly SymbolDisplayFormat TypeExpressionFormat = SymbolDisplayFormat.FullyQualifiedFormat
+        .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers);
+
+    private static readonly DiagnosticDescriptor InvalidProfileMethod = new(
+        id: "FLUIDSG001",
+        title: "Invalid Fluid registration profile method",
+        messageFormat: "Method '{0}' must be a static partial method declaration with explicit accessibility and signature '(TemplateOptions options)' inside a non-generic, non-nested partial class",
+        category: "Fluid.SourceGenerator",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor InvalidOptionsType = new(
+        id: "FLUIDSG002",
+        title: "Invalid Fluid template options type",
+        messageFormat: "Type '{0}' must be a partial, non-generic, non-nested class deriving from TemplateOptions",
+        category: "Fluid.SourceGenerator",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        context.RegisterPostInitializationOutput(static output =>
+        {
+            output.AddSource("FluidRegisterAttribute.g.cs", AttributeSource);
+        });
+
+        var profileMethods = context.SyntaxProvider.CreateSyntaxProvider(
+                predicate: static (node, _) => node is MethodDeclarationSyntax method && method.AttributeLists.Count > 0,
+                transform: static (syntaxContext, _) => GetProfileMethod(syntaxContext))
+            .Where(static candidate => candidate is not null)
+            .Select(static (candidate, _) => candidate!);
+
+        var optionsTypes = context.SyntaxProvider.CreateSyntaxProvider(
+                predicate: static (node, _) => node is ClassDeclarationSyntax type && type.AttributeLists.Count > 0,
+                transform: static (syntaxContext, _) => GetOptionsType(syntaxContext))
+            .Where(static candidate => candidate is not null)
+            .Select(static (candidate, _) => candidate!);
+
+        var combined = context.CompilationProvider.Combine(profileMethods.Collect()).Combine(optionsTypes.Collect());
+        context.RegisterSourceOutput(combined, static (sourceContext, source) => Execute(sourceContext, source.Left.Right, source.Right));
+    }
+
+    private static ProfileMethodCandidate? GetProfileMethod(GeneratorSyntaxContext context)
+    {
+        if (context.Node is not MethodDeclarationSyntax methodSyntax)
+        {
+            return null;
+        }
+
+        if (context.SemanticModel.GetDeclaredSymbol(methodSyntax) is not IMethodSymbol methodSymbol)
+        {
+            return null;
+        }
+
+        var registeredTypes = GetRegisteredTypes(methodSymbol);
+        if (registeredTypes.IsDefaultOrEmpty)
+        {
+            return null;
+        }
+
+        var hasPartialModifier = methodSyntax.Modifiers.Any(static m => m.IsKind(SyntaxKind.PartialKeyword));
+        var hasExplicitAccessibility = methodSyntax.Modifiers.Any(static m =>
+            m.IsKind(SyntaxKind.PublicKeyword) ||
+            m.IsKind(SyntaxKind.InternalKeyword) ||
+            m.IsKind(SyntaxKind.PrivateKeyword) ||
+            m.IsKind(SyntaxKind.ProtectedKeyword));
+        var hasBody = methodSyntax.Body is not null || methodSyntax.ExpressionBody is not null;
+
+        return new ProfileMethodCandidate(
+            methodSymbol,
+            registeredTypes.ToImmutableArray(),
+            hasPartialModifier,
+            hasExplicitAccessibility,
+            hasBody,
+            methodSyntax.GetLocation());
+    }
+
+    private static OptionsTypeCandidate? GetOptionsType(GeneratorSyntaxContext context)
+    {
+        if (context.Node is not ClassDeclarationSyntax typeSyntax)
+        {
+            return null;
+        }
+
+        if (context.SemanticModel.GetDeclaredSymbol(typeSyntax) is not INamedTypeSymbol typeSymbol)
+        {
+            return null;
+        }
+
+        var registeredTypes = GetRegisteredTypes(typeSymbol);
+        if (registeredTypes.IsDefaultOrEmpty)
+        {
+            return null;
+        }
+
+        var hasPartialModifier = typeSyntax.Modifiers.Any(static m => m.IsKind(SyntaxKind.PartialKeyword));
+
+        return new OptionsTypeCandidate(
+            typeSymbol,
+            registeredTypes,
+            hasPartialModifier,
+            typeSyntax.GetLocation());
+    }
+
+    private static ImmutableArray<ITypeSymbol> GetRegisteredTypes(ISymbol symbol)
+    {
+        var registerAttributes = symbol.GetAttributes()
+            .Where(static x => string.Equals(x.AttributeClass?.ToDisplayString(), RegisterAttributeType, StringComparison.Ordinal))
+            .ToImmutableArray();
+
+        if (registerAttributes.IsDefaultOrEmpty)
+        {
+            return [];
+        }
+
+        var registeredTypes = new List<ITypeSymbol>(registerAttributes.Length);
+
+        foreach (var attribute in registerAttributes)
+        {
+            if (attribute.ConstructorArguments.Length == 0)
+            {
+                continue;
+            }
+
+            if (attribute.ConstructorArguments[0].Value is not ITypeSymbol registeredType)
+            {
+                continue;
+            }
+
+            if (registeredType is IErrorTypeSymbol || registeredType.TypeKind == TypeKind.TypeParameter)
+            {
+                continue;
+            }
+
+            registeredTypes.Add(registeredType);
+        }
+
+        return registeredTypes.ToImmutableArray();
+    }
+
+    private static void Execute(SourceProductionContext context, ImmutableArray<ProfileMethodCandidate> methodCandidates, ImmutableArray<OptionsTypeCandidate> optionsTypeCandidates)
+    {
+        if (methodCandidates.IsDefaultOrEmpty && optionsTypeCandidates.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        var validMethods = new List<ProfileMethodRegistration>();
+        var validOptionsTypes = new List<OptionsTypeRegistration>();
+        var allRegisteredTypes = new Dictionary<string, ITypeSymbol>(StringComparer.Ordinal);
+
+        foreach (var candidate in methodCandidates)
+        {
+            if (!TryValidateProfileMethod(candidate, context, out var methodRegistration))
+            {
+                continue;
+            }
+
+            validMethods.Add(methodRegistration);
+
+            foreach (var registeredType in methodRegistration.RegisteredTypes)
+            {
+                var typeExpression = registeredType.ToDisplayString(TypeExpressionFormat);
+                allRegisteredTypes[typeExpression] = registeredType;
+            }
+        }
+
+        foreach (var candidate in optionsTypeCandidates)
+        {
+            if (!TryValidateOptionsType(candidate, context, out var optionsTypeRegistration))
+            {
+                continue;
+            }
+
+            validOptionsTypes.Add(optionsTypeRegistration);
+
+            foreach (var registeredType in optionsTypeRegistration.RegisteredTypes)
+            {
+                var typeExpression = registeredType.ToDisplayString(TypeExpressionFormat);
+                allRegisteredTypes[typeExpression] = registeredType;
+            }
+        }
+
+        if ((validMethods.Count == 0 && validOptionsTypes.Count == 0) || allRegisteredTypes.Count == 0)
+        {
+            return;
+        }
+
+        var accessorsByType = new Dictionary<string, AccessorRegistration>(StringComparer.Ordinal);
+        var usedAccessorNames = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var typeEntry in allRegisteredTypes.OrderBy(static x => x.Key, StringComparer.Ordinal))
+        {
+            var members = GetMembers(typeEntry.Value);
+            if (members.Count == 0)
+            {
+                continue;
+            }
+
+            var accessorName = CreateAccessorName(typeEntry.Value, usedAccessorNames);
+            accessorsByType[typeEntry.Key] = new AccessorRegistration(typeEntry.Key, accessorName, members);
+        }
+
+        if (accessorsByType.Count == 0)
+        {
+            return;
+        }
+
+        var methodRegistrations = validMethods
+            .Select(method => new MethodRegistration(
+                method.Method,
+                method.RegisteredTypes
+                    .Select(type => type.ToDisplayString(TypeExpressionFormat))
+                    .Where(typeExpression => accessorsByType.ContainsKey(typeExpression))
+                    .Distinct(StringComparer.Ordinal)
+                    .OrderBy(static x => x, StringComparer.Ordinal)
+                    .Select(typeExpression => accessorsByType[typeExpression])
+                    .ToImmutableArray()))
+            .Where(static method => !method.Accessors.IsDefaultOrEmpty)
+            .OrderBy(static x => x.Method.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), StringComparer.Ordinal)
+            .ThenBy(static x => x.Method.Name, StringComparer.Ordinal)
+            .ToList();
+
+        var optionsTypeRegistrations = validOptionsTypes
+            .Select(optionsType => new GeneratedOptionsTypeRegistration(
+                optionsType.OptionsType,
+                optionsType.RegisteredTypes
+                    .Select(type => type.ToDisplayString(TypeExpressionFormat))
+                    .Where(typeExpression => accessorsByType.ContainsKey(typeExpression))
+                    .Distinct(StringComparer.Ordinal)
+                    .OrderBy(static x => x, StringComparer.Ordinal)
+                    .Select(typeExpression => accessorsByType[typeExpression])
+                    .ToImmutableArray()))
+            .Where(static optionsType => !optionsType.Accessors.IsDefaultOrEmpty)
+            .OrderBy(static x => x.OptionsType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), StringComparer.Ordinal)
+            .ToList();
+
+        if (methodRegistrations.Count == 0 && optionsTypeRegistrations.Count == 0)
+        {
+            return;
+        }
+
+        var source = new StringBuilder();
+        source.AppendLine("// <auto-generated />");
+        source.AppendLine("#nullable enable");
+        source.AppendLine();
+        source.AppendLine("namespace Fluid.SourceGenerated");
+        source.AppendLine("{");
+
+        foreach (var accessor in accessorsByType.Values.OrderBy(static x => x.TypeExpression, StringComparer.Ordinal))
+        {
+            AppendAccessor(source, accessor.AccessorName, accessor.TypeExpression, accessor.Members);
+            source.AppendLine();
+        }
+
+        source.AppendLine("}");
+        source.AppendLine();
+
+        foreach (var containingTypeGroup in methodRegistrations.GroupBy(static x => x.Method.ContainingType, SymbolEqualityComparer.Default))
+        {
+            AppendProfileType(source, (INamedTypeSymbol)containingTypeGroup.Key!, containingTypeGroup.ToImmutableArray());
+            source.AppendLine();
+        }
+
+        foreach (var optionsType in optionsTypeRegistrations)
+        {
+            AppendOptionsType(source, optionsType.OptionsType, optionsType.Accessors);
+            source.AppendLine();
+        }
+
+        context.AddSource("Fluid.MemberAccessProfiles.g.cs", source.ToString());
+    }
+
+    private static bool TryValidateProfileMethod(ProfileMethodCandidate candidate, SourceProductionContext context, out ProfileMethodRegistration registration)
+    {
+        registration = default!;
+
+        var method = candidate.Method;
+        var containingType = method.ContainingType;
+
+        var isValid =
+            candidate.HasPartialModifier &&
+            candidate.HasExplicitAccessibility &&
+            !candidate.HasBody &&
+            method.IsStatic &&
+            method.ReturnsVoid &&
+            method.Arity == 0 &&
+            method.Parameters.Length == 1 &&
+            string.Equals(method.Parameters[0].Type.ToDisplayString(), TemplateOptionsType, StringComparison.Ordinal) &&
+            method.PartialImplementationPart is null &&
+            containingType is not null &&
+            containingType.TypeKind == TypeKind.Class &&
+            containingType.Arity == 0 &&
+            containingType.ContainingType is null &&
+            IsPartialType(containingType);
+
+        if (!isValid)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(InvalidProfileMethod, candidate.Location, method.ToDisplayString()));
+            return false;
+        }
+
+        registration = new ProfileMethodRegistration(method, candidate.RegisteredTypes);
+        return true;
+    }
+
+    private static bool TryValidateOptionsType(OptionsTypeCandidate candidate, SourceProductionContext context, out OptionsTypeRegistration registration)
+    {
+        registration = default!;
+
+        var type = candidate.OptionsType;
+
+        var isValid =
+            candidate.HasPartialModifier &&
+            type.TypeKind == TypeKind.Class &&
+            type.Arity == 0 &&
+            type.ContainingType is null &&
+            InheritsFromTemplateOptions(type);
+
+        if (!isValid)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(InvalidOptionsType, candidate.Location, type.ToDisplayString()));
+            return false;
+        }
+
+        registration = new OptionsTypeRegistration(type, candidate.RegisteredTypes);
+        return true;
+    }
+
+    private static bool InheritsFromTemplateOptions(INamedTypeSymbol typeSymbol)
+    {
+        for (var current = typeSymbol.BaseType; current is not null; current = current.BaseType)
+        {
+            if (string.Equals(current.ToDisplayString(), TemplateOptionsType, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsPartialType(INamedTypeSymbol typeSymbol)
+    {
+        foreach (var syntaxReference in typeSymbol.DeclaringSyntaxReferences)
+        {
+            if (syntaxReference.GetSyntax() is TypeDeclarationSyntax typeSyntax &&
+                typeSyntax.Modifiers.Any(static x => x.IsKind(SyntaxKind.PartialKeyword)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void AppendProfileType(StringBuilder source, INamedTypeSymbol containingType, ImmutableArray<MethodRegistration> methods)
+    {
+        var namespaceName = containingType.ContainingNamespace?.IsGlobalNamespace == false
+            ? containingType.ContainingNamespace.ToDisplayString()
+            : null;
+
+        if (namespaceName is not null)
+        {
+            source.Append("namespace ").Append(namespaceName).AppendLine();
+            source.AppendLine("{");
+        }
+
+        source.Append("    ")
+            .Append(GetAccessibilityKeyword(containingType.DeclaredAccessibility))
+            .Append(containingType.IsStatic ? " static" : string.Empty)
+            .Append(" partial class ")
+            .Append(containingType.Name)
+            .AppendLine();
+        source.AppendLine("    {");
+
+        foreach (var method in methods)
+        {
+            var escapedName = EscapeIdentifier(method.Method.Name);
+            source.Append("        ")
+                .Append(GetAccessibilityKeyword(method.Method.DeclaredAccessibility))
+                .Append(" static partial void ")
+                .Append(escapedName)
+                .AppendLine("(global::Fluid.TemplateOptions options)");
+            source.AppendLine("        {");
+            source.AppendLine("            if (options is null)");
+            source.AppendLine("            {");
+            source.AppendLine("                throw new global::System.ArgumentNullException(nameof(options));");
+            source.AppendLine("            }");
+            source.AppendLine("            var strategy = options.MemberAccessStrategy;");
+            source.AppendLine();
+
+            foreach (var accessor in method.Accessors)
+            {
+                source.Append("            global::Fluid.MemberAccessStrategyExtensions.Register(strategy, typeof(")
+                    .Append(accessor.TypeExpression)
+                    .Append("), \"*\", new global::Fluid.SourceGenerated.")
+                    .Append(accessor.AccessorName)
+                    .AppendLine("());");
+            }
+
+            source.AppendLine("        }");
+            source.AppendLine();
+        }
+
+        source.AppendLine("    }");
+
+        if (namespaceName is not null)
+        {
+            source.AppendLine("}");
+        }
+    }
+
+    private static void AppendOptionsType(StringBuilder source, INamedTypeSymbol optionsType, ImmutableArray<AccessorRegistration> accessors)
+    {
+        var namespaceName = optionsType.ContainingNamespace?.IsGlobalNamespace == false
+            ? optionsType.ContainingNamespace.ToDisplayString()
+            : null;
+
+        if (namespaceName is not null)
+        {
+            source.Append("namespace ").Append(namespaceName).AppendLine();
+            source.AppendLine("{");
+        }
+
+        source.Append("    ")
+            .Append(GetAccessibilityKeyword(optionsType.DeclaredAccessibility))
+            .Append(" partial class ")
+            .Append(optionsType.Name)
+            .AppendLine(" : global::Fluid.ITemplateOptionsMemberAccessorRegistrar");
+        source.AppendLine("    {");
+        source.AppendLine("        void global::Fluid.ITemplateOptionsMemberAccessorRegistrar.RegisterMemberAccessors(global::Fluid.TemplateOptions options)");
+        source.AppendLine("        {");
+        source.AppendLine("            if (options is null)");
+        source.AppendLine("            {");
+        source.AppendLine("                throw new global::System.ArgumentNullException(nameof(options));");
+        source.AppendLine("            }");
+        source.AppendLine("            var strategy = options.MemberAccessStrategy;");
+        source.AppendLine();
+
+        foreach (var accessor in accessors)
+        {
+            source.Append("            global::Fluid.MemberAccessStrategyExtensions.Register(strategy, typeof(")
+                .Append(accessor.TypeExpression)
+                .Append("), \"*\", new global::Fluid.SourceGenerated.")
+                .Append(accessor.AccessorName)
+                .AppendLine("());");
+        }
+
+        source.AppendLine("        }");
+        source.AppendLine("    }");
+
+        if (namespaceName is not null)
+        {
+            source.AppendLine("}");
+        }
+    }
+
+    private static string GetAccessibilityKeyword(Accessibility accessibility)
+    {
+        return accessibility switch
+        {
+            Accessibility.Public => "public",
+            Accessibility.Internal => "internal",
+            Accessibility.Private => "private",
+            Accessibility.Protected => "protected",
+            Accessibility.ProtectedOrInternal => "protected internal",
+            Accessibility.ProtectedAndInternal => "private protected",
+            _ => "private"
+        };
+    }
+
+    private static void AppendAccessor(StringBuilder source, string accessorName, string typeExpression, List<MemberAccess> members)
+    {
+        source.Append("    internal sealed class ").Append(accessorName).AppendLine(" : global::Fluid.IAsyncMemberAccessor");
+        source.AppendLine("    {");
+        source.AppendLine("        public object Get(object obj, string name, global::Fluid.TemplateContext ctx)");
+        source.AppendLine("        {");
+        source.Append("            var typed = (").Append(typeExpression).AppendLine(")obj;");
+        source.AppendLine("            var comparer = ctx.Options.ModelNamesComparer;");
+        source.AppendLine();
+
+        foreach (var member in members)
+        {
+            source.Append("            if (comparer.Equals(name, \"")
+                .Append(member.Name)
+                .AppendLine("\"))");
+            source.AppendLine("            {");
+            source.Append("                return ").Append(member.Expression).AppendLine(";");
+            source.AppendLine("            }");
+        }
+
+        source.AppendLine();
+        source.AppendLine("            return null;");
+        source.AppendLine("        }");
+        source.AppendLine();
+        source.AppendLine("        public async global::System.Threading.Tasks.Task<object> GetAsync(object obj, string name, global::Fluid.TemplateContext ctx)");
+        source.AppendLine("        {");
+        source.Append("            var typed = (").Append(typeExpression).AppendLine(")obj;");
+        source.AppendLine("            var comparer = ctx.Options.ModelNamesComparer;");
+        source.AppendLine();
+
+        foreach (var member in members)
+        {
+            source.Append("            if (comparer.Equals(name, \"")
+                .Append(member.Name)
+                .AppendLine("\"))");
+            source.AppendLine("            {");
+
+            switch (member.AsyncKind)
+            {
+                case AsyncKind.Task:
+                    source.Append("                var task = ").Append(member.Expression).AppendLine(";");
+                    source.AppendLine("                await task.ConfigureAwait(false);");
+                    source.AppendLine("                return task.Result;");
+                    break;
+                case AsyncKind.ValueTask:
+                    source.Append("                var valueTask = ").Append(member.Expression).AppendLine(";");
+                    source.AppendLine("                return await valueTask.ConfigureAwait(false);");
+                    break;
+                case AsyncKind.TaskWithoutResult:
+                    source.Append("                var task = ").Append(member.Expression).AppendLine(";");
+                    source.AppendLine("                await task.ConfigureAwait(false);");
+                    source.AppendLine("                return null;");
+                    break;
+                case AsyncKind.ValueTaskWithoutResult:
+                    source.Append("                var valueTask = ").Append(member.Expression).AppendLine(";");
+                    source.AppendLine("                await valueTask.ConfigureAwait(false);");
+                    source.AppendLine("                return null;");
+                    break;
+                default:
+                    source.Append("                return ").Append(member.Expression).AppendLine(";");
+                    break;
+            }
+
+            source.AppendLine("            }");
+        }
+
+        source.AppendLine();
+        source.AppendLine("            return null;");
+        source.AppendLine("        }");
+        source.AppendLine("    }");
+    }
+
+    private static List<MemberAccess> GetMembers(ITypeSymbol typeSymbol)
+    {
+        var members = new List<MemberAccess>();
+        var names = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var property in EnumerateProperties(typeSymbol))
+        {
+            if (!names.Add(property.Name))
+            {
+                continue;
+            }
+
+            var memberName = EscapeIdentifier(property.Name);
+            if (memberName is null)
+            {
+                continue;
+            }
+
+            var expression = property.IsStatic
+                ? $"{typeSymbol.ToDisplayString(TypeExpressionFormat)}.{memberName}"
+                : $"typed.{memberName}";
+
+            members.Add(new MemberAccess(property.Name, expression, GetAsyncKind(property.Type)));
+        }
+
+        foreach (var field in EnumerateFields(typeSymbol))
+        {
+            if (!names.Add(field.Name))
+            {
+                continue;
+            }
+
+            var memberName = EscapeIdentifier(field.Name);
+            if (memberName is null)
+            {
+                continue;
+            }
+
+            var expression = field.IsStatic
+                ? $"{typeSymbol.ToDisplayString(TypeExpressionFormat)}.{memberName}"
+                : $"typed.{memberName}";
+
+            members.Add(new MemberAccess(field.Name, expression, GetAsyncKind(field.Type)));
+        }
+
+        foreach (var method in EnumerateMethods(typeSymbol))
+        {
+            if (!names.Add(method.Name))
+            {
+                continue;
+            }
+
+            var memberName = EscapeIdentifier(method.Name);
+            if (memberName is null)
+            {
+                continue;
+            }
+
+            var expression = method.IsStatic
+                ? $"{typeSymbol.ToDisplayString(TypeExpressionFormat)}.{memberName}()"
+                : $"typed.{memberName}()";
+
+            members.Add(new MemberAccess(method.Name, expression, GetAsyncKind(method.ReturnType)));
+        }
+
+        return members;
+    }
+
+    private static IEnumerable<IPropertySymbol> EnumerateProperties(ITypeSymbol typeSymbol)
+    {
+        foreach (var symbol in EnumerateMembers(typeSymbol).OfType<IPropertySymbol>())
+        {
+            if (symbol.IsIndexer || symbol.GetMethod is null)
+            {
+                continue;
+            }
+
+            if (symbol.DeclaredAccessibility != Accessibility.Public)
+            {
+                continue;
+            }
+
+            yield return symbol;
+        }
+    }
+
+    private static IEnumerable<IFieldSymbol> EnumerateFields(ITypeSymbol typeSymbol)
+    {
+        foreach (var symbol in EnumerateMembers(typeSymbol).OfType<IFieldSymbol>())
+        {
+            if (symbol.DeclaredAccessibility != Accessibility.Public || symbol.IsConst)
+            {
+                continue;
+            }
+
+            yield return symbol;
+        }
+    }
+
+    private static IEnumerable<IMethodSymbol> EnumerateMethods(ITypeSymbol typeSymbol)
+    {
+        foreach (var symbol in EnumerateMembers(typeSymbol).OfType<IMethodSymbol>())
+        {
+            if (symbol.MethodKind != MethodKind.Ordinary || symbol.IsGenericMethod)
+            {
+                continue;
+            }
+
+            if (symbol.DeclaredAccessibility != Accessibility.Public || symbol.Parameters.Length != 0 || symbol.ReturnsVoid)
+            {
+                continue;
+            }
+
+            if (symbol.ContainingType.SpecialType == SpecialType.System_Object)
+            {
+                continue;
+            }
+
+            yield return symbol;
+        }
+    }
+
+    private static IEnumerable<ISymbol> EnumerateMembers(ITypeSymbol typeSymbol)
+    {
+        if (typeSymbol.TypeKind == TypeKind.Interface)
+        {
+            foreach (var member in typeSymbol.GetMembers())
+            {
+                yield return member;
+            }
+
+            foreach (var iface in typeSymbol.AllInterfaces)
+            {
+                foreach (var member in iface.GetMembers())
+                {
+                    yield return member;
+                }
+            }
+
+            yield break;
+        }
+
+        for (var current = typeSymbol; current is not null && current.SpecialType != SpecialType.System_Object; current = current.BaseType)
+        {
+            foreach (var member in current.GetMembers())
+            {
+                yield return member;
+            }
+        }
+    }
+
+    private static AsyncKind GetAsyncKind(ITypeSymbol type)
+    {
+        if (type is not INamedTypeSymbol namedType)
+        {
+            return AsyncKind.None;
+        }
+
+        var containingNamespace = namedType.ContainingNamespace?.ToDisplayString();
+        if (!string.Equals(containingNamespace, "System.Threading.Tasks", StringComparison.Ordinal))
+        {
+            return AsyncKind.None;
+        }
+
+        return namedType.Name switch
+        {
+            "Task" when namedType.IsGenericType => AsyncKind.Task,
+            "Task" => AsyncKind.TaskWithoutResult,
+            "ValueTask" when namedType.IsGenericType => AsyncKind.ValueTask,
+            "ValueTask" => AsyncKind.ValueTaskWithoutResult,
+            _ => AsyncKind.None
+        };
+    }
+
+    private static string CreateAccessorName(ITypeSymbol typeSymbol, HashSet<string> usedAccessorNames)
+    {
+        var baseName = typeSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+        var accessorNameBuilder = new StringBuilder(baseName.Length + 16);
+
+        for (var i = 0; i < baseName.Length; i++)
+        {
+            var c = baseName[i];
+            accessorNameBuilder.Append(char.IsLetterOrDigit(c) || c == '_' ? c : '_');
+        }
+
+        accessorNameBuilder.Append("_GeneratedMemberAccessor");
+        var accessorName = accessorNameBuilder.ToString();
+
+        if (usedAccessorNames.Add(accessorName))
+        {
+            return accessorName;
+        }
+
+        var suffix = 2;
+        while (!usedAccessorNames.Add(accessorName + suffix))
+        {
+            suffix++;
+        }
+
+        return accessorName + suffix;
+    }
+
+    private static string? EscapeIdentifier(string identifier)
+    {
+        if (!SyntaxFacts.IsValidIdentifier(identifier))
+        {
+            return null;
+        }
+
+        return SyntaxFacts.GetKeywordKind(identifier) != SyntaxKind.None ? "@" + identifier : identifier;
+    }
+
+    private sealed record ProfileMethodCandidate(
+        IMethodSymbol Method,
+        ImmutableArray<ITypeSymbol> RegisteredTypes,
+        bool HasPartialModifier,
+        bool HasExplicitAccessibility,
+        bool HasBody,
+        Location Location);
+
+    private sealed record OptionsTypeCandidate(
+        INamedTypeSymbol OptionsType,
+        ImmutableArray<ITypeSymbol> RegisteredTypes,
+        bool HasPartialModifier,
+        Location Location);
+
+    private sealed record ProfileMethodRegistration(
+        IMethodSymbol Method,
+        ImmutableArray<ITypeSymbol> RegisteredTypes);
+
+    private sealed record OptionsTypeRegistration(
+        INamedTypeSymbol OptionsType,
+        ImmutableArray<ITypeSymbol> RegisteredTypes);
+
+    private sealed record AccessorRegistration(
+        string TypeExpression,
+        string AccessorName,
+        List<MemberAccess> Members);
+
+    private sealed record MethodRegistration(
+        IMethodSymbol Method,
+        ImmutableArray<AccessorRegistration> Accessors);
+
+    private sealed record GeneratedOptionsTypeRegistration(
+        INamedTypeSymbol OptionsType,
+        ImmutableArray<AccessorRegistration> Accessors);
+
+    private sealed record MemberAccess(string Name, string Expression, AsyncKind AsyncKind);
+
+    private enum AsyncKind
+    {
+        None,
+        Task,
+        ValueTask,
+        TaskWithoutResult,
+        ValueTaskWithoutResult
+    }
+
+    private static readonly string AttributeSource = """
+        // <auto-generated />
+        #nullable enable
+        namespace Fluid
+        {
+            [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+            internal sealed class FluidRegisterAttribute : global::System.Attribute
+            {
+                public FluidRegisterAttribute(global::System.Type type)
+                {
+                    Type = type;
+                }
+
+                public global::System.Type Type { get; }
+            }
+        }
+        """;
+}

--- a/Fluid.Tests/EnumTests.cs
+++ b/Fluid.Tests/EnumTests.cs
@@ -1,0 +1,42 @@
+using Fluid;
+using Fluid.Tests.Domain;
+using Fluid.Values;
+using Xunit;
+
+namespace Fluid.Tests
+{
+    public class EnumTests
+    {
+        [Fact]
+        public void EnumInContextShouldRenderAsString()
+        {
+            var parser = new FluidParser();
+            var options = new TemplateOptions();
+            var context = new TemplateContext(options);
+            
+            // Set an enum value directly in context
+            context.SetValue("color", Colors.Blue);
+            
+            var template = parser.Parse("{{color}}");
+            var result = template.Render(context);
+            
+            Assert.Equal("Blue", result);
+        }
+        
+        [Fact]
+        public void EnumInArrayShouldRenderAsString()
+        {
+            var parser = new FluidParser();
+            var options = new TemplateOptions();
+            var context = new TemplateContext(options);
+            
+            // Set an array containing enums
+            context.SetValue("colors", new[] { Colors.Blue, Colors.Red, Colors.Yellow });
+            
+            var template = parser.Parse("{% for c in colors %}{{c}} {% endfor %}");
+            var result = template.Render(context);
+            
+            Assert.Equal("Blue Red Yellow ", result);
+        }
+    }
+}

--- a/Fluid.Tests/Fluid.Tests.csproj
+++ b/Fluid.Tests/Fluid.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <DefineConstants Condition="'$(Compiled)' == 'true'">$(DefineConstants);COMPILED</DefineConstants>
     <IsPackable>false</IsPackable>

--- a/Fluid.Tests/Fluid.Tests.csproj
+++ b/Fluid.Tests/Fluid.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.analyzers" />
@@ -23,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Fluid.MvcViewEngine\Fluid.MvcViewEngine.csproj" />
+    <ProjectReference Include="..\Fluid.SourceGenerator\Fluid.SourceGenerator.csproj" />
     <ProjectReference Include="..\Fluid.ViewEngine\Fluid.ViewEngine.csproj" />
     <ProjectReference Include="..\Fluid\Fluid.csproj" />
   </ItemGroup>

--- a/Fluid.Tests/IfChangedStatementTests.cs
+++ b/Fluid.Tests/IfChangedStatementTests.cs
@@ -1,0 +1,130 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Fluid.Ast;
+using Fluid.Values;
+using Xunit;
+
+namespace Fluid.Tests
+{
+    public class IfChangedStatementTests
+    {
+        [Fact]
+        public async Task IfChangedOutputsOnFirstInvocation()
+        {
+            var statement = new IfChangedStatement(
+                [new OutputStatement(new LiteralExpression(new StringValue("hello")))]
+            );
+
+            var context = new TemplateContext();
+            var sw = new StringWriter();
+
+            await statement.WriteToAsync(sw, HtmlEncoder.Default, context);
+
+            Assert.Equal("hello", sw.ToString());
+        }
+
+        [Fact]
+        public async Task IfChangedDoesNotOutputOnSecondIdenticalInvocation()
+        {
+            var statement = new IfChangedStatement(
+                [new OutputStatement(new LiteralExpression(new StringValue("hello")))]
+            );
+
+            var context = new TemplateContext();
+            var sw = new StringWriter();
+
+            await statement.WriteToAsync(sw, HtmlEncoder.Default, context);
+            await statement.WriteToAsync(sw, HtmlEncoder.Default, context);
+
+            Assert.Equal("hello", sw.ToString());
+        }
+
+        [Fact]
+        public async Task IfChangedOutputsWhenContentChanges()
+        {
+            // We need to use parsed templates to test dynamic content
+            var parser = new FluidParser();
+            var template = parser.Parse("{% assign x = 'a' %}{% ifchanged %}{{ x }}{% endifchanged %}{% assign x = 'b' %}{% ifchanged %}{{ x }}{% endifchanged %}");
+
+            var context = new TemplateContext();
+            var result = await template.RenderAsync(context);
+
+            Assert.Equal("ab", result);
+        }
+
+        [Fact]
+        public async Task IfChangedEmptyBlockOutputsOnce()
+        {
+            var parser = new FluidParser();
+            var template = parser.Parse("{% ifchanged %}{% endifchanged %}{% ifchanged %}{% endifchanged %}");
+
+            var context = new TemplateContext();
+            var result = await template.RenderAsync(context);
+
+            Assert.Equal("", result);
+        }
+
+        [Fact]
+        public async Task IfChangedWorksWithinForLoop()
+        {
+            var parser = new FluidParser();
+            var template = parser.Parse("{% assign list = '1,1,2,2,3' | split: ',' %}{% for item in list %}{% ifchanged %}{{ item }}{% endifchanged %}{% endfor %}");
+
+            var context = new TemplateContext();
+            var result = await template.RenderAsync(context);
+
+            Assert.Equal("123", result);
+        }
+
+        [Fact]
+        public async Task IfChangedOutputsDifferentContent()
+        {
+            var parser = new FluidParser();
+            var template = parser.Parse("{% ifchanged %}a{% endifchanged %}{% ifchanged %}b{% endifchanged %}");
+
+            var context = new TemplateContext();
+            var result = await template.RenderAsync(context);
+
+            // Both output because content is different ("a" vs "b")
+            Assert.Equal("ab", result);
+        }
+
+        [Fact]
+        public async Task IfChangedRespectsWhitespaceTrimming()
+        {
+            var parser = new FluidParser();
+            var template = parser.Parse("X{%- ifchanged -%}Y{%- endifchanged -%}Z");
+
+            var context = new TemplateContext();
+            var result = await template.RenderAsync(context);
+
+            Assert.Equal("XYZ", result);
+        }
+
+        [Fact]
+        public async Task IfChangedHandlesNilValues()
+        {
+            var parser = new FluidParser();
+            var template = parser.Parse("{% ifchanged %}{{ undefined }}{% endifchanged %}{% ifchanged %}{{ undefined }}{% endifchanged %}");
+
+            var context = new TemplateContext();
+            var result = await template.RenderAsync(context);
+
+            // Both output empty string, but first invocation outputs (empty), second doesn't
+            Assert.Equal("", result);
+        }
+
+        [Fact]
+        public async Task IfChangedWithSortedList()
+        {
+            var parser = new FluidParser();
+            var template = parser.Parse("{% assign list = \"1,3,2,1,3,1,2\" | split: \",\" | sort %}{% for item in list -%}{%- ifchanged %} {{ item }}{% endifchanged -%}{%- endfor %}");
+
+            var context = new TemplateContext();
+            var result = await template.RenderAsync(context);
+
+            Assert.Equal(" 1 2 3", result);
+        }
+    }
+}

--- a/Fluid.Tests/IncludeStatementTests.cs
+++ b/Fluid.Tests/IncludeStatementTests.cs
@@ -659,6 +659,26 @@ shape: ''";
         }
 
         [Fact]
+        public void RenderTag_NamedArguments_AreEvaluatedBeforeAssignment()
+        {
+            var fileProvider = new MockFileProvider();
+            fileProvider.Add("file.liquid", "{{ value }} {{ key }}");
+
+            var options = new TemplateOptions()
+            {
+                FileProvider = fileProvider,
+                MemberAccessStrategy = UnsafeMemberAccessStrategy.Instance
+            };
+            var context = new TemplateContext(options);
+            context.SetValue("value", new { f1 = "Hello", f2 = "World" });
+            _parser.TryParse("{% render 'file', value: value.f1, key: value.f2 %}", out var template);
+
+            var result = template.Render(context);
+
+            Assert.Equal("Hello World", result);
+        }
+
+        [Fact]
         public void RenderTag_For_And_NamedArguments()
         {
             var fileProvider = new MockFileProvider();

--- a/Fluid.Tests/IncludeStatementTests.cs
+++ b/Fluid.Tests/IncludeStatementTests.cs
@@ -724,5 +724,152 @@ shape: ''";
 
             Assert.Equal("test", result);
         }
+
+        [Fact]
+        public void IncludeTag_CustomExtension_Html()
+        {
+            var fileProvider = new MockFileProvider();
+            fileProvider.Add("template.html", "<div>{{ content }}</div>");
+
+            var options = new TemplateOptions() { FileProvider = fileProvider, DefaultFileExtension = ".html" };
+            var context = new TemplateContext(options);
+            context.SetValue("content", "Hello World");
+            _parser.TryParse("{% include 'template' %}", out var template);
+            var result = template.Render(context);
+
+            Assert.Equal("<div>Hello World</div>", result);
+        }
+
+        [Fact]
+        public void RenderTag_CustomExtension_Html()
+        {
+            var fileProvider = new MockFileProvider();
+            fileProvider.Add("template.html", "<div>{{ content }}</div>");
+
+            var options = new TemplateOptions() { FileProvider = fileProvider, DefaultFileExtension = ".html" };
+            var context = new TemplateContext(options);
+            context.SetValue("content", "Hello World");
+            _parser.TryParse("{% render 'template' %}", out var template);
+            var result = template.Render(context);
+
+            Assert.Equal("<div>Hello World</div>", result);
+        }
+
+        [Fact]
+        public void IncludeTag_CustomExtension_Css()
+        {
+            var fileProvider = new MockFileProvider();
+            fileProvider.Add("styles.css", ".class { color: {{ color }}; }");
+
+            var options = new TemplateOptions() { FileProvider = fileProvider, DefaultFileExtension = ".css" };
+            var context = new TemplateContext(options);
+            context.SetValue("color", "red");
+            _parser.TryParse("{% include 'styles' %}", out var template);
+            var result = template.Render(context);
+
+            Assert.Equal(".class { color: red; }", result);
+        }
+
+        [Fact]
+        public void IncludeTag_ExplicitExtension_TakesPrecedence()
+        {
+            var fileProvider = new MockFileProvider();
+            fileProvider.Add("template.html", "HTML content");
+            fileProvider.Add("template.liquid", "Liquid content");
+
+            var options = new TemplateOptions() { FileProvider = fileProvider, DefaultFileExtension = ".liquid" };
+            var context = new TemplateContext(options);
+            _parser.TryParse("{% include 'template.html' %}", out var template);
+            var result = template.Render(context);
+
+            Assert.Equal("HTML content", result);
+        }
+
+        [Fact]
+        public void RenderTag_ExplicitExtension_TakesPrecedence()
+        {
+            var fileProvider = new MockFileProvider();
+            fileProvider.Add("template.html", "HTML content");
+            fileProvider.Add("template.liquid", "Liquid content");
+
+            var options = new TemplateOptions() { FileProvider = fileProvider, DefaultFileExtension = ".liquid" };
+            var context = new TemplateContext(options);
+            _parser.TryParse("{% render 'template.html' %}", out var template);
+            var result = template.Render(context);
+
+            Assert.Equal("HTML content", result);
+        }
+
+        [Fact]
+        public void IncludeTag_NoExtension_WhenDefaultIsNull()
+        {
+            var fileProvider = new MockFileProvider();
+            fileProvider.Add("template", "No extension content");
+
+            var options = new TemplateOptions() { FileProvider = fileProvider, DefaultFileExtension = null };
+            var context = new TemplateContext(options);
+            _parser.TryParse("{% include 'template' %}", out var template);
+            var result = template.Render(context);
+
+            Assert.Equal("No extension content", result);
+        }
+
+        [Fact]
+        public void RenderTag_NoExtension_WhenDefaultIsNull()
+        {
+            var fileProvider = new MockFileProvider();
+            fileProvider.Add("template", "No extension content");
+
+            var options = new TemplateOptions() { FileProvider = fileProvider, DefaultFileExtension = null };
+            var context = new TemplateContext(options);
+            _parser.TryParse("{% render 'template' %}", out var template);
+            var result = template.Render(context);
+
+            Assert.Equal("No extension content", result);
+        }
+
+        [Fact]
+        public void IncludeTag_NoExtension_WhenDefaultIsEmpty()
+        {
+            var fileProvider = new MockFileProvider();
+            fileProvider.Add("template", "No extension content");
+
+            var options = new TemplateOptions() { FileProvider = fileProvider, DefaultFileExtension = "" };
+            var context = new TemplateContext(options);
+            _parser.TryParse("{% include 'template' %}", out var template);
+            var result = template.Render(context);
+
+            Assert.Equal("No extension content", result);
+        }
+
+        [Fact]
+        public void IncludeTag_DefaultExtension_BackwardCompatibility()
+        {
+            // Test that default behavior (using .liquid) still works
+            var fileProvider = new MockFileProvider();
+            fileProvider.Add("template.liquid", "Default behavior");
+
+            var options = new TemplateOptions() { FileProvider = fileProvider };
+            var context = new TemplateContext(options);
+            _parser.TryParse("{% include 'template' %}", out var template);
+            var result = template.Render(context);
+
+            Assert.Equal("Default behavior", result);
+        }
+
+        [Fact]
+        public void RenderTag_DefaultExtension_BackwardCompatibility()
+        {
+            // Test that default behavior (using .liquid) still works
+            var fileProvider = new MockFileProvider();
+            fileProvider.Add("template.liquid", "Default behavior");
+
+            var options = new TemplateOptions() { FileProvider = fileProvider };
+            var context = new TemplateContext(options);
+            _parser.TryParse("{% render 'template' %}", out var template);
+            var result = template.Render(context);
+
+            Assert.Equal("Default behavior", result);
+        }
     }
 }

--- a/Fluid.Tests/IncludeStatementTests.cs
+++ b/Fluid.Tests/IncludeStatementTests.cs
@@ -871,5 +871,141 @@ shape: ''";
 
             Assert.Equal("Default behavior", result);
         }
+
+        [Fact]
+        public async Task RenderStatement_ShouldInvokeTemplateParsedCallback()
+        {
+            // This test verifies that the TemplateParsed callback is invoked for templates loaded by render statements
+            var fileProvider = new MockFileProvider();
+            fileProvider.Add("inner.liquid", "{{ 2 | plus: 2 }}");
+
+            var options = new TemplateOptions() { FileProvider = fileProvider };
+            
+            // Use a visitor to replace 2 with 4
+            options.TemplateParsed = (path, template) =>
+            {
+                var visitor = new Fluid.Tests.Visitors.ReplaceTwosVisitor(Fluid.Values.NumberValue.Create(4));
+                return visitor.VisitTemplate(template);
+            };
+
+            var context = new TemplateContext(options);
+            
+            // Parse the outer template manually and apply visitor to it too
+            _parser.TryParse("{{ 1 | plus: 2 }}\n{% render 'inner' %}", out var outerTemplate);
+            var visitor = new Fluid.Tests.Visitors.ReplaceTwosVisitor(Fluid.Values.NumberValue.Create(4));
+            outerTemplate = visitor.VisitTemplate(outerTemplate);
+            
+            var result = await outerTemplate.RenderAsync(context);
+
+            // Both the outer template and the inner template should have 2 replaced with 4
+            // Outer: 1 + 4 = 5
+            // Inner: 4 + 4 = 8
+            Assert.Equal("5\n8", result);
+        }
+
+        [Fact]
+        public async Task IncludeStatement_ShouldInvokeTemplateParsedCallback()
+        {
+            // This test verifies that the TemplateParsed callback is invoked for templates loaded by include statements
+            var fileProvider = new MockFileProvider();
+            fileProvider.Add("inner.liquid", "{{ 2 | plus: 2 }}");
+
+            var options = new TemplateOptions() { FileProvider = fileProvider };
+            
+            // Use a visitor to replace 2 with 4
+            options.TemplateParsed = (path, template) =>
+            {
+                var visitor = new Fluid.Tests.Visitors.ReplaceTwosVisitor(Fluid.Values.NumberValue.Create(4));
+                return visitor.VisitTemplate(template);
+            };
+
+            var context = new TemplateContext(options);
+            
+            // Parse the outer template manually and apply visitor to it too
+            _parser.TryParse("{{ 1 | plus: 2 }}\n{% include 'inner' %}", out var outerTemplate);
+            var visitor = new Fluid.Tests.Visitors.ReplaceTwosVisitor(Fluid.Values.NumberValue.Create(4));
+            outerTemplate = visitor.VisitTemplate(outerTemplate);
+            
+            var result = await outerTemplate.RenderAsync(context);
+
+            // Both the outer template and the inner template should have 2 replaced with 4
+            // Outer: 1 + 4 = 5
+            // Inner: 4 + 4 = 8
+            Assert.Equal("5\n8", result);
+        }
+
+        [Fact]
+        public async Task RenderStatement_ShouldCacheModifiedTemplate()
+        {
+            // This test verifies that the modified template is cached after TemplateParsed callback
+            var fileProvider = new MockFileProvider();
+            fileProvider.Add("inner.liquid", "{{ 2 | plus: 2 }}");
+
+            var options = new TemplateOptions() 
+            { 
+                FileProvider = fileProvider
+                // TemplateCache is created by default
+            };
+            
+            var callbackCount = 0;
+            
+            // Use a visitor to replace 2 with 4
+            options.TemplateParsed = (path, template) =>
+            {
+                callbackCount++;
+                var visitor = new Fluid.Tests.Visitors.ReplaceTwosVisitor(Fluid.Values.NumberValue.Create(4));
+                return visitor.VisitTemplate(template);
+            };
+
+            var context = new TemplateContext(options);
+            _parser.TryParse("{% render 'inner' %}", out var template);
+            
+            // First render - template is parsed and cached
+            var result1 = await template.RenderAsync(context);
+            Assert.Equal("8", result1);
+            Assert.Equal(1, callbackCount);
+            
+            // Second render - template is retrieved from cache, callback should NOT be invoked
+            var result2 = await template.RenderAsync(context);
+            Assert.Equal("8", result2);
+            Assert.Equal(1, callbackCount); // Callback count should still be 1
+        }
+
+        [Fact]
+        public async Task IncludeStatement_ShouldCacheModifiedTemplate()
+        {
+            // This test verifies that the modified template is cached after TemplateParsed callback
+            var fileProvider = new MockFileProvider();
+            fileProvider.Add("inner.liquid", "{{ 2 | plus: 2 }}");
+
+            var options = new TemplateOptions() 
+            { 
+                FileProvider = fileProvider
+                // TemplateCache is created by default
+            };
+            
+            var callbackCount = 0;
+            
+            // Use a visitor to replace 2 with 4
+            options.TemplateParsed = (path, template) =>
+            {
+                callbackCount++;
+                var visitor = new Fluid.Tests.Visitors.ReplaceTwosVisitor(Fluid.Values.NumberValue.Create(4));
+                return visitor.VisitTemplate(template);
+            };
+
+            var context = new TemplateContext(options);
+            _parser.TryParse("{% include 'inner' %}", out var template);
+            
+            // First render - template is parsed and cached
+            var result1 = await template.RenderAsync(context);
+            Assert.Equal("8", result1);
+            Assert.Equal(1, callbackCount);
+            
+            // Second render - template is retrieved from cache, callback should NOT be invoked
+            var result2 = await template.RenderAsync(context);
+            Assert.Equal("8", result2);
+            Assert.Equal(1, callbackCount); // Callback count should still be 1
+        }
     }
 }

--- a/Fluid.Tests/MemberAccessStrategyTests.cs
+++ b/Fluid.Tests/MemberAccessStrategyTests.cs
@@ -251,7 +251,7 @@ namespace Fluid.Tests
             var john = new Person { Firstname = "John", EyesColor = Colors.Yellow };
 
             var template = _parser.Parse("{{Firstname}} {{EyesColor}}");
-            Assert.Equal("John 2", template.Render(new TemplateContext(john, options, false)));
+            Assert.Equal("John Yellow", template.Render(new TemplateContext(john, options, false)));
         }
 
         [Fact]

--- a/Fluid.Tests/MemberAccessStrategyTests.cs
+++ b/Fluid.Tests/MemberAccessStrategyTests.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -41,6 +42,40 @@ namespace Fluid.Tests
             Assert.NotNull(strategy.GetAccessor(typeof(Class1), nameof(Class1.Property2)));
 
             Assert.Null(strategy.GetAccessor(typeof(Class1), nameof(Class1.PrivateProperty)));
+        }
+
+        [Fact]
+        public void RegisterByTypeUsesAotSafePropertyAccessorWhenDynamicCodeIsUnavailable()
+        {
+            var strategy = new DefaultMemberAccessStrategy();
+            strategy.Register<Class1>();
+            var accessor = strategy.GetAccessor(typeof(Class1), nameof(Class1.Property1));
+
+            if (RuntimeFeature.IsDynamicCodeSupported)
+            {
+                Assert.IsType<PropertyInfoAccessor>(accessor, exactMatch: false);
+            }
+            else
+            {
+                Assert.Equal("ReflectionPropertyInfoAccessor", accessor.GetType().Name);
+            }
+        }
+
+        [Fact]
+        public void RegisterByTypeUsesAotSafeFieldAccessorWhenDynamicCodeIsUnavailable()
+        {
+            var strategy = new DefaultMemberAccessStrategy();
+            strategy.Register<Class1>();
+            var accessor = strategy.GetAccessor(typeof(Class1), nameof(Class1.Field1));
+
+            if (RuntimeFeature.IsDynamicCodeSupported)
+            {
+                Assert.IsType<DelegateAccessor>(accessor, exactMatch: false);
+            }
+            else
+            {
+                Assert.Equal("ReflectionFieldInfoAccessor", accessor.GetType().Name);
+            }
         }
 
         [Fact]
@@ -286,6 +321,44 @@ namespace Fluid.Tests
             var template = _parser.Parse("{{X1}} {{X2}} {{X3}}");
             Assert.Equal("1 2 3", template.Render(new TemplateContext(s, options, false)));
         }
+        [Fact]
+        public void ShouldApplyGeneratedMemberAccessorsFromTemplateOptionsSubclass()
+        {
+            var options = new GeneratedTemplateOptions();
+            var model = new GeneratedModel();
+
+            var template = _parser.Parse("{{Generated}}");
+
+            Assert.Equal("generated", template.Render(new TemplateContext(model, options)));
+        }
+
+        [Fact]
+        public void ShouldReapplyGeneratedMemberAccessorsWhenStrategyIsReplaced()
+        {
+            var options = new GeneratedTemplateOptions
+            {
+                MemberAccessStrategy = new DefaultMemberAccessStrategy()
+            };
+            var model = new GeneratedModel();
+
+            var template = _parser.Parse("{{Generated}}");
+
+            Assert.Equal("generated", template.Render(new TemplateContext(model, options)));
+        }
+
+        [Fact]
+        public void ShouldAllowRuntimeRegistrationsToOverrideGeneratedMemberAccessors()
+        {
+            var options = new GeneratedTemplateOptions();
+            options.MemberAccessStrategy.Register(
+                typeof(GeneratedModel),
+                [new KeyValuePair<string, IMemberAccessor>(nameof(GeneratedModel.Generated), new FixedMemberAccessor("runtime"))]);
+            var model = new GeneratedModel();
+
+            var template = _parser.Parse("{{Generated}}");
+
+            Assert.Equal("runtime", template.Render(new TemplateContext(model, options)));
+        }
     }
 
     public class Class1
@@ -301,5 +374,32 @@ namespace Fluid.Tests
         public int Property2 { get; set; }
         public Task<string> Property3 { get; set; }
         public string WriteOnlyProperty { private get; set; }
+    }
+
+    public sealed class GeneratedModel
+    {
+        public string Generated { get; set; } = "model";
+    }
+
+    public sealed class GeneratedTemplateOptions : TemplateOptions, ITemplateOptionsMemberAccessorRegistrar
+    {
+        void ITemplateOptionsMemberAccessorRegistrar.RegisterMemberAccessors(TemplateOptions options)
+        {
+            options.MemberAccessStrategy.Register(
+                typeof(GeneratedModel),
+                [new KeyValuePair<string, IMemberAccessor>("*", new FixedMemberAccessor("generated"))]);
+        }
+    }
+
+    public sealed class FixedMemberAccessor : IMemberAccessor
+    {
+        private readonly string _value;
+
+        public FixedMemberAccessor(string value)
+        {
+            _value = value;
+        }
+
+        public object Get(object obj, string name, TemplateContext ctx) => _value;
     }
 }

--- a/Fluid.Tests/MemberAccessorGeneratorTests.cs
+++ b/Fluid.Tests/MemberAccessorGeneratorTests.cs
@@ -1,0 +1,151 @@
+using Fluid.SourceGenerator;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Fluid.Tests;
+
+public class MemberAccessorGeneratorTests
+{
+    [Fact]
+    public void ShouldGenerateProfileMethodImplementationFromFluidRegisterAttributes()
+    {
+        var source = """
+            using Fluid;
+
+            public class Person
+            {
+                public string FirstName { get; set; } = "";
+                public int Age;
+                public System.Threading.Tasks.Task Loaded() => System.Threading.Tasks.Task.CompletedTask;
+                public System.Threading.Tasks.ValueTask Initialized() => System.Threading.Tasks.ValueTask.CompletedTask;
+            }
+
+            public static partial class FluidProfiles
+            {
+                [FluidRegister(typeof(Person))]
+                public static partial void ApplyPublic(TemplateOptions options);
+            }
+            """;
+
+        var generated = RunGenerator(source);
+
+        Assert.Contains("internal sealed class FluidRegisterAttribute", generated);
+        Assert.Contains("public static partial void ApplyPublic(global::Fluid.TemplateOptions options)", generated);
+        Assert.Contains("global::Fluid.MemberAccessStrategyExtensions.Register(strategy, typeof(global::Person), \"*\", new global::Fluid.SourceGenerated.Person_GeneratedMemberAccessor());", generated);
+        Assert.Contains("comparer.Equals(name, \"FirstName\")", generated);
+        Assert.Contains("comparer.Equals(name, \"Age\")", generated);
+        Assert.Contains("var task = typed.Loaded();", generated);
+        Assert.Contains("await task.ConfigureAwait(false);", generated);
+        Assert.Contains("var valueTask = typed.Initialized();", generated);
+        Assert.Contains("await valueTask.ConfigureAwait(false);", generated);
+        Assert.Contains("return null;", generated);
+    }
+
+    [Fact]
+    public void ShouldGenerateIndependentProfilesForDifferentTemplateOptionsInstances()
+    {
+        var source = """
+            using Fluid;
+
+            public class PublicModel
+            {
+                public string Title { get; set; } = "";
+            }
+
+            public class AdminModel
+            {
+                public string Secret { get; set; } = "";
+            }
+
+            public static partial class FluidProfiles
+            {
+                [FluidRegister(typeof(PublicModel))]
+                public static partial void ApplyPublic(TemplateOptions options);
+
+                [FluidRegister(typeof(AdminModel))]
+                public static partial void ApplyAdmin(TemplateOptions options);
+            }
+            """;
+
+        var generated = RunGenerator(source);
+
+        Assert.Contains("public static partial void ApplyPublic(global::Fluid.TemplateOptions options)", generated);
+        Assert.Contains("public static partial void ApplyAdmin(global::Fluid.TemplateOptions options)", generated);
+        Assert.Contains("global::Fluid.MemberAccessStrategyExtensions.Register(strategy, typeof(global::PublicModel), \"*\", new global::Fluid.SourceGenerated.PublicModel_GeneratedMemberAccessor());", generated);
+        Assert.Contains("global::Fluid.MemberAccessStrategyExtensions.Register(strategy, typeof(global::AdminModel), \"*\", new global::Fluid.SourceGenerated.AdminModel_GeneratedMemberAccessor());", generated);
+    }
+
+    [Fact]
+    public void ShouldGenerateOptionsSubclassRegistrationFromFluidRegisterAttributes()
+    {
+        var source = """
+            using Fluid;
+
+            public class Person
+            {
+                public string FirstName { get; set; } = "";
+            }
+
+            public class Address
+            {
+                public string City { get; set; } = "";
+            }
+
+            [FluidRegister(typeof(Person))]
+            [FluidRegister(typeof(Address))]
+            public partial class PublicTemplateOptions : TemplateOptions
+            {
+            }
+            """;
+
+        var generated = RunGenerator(source);
+
+        Assert.Contains("public partial class PublicTemplateOptions : global::Fluid.ITemplateOptionsMemberAccessorRegistrar", generated);
+        Assert.Contains("void global::Fluid.ITemplateOptionsMemberAccessorRegistrar.RegisterMemberAccessors(global::Fluid.TemplateOptions options)", generated);
+        Assert.Contains("throw new global::System.ArgumentNullException(nameof(options));", generated);
+        Assert.Contains("global::Fluid.MemberAccessStrategyExtensions.Register(strategy, typeof(global::Person), \"*\", new global::Fluid.SourceGenerated.Person_GeneratedMemberAccessor());", generated);
+        Assert.Contains("global::Fluid.MemberAccessStrategyExtensions.Register(strategy, typeof(global::Address), \"*\", new global::Fluid.SourceGenerated.Address_GeneratedMemberAccessor());", generated);
+    }
+
+    private static string RunGenerator(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var compilation = CSharpCompilation.Create(
+            "GeneratorInput",
+            [syntaxTree],
+            GetMetadataReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var generator = new MemberAccessorGenerator();
+        var driver = CSharpGeneratorDriver.Create(generator).RunGenerators(compilation);
+        var runResult = driver.GetRunResult();
+
+        Assert.Equal(2, runResult.GeneratedTrees.Length);
+        Assert.Empty(runResult.Diagnostics.Where(static x => x.Severity == DiagnosticSeverity.Error));
+
+        var outputCompilation = compilation.AddSyntaxTrees(runResult.GeneratedTrees);
+        Assert.Empty(outputCompilation.GetDiagnostics().Where(static x => x.Severity == DiagnosticSeverity.Error));
+
+        return string.Join(Environment.NewLine, runResult.GeneratedTrees.Select(static x => x.GetText().ToString()));
+    }
+
+    private static IEnumerable<MetadataReference> GetMetadataReferences()
+    {
+        var references = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(static assembly => !assembly.IsDynamic && !string.IsNullOrEmpty(assembly.Location))
+            .Select(static assembly => MetadataReference.CreateFromFile(assembly.Location))
+            .GroupBy(static reference => reference.Display!, StringComparer.Ordinal)
+            .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.Ordinal);
+
+        references.TryAdd(typeof(TemplateOptions).Assembly.Location, MetadataReference.CreateFromFile(typeof(TemplateOptions).Assembly.Location));
+        references.TryAdd(typeof(MemberAccessorGenerator).Assembly.Location, MetadataReference.CreateFromFile(typeof(MemberAccessorGenerator).Assembly.Location));
+        references.TryAdd(typeof(Enumerable).Assembly.Location, MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location));
+        references.TryAdd(typeof(object).Assembly.Location, MetadataReference.CreateFromFile(typeof(object).Assembly.Location));
+
+        return references.Values;
+    }
+}

--- a/Fluid.Tests/MiscFiltersTests.cs
+++ b/Fluid.Tests/MiscFiltersTests.cs
@@ -214,6 +214,38 @@ namespace Fluid.Tests
             Assert.Equal("1 &lt; 2 &amp; 3", result.ToStringValue());
         }
 
+        [Fact]
+        public async Task EscapeReturnsNonEncodableStringValue()
+        {
+            // The escape filter should return a StringValue with Encode = false
+            // to prevent double-encoding when rendered with an encoder
+            var input = new StringValue("<div>test</div>");
+            var arguments = new FilterArguments();
+            var context = new TemplateContext();
+
+            var result = await MiscFilters.Escape(input, arguments, context);
+
+            Assert.IsType<StringValue>(result);
+            var stringValue = (StringValue)result;
+            Assert.False(stringValue.Encode, "Escape filter should return StringValue with Encode = false");
+        }
+
+        [Fact]
+        public async Task EscapeOnceReturnsNonEncodableStringValue()
+        {
+            // The escape_once filter should return a StringValue with Encode = false
+            // to prevent double-encoding when rendered with an encoder
+            var input = new StringValue("&lt;div&gt;test&lt;/div&gt;");
+            var arguments = new FilterArguments();
+            var context = new TemplateContext();
+
+            var result = await MiscFilters.EscapeOnce(input, arguments, context);
+
+            Assert.IsType<StringValue>(result);
+            var stringValue = (StringValue)result;
+            Assert.False(stringValue.Encode, "EscapeOnce filter should return StringValue with Encode = false");
+        }
+
         [Theory]
         [InlineData("%a", "Tue")]
         [InlineData("%a", "Sun", "2022-06-26 00:00:00 -0500")]

--- a/Fluid.Tests/MiscFiltersTests.cs
+++ b/Fluid.Tests/MiscFiltersTests.cs
@@ -777,7 +777,7 @@ namespace Fluid.Tests
         }
 
         [Fact]
-        public async Task JsonShouldSerializeEnumsAsNumbers()
+        public async Task JsonShouldSerializeEnumsAsStrings()
         {
             var options = new TemplateOptions();
             options.MemberAccessStrategy.Register<Domain.Colors>();
@@ -786,12 +786,12 @@ namespace Fluid.Tests
             var context = new TemplateContext(options);
             var result = await MiscFilters.Json(input, new FilterArguments(), context);
 
-            // Enum should be serialized as number (1 for Red)
-            Assert.Equal("1", result.ToStringValue());
+            // Enum is converted to StringValue by default, so it's serialized as a string
+            Assert.Equal("\"Red\"", result.ToStringValue());
         }
         
         [Fact]
-        public async Task JsonShouldSerializeEnumsAsStrings()
+        public async Task JsonShouldSerializeEnumsInObjectsAsStrings()
         {
             var options = new TemplateOptions
             {

--- a/Fluid.Tests/MoneyFiltersTests.cs
+++ b/Fluid.Tests/MoneyFiltersTests.cs
@@ -1,0 +1,340 @@
+using Fluid.Filters;
+using Fluid.Values;
+using System;
+using System.Globalization;
+using Xunit;
+
+namespace Fluid.Tests
+{
+    public class MoneyFiltersTests
+    {
+        private static readonly FluidParser _parser = new FluidParser();
+
+        [Theory]
+        [InlineData(10, "$10.00")]
+        [InlineData(0, "$0.00")]
+        [InlineData(1134.65, "$1,134.65")]
+        [InlineData(1234567.891, "$1,234,567.89")]
+        [InlineData(10.005, "$10.01")] // rounded away from zero, not to even
+        [InlineData(-10, "-$10.00")]
+        public void Money(decimal value, string expected)
+        {
+            Assert.Equal(expected, Invoke(MoneyFilters.Money, value));
+        }
+
+        [Theory]
+        [InlineData(10, "$10.00 USD")]
+        [InlineData(1134.65, "$1,134.65 USD")]
+        public void MoneyWithCurrency(decimal value, string expected)
+        {
+            Assert.Equal(expected, Invoke(MoneyFilters.MoneyWithCurrency, value));
+        }
+
+        [Theory]
+        [InlineData(10, "10.00")]
+        [InlineData(1134.65, "1,134.65")]
+        [InlineData(-1134.65, "-1,134.65")]
+        public void MoneyWithoutCurrency(decimal value, string expected)
+        {
+            Assert.Equal(expected, Invoke(MoneyFilters.MoneyWithoutCurrency, value));
+        }
+
+        [Theory]
+        [InlineData(10, "$10")]
+        [InlineData(10.5, "$10.50")]
+        [InlineData(1134, "$1,134")]
+        [InlineData(1134.65, "$1,134.65")]
+        [InlineData(0, "$0")]
+        public void MoneyWithoutTrailingZeros(decimal value, string expected)
+        {
+            Assert.Equal(expected, Invoke(MoneyFilters.MoneyWithoutTrailingZeros, value));
+        }
+
+        [Theory]
+        [InlineData("31.3")]
+        [InlineData("31.30")]
+        [InlineData("31.300")]
+        public void MoneyShouldNotDependOnTheScaleOfTheInput(string value)
+        {
+            // https://github.com/sebastienros/fluid/issues/238#issuecomment-2360412081
+            var amount = decimal.Parse(value, CultureInfo.InvariantCulture);
+
+            Assert.Equal("$31.30", Invoke(MoneyFilters.Money, amount));
+            Assert.Equal("31.30", Invoke(MoneyFilters.MoneyWithoutCurrency, amount));
+        }
+
+        [Theory]
+        [InlineData(1450, "$14.50")]
+        [InlineData(1000, "$10.00")]
+        [InlineData(0, "$0.00")]
+        public void AmountsInCents(decimal value, string expected)
+        {
+            var context = CreateContext(options => options.MoneyOptions.AmountsInCents = true);
+
+            Assert.Equal(expected, Invoke(MoneyFilters.Money, value, context));
+        }
+
+        [Fact]
+        public void CurrencyCanBeConfiguredInOptions()
+        {
+            var context = CreateContext(options => options.MoneyOptions.Currency = "EUR");
+
+            Assert.Equal("€10.00", Invoke(MoneyFilters.Money, 10, context));
+            Assert.Equal("€10.00 EUR", Invoke(MoneyFilters.MoneyWithCurrency, 10, context));
+        }
+
+        [Fact]
+        public void CurrencyCanBePassedAsAPositionalArgument()
+        {
+            var arguments = new FilterArguments(new StringValue("EUR"));
+
+            Assert.Equal("€10.00", Invoke(MoneyFilters.Money, 10, CreateContext(), arguments));
+        }
+
+        [Fact]
+        public void CurrencyCanBePassedAsANamedArgument()
+        {
+            var arguments = new FilterArguments().Add("currency", new StringValue("EUR"));
+
+            Assert.Equal("€10.00", Invoke(MoneyFilters.Money, 10, CreateContext(), arguments));
+        }
+
+        [Fact]
+        public void CurrencyArgumentTakesPrecedenceOverOptions()
+        {
+            var context = CreateContext(options => options.MoneyOptions.Currency = "EUR");
+            var arguments = new FilterArguments(new StringValue("GBP"));
+
+            Assert.Equal("£10.00 GBP", Invoke(MoneyFilters.MoneyWithCurrency, 10, context, arguments));
+        }
+
+        [Fact]
+        public void UnknownCurrencyUsesItsCodeAsSymbol()
+        {
+            var arguments = new FilterArguments(new StringValue("XYZ"));
+
+            Assert.Equal("XYZ10.00", Invoke(MoneyFilters.Money, 10, CreateContext(), arguments));
+        }
+
+        [Fact]
+        public void CurrencyCanBeAddedToOptions()
+        {
+            var context = CreateContext(options => options.MoneyOptions.Currencies["XYZ"] = new MoneyCurrency("XYZ", "Ξ", 4));
+            var arguments = new FilterArguments(new StringValue("XYZ"));
+
+            Assert.Equal("Ξ10.0000", Invoke(MoneyFilters.Money, 10, context, arguments));
+        }
+
+        [Theory]
+        [InlineData(10, "¥10")]
+        [InlineData(1234.56, "¥1,235")]
+        public void CurrenciesWithoutDecimalDigits(decimal value, string expected)
+        {
+            var arguments = new FilterArguments(new StringValue("JPY"));
+
+            Assert.Equal(expected, Invoke(MoneyFilters.Money, value, CreateContext(), arguments));
+        }
+
+        [Theory]
+        [InlineData("{{amount}}", "1,134.65")]
+        [InlineData("{{amount_no_decimals}}", "1,135")]
+        [InlineData("{{amount_with_comma_separator}}", "1.134,65")]
+        [InlineData("{{amount_no_decimals_with_comma_separator}}", "1.135")]
+        [InlineData("{{amount_with_apostrophe_separator}}", "1'134.65")]
+        [InlineData("{{amount_no_decimals_with_space_separator}}", "1 135")]
+        [InlineData("{{amount_with_space_separator}}", "1 134,65")]
+        [InlineData("{{amount_with_period_and_space_separator}}", "1 134.65")]
+        [InlineData("${{ amount }}", "$1,134.65")]
+        [InlineData("{{amount_with_comma_separator}} kr", "1.134,65 kr")]
+        [InlineData("{{currency_symbol}}{{amount}} {{currency}}", "$1,134.65 USD")]
+        [InlineData("{{unknown}} {{amount}}", "{{unknown}} 1,134.65")]
+        [InlineData("no placeholder", "no placeholder")]
+        public void MoneyFormatIsUsedWhenDefined(string format, string expected)
+        {
+            var context = CreateContext(options => options.MoneyOptions.MoneyFormat = format);
+
+            Assert.Equal(expected, Invoke(MoneyFilters.Money, 1134.65M, context));
+        }
+
+        [Fact]
+        public void MoneyWithCurrencyFormatIsUsedWhenDefined()
+        {
+            var context = CreateContext(options => options.MoneyOptions.MoneyWithCurrencyFormat = "{{amount}} {{currency}}");
+
+            Assert.Equal("1,134.65 USD", Invoke(MoneyFilters.MoneyWithCurrency, 1134.65M, context));
+        }
+
+        [Fact]
+        public void MoneyWithCurrencyFallsBackToMoneyFormat()
+        {
+            var context = CreateContext(options => options.MoneyOptions.MoneyFormat = "{{amount}} kr");
+
+            Assert.Equal("1,134.65 kr USD", Invoke(MoneyFilters.MoneyWithCurrency, 1134.65M, context));
+        }
+
+        [Theory]
+        [InlineData(10, "$10")]
+        [InlineData(10.5, "$10.50")]
+        public void MoneyWithoutTrailingZerosUsesTheNoDecimalsVariantOfTheFormat(decimal value, string expected)
+        {
+            var context = CreateContext(options => options.MoneyOptions.MoneyFormat = "${{amount}}");
+
+            Assert.Equal(expected, Invoke(MoneyFilters.MoneyWithoutTrailingZeros, value, context));
+        }
+
+        [Fact]
+        public void MoneyWithoutCurrencyIgnoresTheMoneyFormat()
+        {
+            var context = CreateContext(options => options.MoneyOptions.MoneyFormat = "${{amount}}");
+
+            Assert.Equal("1,134.65", Invoke(MoneyFilters.MoneyWithoutCurrency, 1134.65M, context));
+        }
+
+        [Fact]
+        public void EnUsCultureUsesItsOwnCurrency()
+        {
+            var context = CreateContext(options => options.CultureInfo = new CultureInfo("en-US"));
+
+            Assert.Equal("$1,134.65", Invoke(MoneyFilters.Money, 1134.65M, context));
+            Assert.Equal("$1,134.65 USD", Invoke(MoneyFilters.MoneyWithCurrency, 1134.65M, context));
+            Assert.Equal("1,134.65", Invoke(MoneyFilters.MoneyWithoutCurrency, 1134.65M, context));
+        }
+
+        [Theory]
+        [InlineData("de-DE", "1.134,65 €", "EUR")]
+        [InlineData("fr-FR", "1 134,65 €", "EUR")]
+        [InlineData("en-GB", "£1,134.65", "GBP")]
+        [InlineData("ja-JP", "¥1,135", "JPY")]
+        public void CulturesUseTheirOwnCurrency(string cultureName, string expected, string expectedCode)
+        {
+            var context = CreateContext(options => options.CultureInfo = new CultureInfo(cultureName));
+
+            Assert.Equal(expected, Normalize(Invoke(MoneyFilters.Money, 1134.65M, context)));
+            Assert.Equal(expected + " " + expectedCode, Normalize(Invoke(MoneyFilters.MoneyWithCurrency, 1134.65M, context)));
+        }
+
+        [Fact]
+        public void NeutralCulturesResolveTheirCurrency()
+        {
+            var context = CreateContext(options => options.CultureInfo = new CultureInfo("de"));
+
+            Assert.EndsWith("EUR", Invoke(MoneyFilters.MoneyWithCurrency, 10, context));
+        }
+
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("de-DE")]
+        [InlineData("fr-FR")]
+        public void MoneyShouldNotBeAffectedByCurrentCulture(string culture)
+        {
+            var previousCulture = CultureInfo.CurrentCulture;
+            var previousUICulture = CultureInfo.CurrentUICulture;
+
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+                CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
+
+                Assert.Equal("$1,134.65", Invoke(MoneyFilters.Money, 1134.65M));
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = previousCulture;
+                CultureInfo.CurrentUICulture = previousUICulture;
+            }
+        }
+
+        [Fact]
+        public void EmptyValuesRenderAnEmptyString()
+        {
+            var context = CreateContext();
+
+            Assert.Equal("", MoneyFilters.Money(NilValue.Instance, FilterArguments.Empty, context).Result.ToStringValue());
+            Assert.Equal("", MoneyFilters.Money(BlankValue.Instance, FilterArguments.Empty, context).Result.ToStringValue());
+            Assert.Equal("", MoneyFilters.Money(EmptyValue.Instance, FilterArguments.Empty, context).Result.ToStringValue());
+            Assert.Equal("", MoneyFilters.MoneyWithCurrency(NilValue.Instance, FilterArguments.Empty, context).Result.ToStringValue());
+            Assert.Equal("", MoneyFilters.MoneyWithoutCurrency(NilValue.Instance, FilterArguments.Empty, context).Result.ToStringValue());
+            Assert.Equal("", MoneyFilters.MoneyWithoutTrailingZeros(NilValue.Instance, FilterArguments.Empty, context).Result.ToStringValue());
+        }
+
+        [Fact]
+        public void StringValuesAreParsed()
+        {
+            Assert.Equal("$10.50", MoneyFilters.Money(new StringValue("10.50"), FilterArguments.Empty, CreateContext()).Result.ToStringValue());
+        }
+
+        [Fact]
+        public void TooManyArgumentsThrows()
+        {
+            var arguments = new FilterArguments(new StringValue("EUR"), new StringValue("USD"));
+
+            Assert.Throws<FluidException>(() => MoneyFilters.Money(NumberValue.Create(10), arguments, CreateContext()).Result);
+        }
+
+        [Theory]
+        [InlineData("{{ 1134.65 | money }}", "$1,134.65")]
+        [InlineData("{{ 1134.65 | money_with_currency }}", "$1,134.65 USD")]
+        [InlineData("{{ 1134.65 | money_without_currency }}", "1,134.65")]
+        [InlineData("{{ 10.00 | money_without_trailing_zeros }}", "$10")]
+        [InlineData("{{ 10 | money: 'EUR' }}", "€10.00")]
+        [InlineData("{{ 10 | money: currency: 'EUR' }}", "€10.00")]
+        [InlineData("{{ 10 | money: 'XYZ' }}", "XYZ10.00")]
+        [InlineData("{{ nil | money }}", "")]
+        public void MoneyFiltersAreRegisteredByWithMoneyFilters(string source, string expected)
+        {
+            var options = new TemplateOptions();
+            options.Filters.WithMoneyFilters();
+
+            Assert.True(_parser.TryParse(source, out var template, out var errors), errors);
+            Assert.Equal(expected, template.Render(new TemplateContext(options)));
+        }
+
+        [Fact]
+        public void MoneyFiltersAreNotRegisteredByDefault()
+        {
+            var options = new TemplateOptions { StrictFilters = true };
+
+            Assert.True(_parser.TryParse("{{ 10 | money }}", out var template, out var errors), errors);
+            Assert.Throws<FluidException>(() => template.Render(new TemplateContext(options)));
+        }
+
+        [Fact]
+        public void MoneyOptionsCanBeOverriddenPerContext()
+        {
+            var options = new TemplateOptions();
+            options.Filters.WithMoneyFilters();
+
+            var context = new TemplateContext(options)
+            {
+                MoneyOptions = new MoneyOptions { Currency = "EUR" }
+            };
+
+            Assert.True(_parser.TryParse("{{ 10 | money }}", out var template, out var errors), errors);
+            Assert.Equal("€10.00", template.Render(context));
+        }
+
+        private static TemplateContext CreateContext(Action<TemplateOptions> configure = null)
+        {
+            var options = new TemplateOptions();
+            configure?.Invoke(options);
+
+            return new TemplateContext(options);
+        }
+
+        private static string Invoke(FilterDelegate filter, decimal value, TemplateContext context = null, FilterArguments arguments = null)
+        {
+            context ??= CreateContext();
+
+            return filter(NumberValue.Create(value), arguments ?? FilterArguments.Empty, context).Result.ToStringValue();
+        }
+
+        /// <summary>
+        /// Replaces the non-breaking spaces some cultures use as separators so that the assertions
+        /// don't depend on the ICU version of the host.
+        /// </summary>
+        private static string Normalize(string value)
+        {
+            return value.Replace(' ', ' ').Replace(' ', ' ');
+        }
+    }
+}

--- a/Fluid.Tests/MvcViewEngine/ViewEngineTests.cs
+++ b/Fluid.Tests/MvcViewEngine/ViewEngineTests.cs
@@ -1,5 +1,6 @@
 ﻿using Fluid.Tests.Mocks;
 using Fluid.ViewEngine;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -302,6 +303,102 @@ namespace Fluid.Tests.MvcViewEngine
             var template = new TemplateContext(new { BigString = new string(Enumerable.Range(0, 1500).Select(_ => 'b').ToArray()) });
             await _renderer.RenderViewAsync(sw, "Index.liquid", template);
             await sw.FlushAsync();
+        }
+
+        [Fact]
+        public async Task ShouldApplyTemplateParsedCallback()
+        {
+            _mockFileProvider.Add("Views/Index.liquid", "{{ 1 | plus: 2 }}");
+
+            // Use a visitor to replace 2 with 4
+            _options.TemplateParsed = (path, template) =>
+            {
+                var visitor = new Fluid.Tests.Visitors.ReplaceTwosVisitor(Fluid.Values.NumberValue.Create(4));
+                return visitor.VisitTemplate(template);
+            };
+
+            var sw = new StringWriter();
+            await _renderer.RenderViewAsync(sw, "Index.liquid", new TemplateContext());
+            await sw.FlushAsync();
+
+            Assert.Equal("5", sw.ToString());
+
+            _options.TemplateParsed = null;
+        }
+
+        [Fact]
+        public async Task ShouldApplyTemplateParsedCallbackToNestedTemplates()
+        {
+            _mockFileProvider.Add("Views/Index.liquid", "{% partial 'world' %}");
+            _mockFileProvider.Add("Partials/World.liquid", "{{ 1 | plus: 2 }}");
+
+            // Use a visitor to replace 2 with 4
+            _options.TemplateParsed = (path, template) =>
+            {
+                var visitor = new Fluid.Tests.Visitors.ReplaceTwosVisitor(Fluid.Values.NumberValue.Create(4));
+                return visitor.VisitTemplate(template);
+            };
+
+            var sw = new StringWriter();
+            await _renderer.RenderViewAsync(sw, "Index.liquid", new TemplateContext());
+            await sw.FlushAsync();
+
+            Assert.Equal("5", sw.ToString());
+
+            _options.TemplateParsed = null;
+        }
+
+        [Fact]
+        public async Task ShouldApplyTemplateParsedCallbackToViewStarts()
+        {
+            _mockFileProvider.Add("Views/Index.liquid", "Hello");
+            _mockFileProvider.Add("Views/_ViewStart.liquid", "{{ 1 | plus: 2 }} ");
+
+            // Use a visitor to replace 2 with 4
+            _options.TemplateParsed = (path, template) =>
+            {
+                var visitor = new Fluid.Tests.Visitors.ReplaceTwosVisitor(Fluid.Values.NumberValue.Create(4));
+                return visitor.VisitTemplate(template);
+            };
+
+            var sw = new StringWriter();
+            await _renderer.RenderViewAsync(sw, "Index.liquid", new TemplateContext());
+            await sw.FlushAsync();
+
+            Assert.Equal("5 Hello", sw.ToString());
+
+            _options.TemplateParsed = null;
+        }
+
+        [Fact]
+        public async Task CompositeFluidTemplateShouldRenderUsingStatementsNotTemplates()
+        {
+            // This test verifies that CompositeFluidTemplate renders using its Statements property
+            // rather than iterating through the Templates property, which is important for
+            // consistency with FluidTemplate and for ensuring altered statements are rendered.
+            
+            // Create a simple composite template
+            var parser = new FluidParser();
+            var template1 = parser.Parse("{{ 1 | plus: 2 }}");
+            var template2 = parser.Parse(" World");
+            
+            var composite = new Fluid.Parser.CompositeFluidTemplate(template1, template2);
+            
+            // Render it normally - should output "3 World"
+            var sw = new StringWriter();
+            await composite.RenderAsync(sw, System.Text.Encodings.Web.HtmlEncoder.Default, new TemplateContext());
+            Assert.Equal("3 World", sw.ToString());
+            
+            // Now apply a visitor that alters the statements
+            var visitor = new Fluid.Tests.Visitors.ReplaceTwosVisitor(Fluid.Values.NumberValue.Create(4));
+            var altered = visitor.VisitTemplate(composite);
+            
+            // The visitor should return a new template with altered statements
+            var sw2 = new StringWriter();
+            await altered.RenderAsync(sw2, System.Text.Encodings.Web.HtmlEncoder.Default, new TemplateContext());
+            
+            // Should output "5 World" - the '2' has been replaced with '4', so 1+4=5
+            Assert.Equal("5 World", sw2.ToString());
         }
     }
 }

--- a/Fluid.Tests/MvcViewEngine/ViewEngineTests.cs
+++ b/Fluid.Tests/MvcViewEngine/ViewEngineTests.cs
@@ -311,7 +311,7 @@ namespace Fluid.Tests.MvcViewEngine
             _mockFileProvider.Add("Views/Index.liquid", "{{ 1 | plus: 2 }}");
 
             // Use a visitor to replace 2 with 4
-            _options.TemplateParsed = (path, template) =>
+            _options.TemplateOptions.TemplateParsed = (path, template) =>
             {
                 var visitor = new Fluid.Tests.Visitors.ReplaceTwosVisitor(Fluid.Values.NumberValue.Create(4));
                 return visitor.VisitTemplate(template);
@@ -323,7 +323,7 @@ namespace Fluid.Tests.MvcViewEngine
 
             Assert.Equal("5", sw.ToString());
 
-            _options.TemplateParsed = null;
+            _options.TemplateOptions.TemplateParsed = null;
         }
 
         [Fact]
@@ -333,7 +333,7 @@ namespace Fluid.Tests.MvcViewEngine
             _mockFileProvider.Add("Partials/World.liquid", "{{ 1 | plus: 2 }}");
 
             // Use a visitor to replace 2 with 4
-            _options.TemplateParsed = (path, template) =>
+            _options.TemplateOptions.TemplateParsed = (path, template) =>
             {
                 var visitor = new Fluid.Tests.Visitors.ReplaceTwosVisitor(Fluid.Values.NumberValue.Create(4));
                 return visitor.VisitTemplate(template);
@@ -345,7 +345,7 @@ namespace Fluid.Tests.MvcViewEngine
 
             Assert.Equal("5", sw.ToString());
 
-            _options.TemplateParsed = null;
+            _options.TemplateOptions.TemplateParsed = null;
         }
 
         [Fact]
@@ -355,7 +355,7 @@ namespace Fluid.Tests.MvcViewEngine
             _mockFileProvider.Add("Views/_ViewStart.liquid", "{{ 1 | plus: 2 }} ");
 
             // Use a visitor to replace 2 with 4
-            _options.TemplateParsed = (path, template) =>
+            _options.TemplateOptions.TemplateParsed = (path, template) =>
             {
                 var visitor = new Fluid.Tests.Visitors.ReplaceTwosVisitor(Fluid.Values.NumberValue.Create(4));
                 return visitor.VisitTemplate(template);
@@ -367,7 +367,7 @@ namespace Fluid.Tests.MvcViewEngine
 
             Assert.Equal("5 Hello", sw.ToString());
 
-            _options.TemplateParsed = null;
+            _options.TemplateOptions.TemplateParsed = null;
         }
 
         [Fact]

--- a/Fluid.Tests/ParserTests.cs
+++ b/Fluid.Tests/ParserTests.cs
@@ -778,6 +778,27 @@ true
         }
 
         [Theory]
+        [InlineData("p == null", "true")]
+        [InlineData("p != null", "false")]
+        [InlineData("null == p", "true")]
+        [InlineData("null == blank", "true")]
+        [InlineData("blank == null", "true")]
+        [InlineData("null == ''", "false")]
+        [InlineData("'' == null", "false")]
+        [InlineData("empty == null", "false")]
+        [InlineData("null == empty", "false")]
+        [InlineData("null == nil", "true")]
+        [InlineData("nil == null", "true")]
+        [InlineData("e == null", "false")]
+        [InlineData("null == e", "false")]
+        [InlineData("p != null and p != ''", "false")]
+        [InlineData("p != '' and p != null", "false")]
+        public Task NullShouldBehaveLikeNil(string source, string expected)
+        {
+            return CheckAsync(source, expected, t => t.SetValue("e", "").SetValue("f", "hello"));
+        }
+
+        [Theory]
         [InlineData("blank == false", "true")]
         [InlineData("empty == false", "false")]
         public Task BlankShouldComparesToFalse(string source, string expected)

--- a/Fluid.Tests/ParserTests.cs
+++ b/Fluid.Tests/ParserTests.cs
@@ -712,8 +712,8 @@ true
         [InlineData("p == blank", "true")]
         [InlineData("blank == p ", "true")]
 
-        [InlineData("empty == blank", "true")]
-        [InlineData("blank == empty", "true")]
+        [InlineData("empty == blank", "false")]
+        [InlineData("blank == empty", "false")]
 
         [InlineData("nil == blank", "true")]
         [InlineData("blank == nil", "true")]
@@ -800,7 +800,9 @@ true
 
         [Theory]
         [InlineData("blank == false", "true")]
+        [InlineData("false == blank", "true")]
         [InlineData("empty == false", "false")]
+        [InlineData("false == empty", "false")]
         public Task BlankShouldComparesToFalse(string source, string expected)
         {
             return CheckAsync(source, expected, t => t.SetValue("zero", 0).SetValue("one", 1));

--- a/Fluid.Tests/StrictFiltersTests.cs
+++ b/Fluid.Tests/StrictFiltersTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Fluid.Tests;
+
+public class StrictFiltersTests
+{
+#if COMPILED
+    private static readonly FluidParser _parser = new FluidParser().Compile();
+#else
+    private static readonly FluidParser _parser = new FluidParser();
+#endif
+
+    [Fact]
+    public async Task UnknownFilter_DefaultBehavior_ReturnsInput()
+    {
+        _parser.TryParse("{{ 'hello' | unknown }}", out var template, out var _);
+        var context = new TemplateContext();
+        var result = await template.RenderAsync(context);
+        Assert.Equal("hello", result);
+    }
+
+    [Fact]
+    public async Task UnknownFilter_StrictFilters_Throws()
+    {
+        _parser.TryParse("{{ 'hello' | unknown }}", out var template, out var _);
+        var options = new TemplateOptions { StrictFilters = true };
+        var context = new TemplateContext(options);
+        await Assert.ThrowsAsync<FluidException>(() => template.RenderAsync(context).AsTask());
+    }
+
+    [Fact]
+    public async Task KnownFilter_StrictFilters_Succeeds()
+    {
+        _parser.TryParse("{{ 'hello' | upcase }}", out var template, out var _);
+        var options = new TemplateOptions { StrictFilters = true };
+        var context = new TemplateContext(options);
+        var result = await template.RenderAsync(context);
+        Assert.Equal("HELLO", result);
+    }
+}

--- a/Fluid.Tests/StrictVariableTests.cs
+++ b/Fluid.Tests/StrictVariableTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Fluid.Tests.Domain;
@@ -22,6 +23,26 @@ public class StrictVariableTests
         var context = new TemplateContext();
         var result = await template.RenderAsync(context);
         Assert.Equal("", result);
+    }
+
+    [Fact]
+    public async Task StrictVariables_ThrowsOnMissingVariable()
+    {
+        _parser.TryParse("{{ missing }}", out var template, out var _);
+        var options = new TemplateOptions { StrictVariables = true };
+        var context = new TemplateContext(options);
+        await Assert.ThrowsAsync<FluidException>(() => template.RenderAsync(context).AsTask());
+    }
+
+    [Fact]
+    public async Task StrictVariables_DoesNotThrowWhenVariableExists()
+    {
+        _parser.TryParse("{{ existing }}", out var template, out var _);
+        var options = new TemplateOptions { StrictVariables = true };
+        var context = new TemplateContext(options);
+        context.SetValue("existing", "value");
+        var result = await template.RenderAsync(context);
+        Assert.Equal("value", result);
     }
 
     [Fact]

--- a/Fluid.Tests/StringFiltersTests.cs
+++ b/Fluid.Tests/StringFiltersTests.cs
@@ -31,7 +31,7 @@ namespace Fluid.Tests
 
             var result = StringFilters.Capitalize(input, arguments, context);
 
-            Assert.Equal("Hello World", result.Result.ToStringValue());
+            Assert.Equal("Hello world", result.Result.ToStringValue());
         }
 
         [Fact]

--- a/Fluid.Tests/TableRowStatementTests.cs
+++ b/Fluid.Tests/TableRowStatementTests.cs
@@ -1,0 +1,304 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Fluid.Ast;
+using Fluid.Values;
+using System.Text.Encodings.Web;
+using Xunit;
+
+namespace Fluid.Tests
+{
+    public class TableRowStatementTests
+    {
+        private static readonly FluidParser _parser = new FluidParser();
+
+        [Fact]
+        public async Task ShouldRenderBasicTableRow()
+        {
+            var e = new TableRowStatement(
+                [new OutputStatement(new MemberExpression(new IdentifierSegment("i")))],
+                "i",
+                new MemberExpression(new IdentifierSegment("items")),
+                limit: null,
+                offset: null,
+                cols: null
+            );
+
+            var sw = new StringWriter();
+            var context = new TemplateContext();
+            context.SetValue("items", new[] { 1, 2, 3 });
+            await e.WriteToAsync(sw, HtmlEncoder.Default, context);
+
+            Assert.Equal("<tr class=\"row1\">\n<td class=\"col1\">1</td><td class=\"col2\">2</td><td class=\"col3\">3</td></tr>\n", sw.ToString());
+        }
+
+        [Fact]
+        public async Task ShouldRenderWithCols()
+        {
+            var e = new TableRowStatement(
+                [new OutputStatement(new MemberExpression(new IdentifierSegment("i")))],
+                "i",
+                new MemberExpression(new IdentifierSegment("items")),
+                limit: null,
+                offset: null,
+                cols: new LiteralExpression(NumberValue.Create(2))
+            );
+
+            var sw = new StringWriter();
+            var context = new TemplateContext();
+            context.SetValue("items", new[] { 1, 2, 3, 4 });
+            await e.WriteToAsync(sw, HtmlEncoder.Default, context);
+
+            Assert.Equal("<tr class=\"row1\">\n<td class=\"col1\">1</td><td class=\"col2\">2</td></tr>\n<tr class=\"row2\"><td class=\"col1\">3</td><td class=\"col2\">4</td></tr>\n", sw.ToString());
+        }
+
+        [Fact]
+        public async Task ShouldRenderWithLimit()
+        {
+            var e = new TableRowStatement(
+                [new OutputStatement(new MemberExpression(new IdentifierSegment("i")))],
+                "i",
+                new MemberExpression(new IdentifierSegment("items")),
+                limit: new LiteralExpression(NumberValue.Create(2)),
+                offset: null,
+                cols: null
+            );
+
+            var sw = new StringWriter();
+            var context = new TemplateContext();
+            context.SetValue("items", new[] { 1, 2, 3, 4 });
+            await e.WriteToAsync(sw, HtmlEncoder.Default, context);
+
+            Assert.Equal("<tr class=\"row1\">\n<td class=\"col1\">1</td><td class=\"col2\">2</td></tr>\n", sw.ToString());
+        }
+
+        [Fact]
+        public async Task ShouldRenderWithOffset()
+        {
+            var e = new TableRowStatement(
+                [new OutputStatement(new MemberExpression(new IdentifierSegment("i")))],
+                "i",
+                new MemberExpression(new IdentifierSegment("items")),
+                limit: null,
+                offset: new LiteralExpression(NumberValue.Create(2)),
+                cols: null
+            );
+
+            var sw = new StringWriter();
+            var context = new TemplateContext();
+            context.SetValue("items", new[] { 1, 2, 3, 4 });
+            await e.WriteToAsync(sw, HtmlEncoder.Default, context);
+
+            Assert.Equal("<tr class=\"row1\">\n<td class=\"col1\">3</td><td class=\"col2\">4</td></tr>\n", sw.ToString());
+        }
+
+        [Fact]
+        public async Task ShouldRenderWithRange()
+        {
+            var e = new TableRowStatement(
+                [new OutputStatement(new MemberExpression(new IdentifierSegment("i")))],
+                "i",
+                new RangeExpression(
+                    new LiteralExpression(NumberValue.Create(1)),
+                    new LiteralExpression(NumberValue.Create(4))
+                ),
+                limit: null,
+                offset: null,
+                cols: new LiteralExpression(NumberValue.Create(2))
+            );
+
+            var sw = new StringWriter();
+            await e.WriteToAsync(sw, HtmlEncoder.Default, new TemplateContext());
+
+            Assert.Equal("<tr class=\"row1\">\n<td class=\"col1\">1</td><td class=\"col2\">2</td></tr>\n<tr class=\"row2\"><td class=\"col1\">3</td><td class=\"col2\">4</td></tr>\n", sw.ToString());
+        }
+
+        [Fact]
+        public async Task ShouldProvideTableRowLoopVariables()
+        {
+            _parser.TryParse("{% tablerow i in (1..2) %}col:{{ tablerowloop.col }} col0:{{ tablerowloop.col0 }} row:{{ tablerowloop.row }} first:{{ tablerowloop.first }} last:{{ tablerowloop.last }} index:{{ tablerowloop.index }} index0:{{ tablerowloop.index0 }} rindex:{{ tablerowloop.rindex }} rindex0:{{ tablerowloop.rindex0 }} length:{{ tablerowloop.length }} col_first:{{ tablerowloop.col_first }} col_last:{{ tablerowloop.col_last }}{% endtablerow %}", out var template, out var error);
+
+            var result = await template.RenderAsync();
+
+            Assert.Contains("col:1", result);
+            Assert.Contains("col0:0", result);
+            Assert.Contains("row:1", result);
+            Assert.Contains("first:true", result);
+            Assert.Contains("length:2", result);
+            Assert.Contains("col_first:true", result);
+        }
+
+        [Fact]
+        public async Task ShouldHandleEmptyCollection()
+        {
+            var e = new TableRowStatement(
+                [new OutputStatement(new MemberExpression(new IdentifierSegment("i")))],
+                "i",
+                new MemberExpression(new IdentifierSegment("items")),
+                limit: null,
+                offset: null,
+                cols: null
+            );
+
+            var sw = new StringWriter();
+            var context = new TemplateContext();
+            context.SetValue("items", System.Array.Empty<int>());
+            await e.WriteToAsync(sw, HtmlEncoder.Default, context);
+
+            Assert.Equal("", sw.ToString());
+        }
+
+        [Fact]
+        public async Task ShouldHandleBreak()
+        {
+            _parser.TryParse("{% tablerow i in (1..5) cols:2 %}{{ i }}{% if i == 2 %}{% break %}{% endif %}{% endtablerow %}", out var template, out var error);
+
+            var result = await template.RenderAsync();
+
+            Assert.Equal("<tr class=\"row1\">\n<td class=\"col1\">1</td><td class=\"col2\">2</td></tr>\n", result);
+        }
+
+        [Fact]
+        public async Task ShouldParseTableRowTag()
+        {
+            _parser.TryParse("{% tablerow item in collection %}{{ item }}{% endtablerow %}", out var template, out var error);
+
+            Assert.Null(error);
+            Assert.NotNull(template);
+
+            var context = new TemplateContext();
+            context.SetValue("collection", new[] { "a", "b", "c" });
+            var result = await template.RenderAsync(context);
+
+            Assert.Equal("<tr class=\"row1\">\n<td class=\"col1\">a</td><td class=\"col2\">b</td><td class=\"col3\">c</td></tr>\n", result);
+        }
+
+        [Fact]
+        public async Task ShouldParseTableRowWithColsParameter()
+        {
+            _parser.TryParse("{% tablerow item in collection cols:2 %}{{ item }}{% endtablerow %}", out var template, out var error);
+
+            Assert.Null(error);
+            Assert.NotNull(template);
+
+            var context = new TemplateContext();
+            context.SetValue("collection", new[] { "a", "b", "c", "d" });
+            var result = await template.RenderAsync(context);
+
+            Assert.Equal("<tr class=\"row1\">\n<td class=\"col1\">a</td><td class=\"col2\">b</td></tr>\n<tr class=\"row2\"><td class=\"col1\">c</td><td class=\"col2\">d</td></tr>\n", result);
+        }
+
+        [Fact]
+        public async Task ShouldParseTableRowWithLimitParameter()
+        {
+            _parser.TryParse("{% tablerow item in collection limit:2 %}{{ item }}{% endtablerow %}", out var template, out var error);
+
+            Assert.Null(error);
+            Assert.NotNull(template);
+
+            var context = new TemplateContext();
+            context.SetValue("collection", new[] { "a", "b", "c", "d" });
+            var result = await template.RenderAsync(context);
+
+            Assert.Equal("<tr class=\"row1\">\n<td class=\"col1\">a</td><td class=\"col2\">b</td></tr>\n", result);
+        }
+
+        [Fact]
+        public async Task ShouldParseTableRowWithOffsetParameter()
+        {
+            _parser.TryParse("{% tablerow item in collection offset:2 %}{{ item }}{% endtablerow %}", out var template, out var error);
+
+            Assert.Null(error);
+            Assert.NotNull(template);
+
+            var context = new TemplateContext();
+            context.SetValue("collection", new[] { "a", "b", "c", "d" });
+            var result = await template.RenderAsync(context);
+
+            Assert.Equal("<tr class=\"row1\">\n<td class=\"col1\">c</td><td class=\"col2\">d</td></tr>\n", result);
+        }
+
+        [Fact]
+        public async Task ShouldParseTableRowWithRange()
+        {
+            _parser.TryParse("{% tablerow i in (1..4) cols:2 %}{{ i }}{% endtablerow %}", out var template, out var error);
+
+            Assert.Null(error);
+            Assert.NotNull(template);
+
+            var result = await template.RenderAsync();
+
+            Assert.Equal("<tr class=\"row1\">\n<td class=\"col1\">1</td><td class=\"col2\">2</td></tr>\n<tr class=\"row2\"><td class=\"col1\">3</td><td class=\"col2\">4</td></tr>\n", result);
+        }
+
+        [Fact]
+        public async Task ShouldParseTableRowWithAllParameters()
+        {
+            _parser.TryParse("{% tablerow i in (1..10) cols:2 limit:4 offset:2 %}{{ i }}{% endtablerow %}", out var template, out var error);
+
+            Assert.Null(error);
+            Assert.NotNull(template);
+
+            var result = await template.RenderAsync();
+
+            Assert.Equal("<tr class=\"row1\">\n<td class=\"col1\">3</td><td class=\"col2\">4</td></tr>\n<tr class=\"row2\"><td class=\"col1\">5</td><td class=\"col2\">6</td></tr>\n", result);
+        }
+
+        [Fact]
+        public async Task ColsShouldTruncateFloatToInt()
+        {
+            _parser.TryParse("{% tablerow i in (1..4) cols:2.6 %}{{ i }}{% endtablerow %}", out var template, out var error);
+
+            Assert.Null(error);
+            Assert.NotNull(template);
+
+            var result = await template.RenderAsync();
+
+            // 2.6 truncates to 2
+            Assert.Equal("<tr class=\"row1\">\n<td class=\"col1\">1</td><td class=\"col2\">2</td></tr>\n<tr class=\"row2\"><td class=\"col1\">3</td><td class=\"col2\">4</td></tr>\n", result);
+        }
+
+        [Fact]
+        public async Task ShouldHandleOddNumberOfItemsWithCols()
+        {
+            _parser.TryParse("{% tablerow i in (1..5) cols:2 %}{{ i }}{% endtablerow %}", out var template, out var error);
+
+            Assert.Null(error);
+            Assert.NotNull(template);
+
+            var result = await template.RenderAsync();
+
+            Assert.Equal("<tr class=\"row1\">\n<td class=\"col1\">1</td><td class=\"col2\">2</td></tr>\n<tr class=\"row2\"><td class=\"col1\">3</td><td class=\"col2\">4</td></tr>\n<tr class=\"row3\"><td class=\"col1\">5</td></tr>\n", result);
+        }
+
+        [Fact]
+        public async Task TableRowLoopColLastShouldBeCorrect()
+        {
+            _parser.TryParse("{% tablerow i in (1..4) cols:2 %}{{ tablerowloop.col_last }}{% endtablerow %}", out var template, out var error);
+
+            var result = await template.RenderAsync();
+
+            Assert.Equal("<tr class=\"row1\">\n<td class=\"col1\">false</td><td class=\"col2\">true</td></tr>\n<tr class=\"row2\"><td class=\"col1\">false</td><td class=\"col2\">true</td></tr>\n", result);
+        }
+
+        [Fact]
+        public async Task TableRowLoopColFirstShouldBeCorrect()
+        {
+            _parser.TryParse("{% tablerow i in (1..4) cols:2 %}{{ tablerowloop.col_first }}{% endtablerow %}", out var template, out var error);
+
+            var result = await template.RenderAsync();
+
+            Assert.Equal("<tr class=\"row1\">\n<td class=\"col1\">true</td><td class=\"col2\">false</td></tr>\n<tr class=\"row2\"><td class=\"col1\">true</td><td class=\"col2\">false</td></tr>\n", result);
+        }
+
+        [Fact]
+        public async Task TableRowLoopRowShouldIncrement()
+        {
+            _parser.TryParse("{% tablerow i in (1..4) cols:2 %}{{ tablerowloop.row }}{% endtablerow %}", out var template, out var error);
+
+            var result = await template.RenderAsync();
+
+            Assert.Equal("<tr class=\"row1\">\n<td class=\"col1\">1</td><td class=\"col2\">1</td></tr>\n<tr class=\"row2\"><td class=\"col1\">2</td><td class=\"col2\">2</td></tr>\n", result);
+        }
+    }
+}

--- a/Fluid.Tests/TemplateTests.cs
+++ b/Fluid.Tests/TemplateTests.cs
@@ -949,9 +949,24 @@ turtle
         [Theory]
         [InlineData("{{ products | map: 'price' }}", "123")]
         [InlineData("{{ products | map: 'price' | join: ' ' }}", "1 2 3")]
+        [InlineData("{{ 2 | map: 1 }}", "1")]
+        [InlineData("{{ (1..5) | map: 1 | join: '' }}", "01100")]
+        [InlineData("{{ nosuchthing | map: 'title' | join: '#' }}", "")]
         public Task ShouldProcessMapFilter(string source, string expected)
         {
             return CheckAsync(source, expected, ctx => { ctx.SetValue("products", _products); });
+        }
+
+        [Fact]
+        public async Task MapFilterShouldFailForInvalidNumberSelector()
+        {
+            _parser.TryParse("{{ 2 | map: 'z' }}", out var template, out var error);
+
+            var context = new TemplateContext();
+
+            var exception = await Assert.ThrowsAsync<FluidException>(async () => await template.RenderAsync(context));
+
+            Assert.Equal("cannot select the property 'z'", exception.Message);
         }
 
         [Theory]

--- a/Fluid.Tests/TemplateTests.cs
+++ b/Fluid.Tests/TemplateTests.cs
@@ -170,6 +170,24 @@ namespace Fluid.Tests
         }
 
         [Fact]
+        public async Task ReplaceShouldPreserveStringValueEncodeState()
+        {
+            const string source = "{{ obj.html | replace: 'test', 'content' }}";
+
+            _parser.TryParse(source, out var template, out var error);
+
+            var context = new TemplateContext(new TemplateOptions
+            {
+                MemberAccessStrategy = UnsafeMemberAccessStrategy.Instance
+            });
+            context.SetValue("obj", new { html = new StringValue("<div>test</div>", false) });
+
+            var result = await template.RenderAsync(context, HtmlEncoder.Default);
+
+            Assert.Equal("<div>content</div>", result);
+        }
+
+        [Fact]
         public async Task EscapeFilterShouldNotDoubleEncode()
         {
             // Using escape filter with HtmlEncoder should not double-encode

--- a/Fluid.Tests/TemplateTests.cs
+++ b/Fluid.Tests/TemplateTests.cs
@@ -740,6 +740,28 @@ turtle
         }
 
         [Theory]
+        [InlineData("{%if x == blank%}true{%else%}false{%endif%} {%if y == blank%}true{%else%}false{%endif%}", "false true")]
+        public Task ArrayCompareBlankValue(string source, string expected)
+        {
+            return CheckAsync(source, expected, ctx =>
+            {
+                ctx.SetValue("x", new[] { 1, 2, 3 });
+                ctx.SetValue("y", new int[0]);
+            });
+        }
+
+        [Theory]
+        [InlineData("{%if x == blank%}true{%else%}false{%endif%} {%if y == blank%}true{%else%}false{%endif%}", "false true")]
+        public Task DictionaryCompareBlankValue(string source, string expected)
+        {
+            return CheckAsync(source, expected, ctx =>
+            {
+                ctx.SetValue("x", new Dictionary<string, int> { { "1", 1 }, { "2", 2 }, { "3", 3 } });
+                ctx.SetValue("y", new Dictionary<string, int>());
+            });
+        }
+
+        [Theory]
         [InlineData("{{x.size}} {{y.size}}", "3 0")]
         public Task ArrayEvaluatesSize(string source, string expected)
         {

--- a/Fluid.ViewEngine/Fluid.ViewEngine.csproj
+++ b/Fluid.ViewEngine/Fluid.ViewEngine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>true</IsPackable>
     <PackageIcon>logo_64x64.png</PackageIcon>

--- a/Fluid.ViewEngine/FluidViewEngineOptions.cs
+++ b/Fluid.ViewEngine/FluidViewEngineOptions.cs
@@ -73,5 +73,16 @@ namespace Fluid.ViewEngine
         /// Gets or sets the delegate to execute when a view is rendered.
         /// </summary>
         public RenderingViewDelegate RenderingViewAsync { get; set; }
+
+        /// <summary>
+        /// <para>Represents the method that will handle the template parsed event.</para>
+        /// </summary>
+        public delegate IFluidTemplate TemplateParsedDelegate(string path, IFluidTemplate template);
+
+        /// <summary>
+        /// Gets or sets the delegate to execute when a template is parsed, before it is cached.
+        /// This can be used to apply AST visitors or rewriters to modify templates.
+        /// </summary>
+        public TemplateParsedDelegate TemplateParsed { get; set; }
     }
 }

--- a/Fluid.ViewEngine/FluidViewEngineOptions.cs
+++ b/Fluid.ViewEngine/FluidViewEngineOptions.cs
@@ -73,16 +73,5 @@ namespace Fluid.ViewEngine
         /// Gets or sets the delegate to execute when a view is rendered.
         /// </summary>
         public RenderingViewDelegate RenderingViewAsync { get; set; }
-
-        /// <summary>
-        /// <para>Represents the method that will handle the template parsed event.</para>
-        /// </summary>
-        public delegate IFluidTemplate TemplateParsedDelegate(string path, IFluidTemplate template);
-
-        /// <summary>
-        /// Gets or sets the delegate to execute when a template is parsed, before it is cached.
-        /// This can be used to apply AST visitors or rewriters to modify templates.
-        /// </summary>
-        public TemplateParsedDelegate TemplateParsed { get; set; }
     }
 }

--- a/Fluid.ViewEngine/FluidViewRenderer.cs
+++ b/Fluid.ViewEngine/FluidViewRenderer.cs
@@ -224,6 +224,12 @@ namespace Fluid.ViewEngine
 
             template = await ParseLiquidFileAsync(path, fileProvider, includeViewStarts);
 
+            // Allow user to modify the template before caching (e.g., apply visitors/rewriters)
+            if (_fluidViewEngineOptions.TemplateParsed != null)
+            {
+                template = _fluidViewEngineOptions.TemplateParsed(path, template);
+            }
+
             cache.TemplateCache[path] = template;
 
             return template;

--- a/Fluid.ViewEngine/FluidViewRenderer.cs
+++ b/Fluid.ViewEngine/FluidViewRenderer.cs
@@ -225,9 +225,9 @@ namespace Fluid.ViewEngine
             template = await ParseLiquidFileAsync(path, fileProvider, includeViewStarts);
 
             // Allow user to modify the template before caching (e.g., apply visitors/rewriters)
-            if (_fluidViewEngineOptions.TemplateParsed != null)
+            if (_fluidViewEngineOptions.TemplateOptions.TemplateParsed != null)
             {
-                template = _fluidViewEngineOptions.TemplateParsed(path, template);
+                template = _fluidViewEngineOptions.TemplateOptions.TemplateParsed(path, template);
             }
 
             cache.TemplateCache[path] = template;

--- a/Fluid.sln
+++ b/Fluid.sln
@@ -34,6 +34,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MinimalApis.LiquidViews", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fluid.MinimalApisSample", "Fluid.MinimalApisSample\Fluid.MinimalApisSample.csproj", "{6390F2D4-564B-455E-9C02-3DB998E5BD09}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fluid.SourceGenerator", "Fluid.SourceGenerator\Fluid.SourceGenerator.csproj", "{0E78F7FC-9A79-4A55-B228-6E57D42A15C5}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D1E1DE19-67EF-43C8-BC9A-53E60D65ECFE}"
 EndProject
 Global
@@ -74,6 +76,10 @@ Global
 		{6390F2D4-564B-455E-9C02-3DB998E5BD09}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6390F2D4-564B-455E-9C02-3DB998E5BD09}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6390F2D4-564B-455E-9C02-3DB998E5BD09}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0E78F7FC-9A79-4A55-B228-6E57D42A15C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E78F7FC-9A79-4A55-B228-6E57D42A15C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E78F7FC-9A79-4A55-B228-6E57D42A15C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E78F7FC-9A79-4A55-B228-6E57D42A15C5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Fluid/Accessors/AccessorValueConverter.cs
+++ b/Fluid/Accessors/AccessorValueConverter.cs
@@ -1,0 +1,33 @@
+using Fluid.Values;
+
+namespace Fluid.Accessors;
+
+internal static class AccessorValueConverter
+{
+    public static object Convert(object value, TypeCode typeCode, bool isEnum)
+    {
+        if (value == null || isEnum)
+        {
+            return value;
+        }
+
+        return typeCode switch
+        {
+            TypeCode.Boolean => (bool)value ? BooleanValue.True : BooleanValue.False,
+            TypeCode.Byte => NumberValue.Create((byte)value),
+            TypeCode.UInt16 => NumberValue.Create((ushort)value),
+            TypeCode.UInt32 => NumberValue.Create((uint)value),
+            TypeCode.SByte => NumberValue.Create((sbyte)value),
+            TypeCode.Int16 => NumberValue.Create((short)value),
+            TypeCode.Int32 => NumberValue.Create((int)value),
+            TypeCode.UInt64 => NumberValue.Create((ulong)value),
+            TypeCode.Int64 => NumberValue.Create((long)value),
+            TypeCode.Double => NumberValue.Create((decimal)(double)value),
+            TypeCode.Single => NumberValue.Create((decimal)(float)value),
+            TypeCode.Decimal => NumberValue.Create((decimal)value),
+            TypeCode.DateTime => new DateTimeValue((DateTime)value),
+            TypeCode.String => StringValue.Create((string)value),
+            _ => value,
+        };
+    }
+}

--- a/Fluid/Accessors/ReflectionFieldInfoAccessor.cs
+++ b/Fluid/Accessors/ReflectionFieldInfoAccessor.cs
@@ -1,0 +1,22 @@
+using System.Reflection;
+
+namespace Fluid.Accessors;
+
+internal sealed class ReflectionFieldInfoAccessor : IMemberAccessor
+{
+    private readonly FieldInfo _fieldInfo;
+    private readonly TypeCode _typeCode;
+    private readonly bool _isEnum;
+
+    public ReflectionFieldInfoAccessor(FieldInfo fieldInfo)
+    {
+        _fieldInfo = fieldInfo;
+        _typeCode = Type.GetTypeCode(fieldInfo.FieldType);
+        _isEnum = fieldInfo.FieldType.IsEnum;
+    }
+
+    public object Get(object obj, string name, TemplateContext ctx)
+    {
+        return AccessorValueConverter.Convert(_fieldInfo.GetValue(obj), _typeCode, _isEnum);
+    }
+}

--- a/Fluid/Accessors/ReflectionPropertyInfoAccessor.cs
+++ b/Fluid/Accessors/ReflectionPropertyInfoAccessor.cs
@@ -1,0 +1,22 @@
+using System.Reflection;
+
+namespace Fluid.Accessors;
+
+internal sealed class ReflectionPropertyInfoAccessor : IMemberAccessor
+{
+    private readonly PropertyInfo _propertyInfo;
+    private readonly TypeCode _typeCode;
+    private readonly bool _isEnum;
+
+    public ReflectionPropertyInfoAccessor(PropertyInfo propertyInfo)
+    {
+        _propertyInfo = propertyInfo;
+        _typeCode = Type.GetTypeCode(propertyInfo.PropertyType);
+        _isEnum = propertyInfo.PropertyType.IsEnum;
+    }
+
+    public object Get(object obj, string name, TemplateContext ctx)
+    {
+        return AccessorValueConverter.Convert(_propertyInfo.GetValue(obj), _typeCode, _isEnum);
+    }
+}

--- a/Fluid/Ast/AstRewriter.cs
+++ b/Fluid/Ast/AstRewriter.cs
@@ -420,6 +420,16 @@ namespace Fluid.Ast
             return ifStatement;
         }
 
+        protected internal override Statement VisitIfChangedStatement(IfChangedStatement ifChangedStatement)
+        {
+            if (TryRewriteStatements(ifChangedStatement.Statements, out var newStatements))
+            {
+                return new IfChangedStatement(newStatements.ToList());
+            }
+
+            return ifChangedStatement;
+        }
+
         protected internal override Statement VisitIncludeStatement(IncludeStatement includeStatement)
         {
             if (TryRewriteExpression(includeStatement.For, out var newFor) |

--- a/Fluid/Ast/AstRewriter.cs
+++ b/Fluid/Ast/AstRewriter.cs
@@ -383,6 +383,20 @@ namespace Fluid.Ast
             return forStatement;
         }
 
+        protected internal override Statement VisitTableRowStatement(TableRowStatement tableRowStatement)
+        {
+            if (TryRewriteExpression(tableRowStatement.Source, out var newSource) |
+                TryRewriteExpression(tableRowStatement.Limit, out var newLimit) |
+                TryRewriteExpression(tableRowStatement.Offset, out var newOffset) |
+                TryRewriteExpression(tableRowStatement.Cols, out var newCols) |
+                TryRewriteStatements(tableRowStatement.Statements, out var newStatements))
+            {
+                return new TableRowStatement(newStatements.ToList(), tableRowStatement.Identifier, newSource, newLimit, newOffset, newCols);
+            }
+
+            return tableRowStatement;
+        }
+
         protected internal override Statement VisitFromStatement(FromStatement fromStatement)
         {
             if (TryRewriteExpression(fromStatement.Path, out var newPath))

--- a/Fluid/Ast/AstVisitor.cs
+++ b/Fluid/Ast/AstVisitor.cs
@@ -346,6 +346,16 @@ namespace Fluid.Ast
             return ifStatement;
         }
 
+        protected internal virtual Statement VisitIfChangedStatement(IfChangedStatement ifChangedStatement)
+        {
+            foreach (var statement in ifChangedStatement.Statements)
+            {
+                Visit(statement);
+            }
+
+            return ifChangedStatement;
+        }
+
         protected internal virtual Statement VisitIncludeStatement(IncludeStatement includeStatement)
         {
             Visit(includeStatement.For);

--- a/Fluid/Ast/AstVisitor.cs
+++ b/Fluid/Ast/AstVisitor.cs
@@ -306,6 +306,21 @@ namespace Fluid.Ast
             return forStatement;
         }
 
+        protected internal virtual Statement VisitTableRowStatement(TableRowStatement tableRowStatement)
+        {
+            Visit(tableRowStatement.Source);
+            Visit(tableRowStatement.Limit);
+            Visit(tableRowStatement.Offset);
+            Visit(tableRowStatement.Cols);
+
+            foreach (var statement in tableRowStatement.Statements)
+            {
+                Visit(statement);
+            }
+
+            return tableRowStatement;
+        }
+
         protected internal virtual Statement VisitFromStatement(FromStatement fromStatement)
         {
             Visit(fromStatement.Path);

--- a/Fluid/Ast/FilterExpression.cs
+++ b/Fluid/Ast/FilterExpression.cs
@@ -1,4 +1,5 @@
-﻿using Fluid.Values;
+﻿using System;
+using Fluid.Values;
 
 namespace Fluid.Ast
 {
@@ -48,7 +49,12 @@ namespace Fluid.Ast
 
             if (!context.Options.Filters.TryGetValue(Name, out var filter))
             {
-                // When a filter is not defined, return the input
+                // When a filter is not defined, return the input unless strict filters are enabled
+                if (context.Options.StrictFilters)
+                {
+                    throw new FluidException($"Undefined filter '{Name}'");
+                }
+
                 return input;
             }
 

--- a/Fluid/Ast/IfChangedStatement.cs
+++ b/Fluid/Ast/IfChangedStatement.cs
@@ -1,0 +1,51 @@
+using Fluid.Utils;
+using System.Text.Encodings.Web;
+
+namespace Fluid.Ast
+{
+    public sealed class IfChangedStatement : TagStatement
+    {
+        private const string IfChangedRegisterKey = "$$ifchanged$$";
+
+        public IfChangedStatement(IReadOnlyList<Statement> statements) : base(statements)
+        {
+        }
+
+        public override async ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
+        {
+            context.IncrementSteps();
+
+            // Get the previous value (shared across all ifchanged blocks)
+            context.AmbientValues.TryGetValue(IfChangedRegisterKey, out var previousValueObj);
+            var previousValue = previousValueObj as string;
+
+            // Render inner statements to a buffer
+            using var builder = StringBuilderPool.GetInstance();
+            using var captureWriter = new StringWriter(builder.Builder);
+            var completion = Completion.Normal;
+
+            for (var i = 0; i < Statements.Count; i++)
+            {
+                completion = await Statements[i].WriteToAsync(captureWriter, encoder, context);
+
+                if (completion != Completion.Normal)
+                {
+                    break;
+                }
+            }
+
+            var currentValue = captureWriter.ToString();
+
+            // Output only if content has changed from the last ifchanged output
+            if (!string.Equals(previousValue, currentValue, StringComparison.Ordinal))
+            {
+                context.AmbientValues[IfChangedRegisterKey] = currentValue;
+                writer.Write(currentValue);
+            }
+
+            return completion;
+        }
+
+        protected internal override Statement Accept(AstVisitor visitor) => visitor.VisitIfChangedStatement(this);
+    }
+}

--- a/Fluid/Ast/IncludeStatement.cs
+++ b/Fluid/Ast/IncludeStatement.cs
@@ -74,6 +74,12 @@ namespace Fluid.Ast
                     throw new ParseException(errors);
                 }
 
+                // Allow user to modify the template before caching (e.g., apply visitors/rewriters)
+                if (context.Options.TemplateParsed != null)
+                {
+                    template = context.Options.TemplateParsed(relativePath, template);
+                }
+
                 context.Options.TemplateCache?.SetTemplate(relativePath, fileInfo.LastModified, template);
             }
 

--- a/Fluid/Ast/MemberExpression.cs
+++ b/Fluid/Ast/MemberExpression.cs
@@ -47,9 +47,16 @@ namespace Fluid.Ast
                     // Check equality as IsNil() is also true for UndefinedValue
                     if (context.Undefined is not null && value == UndefinedValue.Instance)
                     {
+                        if (context.Options.StrictVariables)
+                        {
+                            throw new FluidException($"Undefined variable '{initial.Identifier}'");
+                        }
                         return context.Undefined.Invoke(initial.Identifier);
                     }
-
+                    if (context.Options.StrictVariables)
+                    {
+                        throw new FluidException($"Undefined variable '{initial.Identifier}'");
+                    }
                     return value;
                 }
 
@@ -72,6 +79,10 @@ namespace Fluid.Ast
                 // Stop processing as soon as a member returns nothing
                 if (value.IsNil())
                 {
+                    if (context.Options.StrictVariables)
+                    {
+                        throw new FluidException($"Undefined variable '{_segments[i]}'");
+                    }
                     return value;
                 }
             }

--- a/Fluid/Ast/RenderStatement.cs
+++ b/Fluid/Ast/RenderStatement.cs
@@ -77,6 +77,12 @@ namespace Fluid.Ast
                     throw new ParseException(errors);
                 }
 
+                // Allow user to modify the template before caching (e.g., apply visitors/rewriters)
+                if (context.Options.TemplateParsed != null)
+                {
+                    template = context.Options.TemplateParsed(relativePath, template);
+                }
+
                 context.Options.TemplateCache?.SetTemplate(relativePath, fileInfo.LastModified, template);
             }
 

--- a/Fluid/Ast/RenderStatement.cs
+++ b/Fluid/Ast/RenderStatement.cs
@@ -34,15 +34,28 @@ namespace Fluid.Ast
             context.IncrementSteps();
 
             var relativePath = Path;
-
-            if (!relativePath.EndsWith(ViewExtension, StringComparison.OrdinalIgnoreCase))
-            {
-                relativePath += ViewExtension;
-            }
-
             var fileProvider = context.Options.FileProvider;
 
+            // First, try to get the file with the exact path provided
             var fileInfo = fileProvider.GetFileInfo(relativePath);
+
+            // If the file doesn't exist and a default extension is configured
+            if ((fileInfo == null || !fileInfo.Exists || fileInfo.IsDirectory) && !string.IsNullOrEmpty(context.Options.DefaultFileExtension))
+            {
+                // Check if the path already ends with the default extension
+                if (!relativePath.EndsWith(context.Options.DefaultFileExtension, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Try adding the default extension
+                    var pathWithExtension = relativePath + context.Options.DefaultFileExtension;
+                    var fileInfoWithExtension = fileProvider.GetFileInfo(pathWithExtension);
+
+                    if (fileInfoWithExtension != null && fileInfoWithExtension.Exists && !fileInfoWithExtension.IsDirectory)
+                    {
+                        relativePath = pathWithExtension;
+                        fileInfo = fileInfoWithExtension;
+                    }
+                }
+            }
 
             if (fileInfo == null || !fileInfo.Exists || fileInfo.IsDirectory)
             {

--- a/Fluid/Ast/RenderStatement.cs
+++ b/Fluid/Ast/RenderStatement.cs
@@ -105,11 +105,7 @@ namespace Fluid.Ast
                     // Evaluate assign statements in the new scope if present
                     if (AssignStatements.Count > 0)
                     {
-                        var length = AssignStatements.Count;
-                        for (var i = 0; i < length; i++)
-                        {
-                            await AssignStatements[i].WriteToAsync(writer, encoder, context);
-                        }
+                        await EvaluateAssignStatementsAsync(AssignStatements, context);
                     }
 
                     await template.RenderAsync(writer, encoder, context);
@@ -128,11 +124,7 @@ namespace Fluid.Ast
                         // Evaluate assign statements in the new scope before the loop if present
                         if (AssignStatements.Count > 0)
                         {
-                            var assignLength = AssignStatements.Count;
-                            for (var j = 0; j < assignLength; j++)
-                            {
-                                await AssignStatements[j].WriteToAsync(writer, encoder, context);
-                            }
+                            await EvaluateAssignStatementsAsync(AssignStatements, context);
                         }
 
                         var length = forloop.Length = list.Count;
@@ -169,11 +161,7 @@ namespace Fluid.Ast
                 }
                 else if (AssignStatements.Count > 0)
                 {
-                    var length = AssignStatements.Count;
-                    for (var i = 0; i < length; i++)
-                    {
-                        await AssignStatements[i].WriteToAsync(writer, encoder, context);
-                    }
+                    await EvaluateAssignStatementsAsync(AssignStatements, context);
 
                     context.LocalScope = new Scope(context.RootScope);
                     previousScope.CopyTo(context.LocalScope);
@@ -198,6 +186,33 @@ namespace Fluid.Ast
         }
 
         protected internal override Statement Accept(AstVisitor visitor) => visitor.VisitRenderStatement(this);
+
+        private static async ValueTask EvaluateAssignStatementsAsync(IReadOnlyList<AssignStatement> assignStatements, TemplateContext context)
+        {
+            var length = assignStatements.Count;
+            var evaluatedValues = new KeyValuePair<string, FluidValue>[length];
+
+            for (var i = 0; i < length; i++)
+            {
+                context.IncrementSteps();
+
+                var assignStatement = assignStatements[i];
+                var value = await assignStatement.Value.EvaluateAsync(context);
+
+                if (context.Assigned != null)
+                {
+                    value = await context.Assigned.Invoke(assignStatement.Identifier, value, context);
+                }
+
+                evaluatedValues[i] = new KeyValuePair<string, FluidValue>(assignStatement.Identifier, value);
+            }
+
+            for (var i = 0; i < length; i++)
+            {
+                var entry = evaluatedValues[i];
+                context.SetValue(entry.Key, entry.Value);
+            }
+        }
 
         private sealed record CachedTemplate(IFluidTemplate Template, string Name);
     }

--- a/Fluid/Ast/TableRowStatement.cs
+++ b/Fluid/Ast/TableRowStatement.cs
@@ -1,0 +1,185 @@
+using Fluid.Values;
+using System.Globalization;
+using System.Text.Encodings.Web;
+
+namespace Fluid.Ast
+{
+    /// <summary>
+    /// Generates HTML table rows for every item in an array.
+    /// </summary>
+    public sealed class TableRowStatement : TagStatement
+    {
+        public TableRowStatement(
+            IReadOnlyList<Statement> statements,
+            string identifier,
+            Expression source,
+            Expression limit,
+            Expression offset,
+            Expression cols
+        ) : base(statements)
+        {
+            Identifier = identifier;
+            Source = source;
+            Limit = limit;
+            Offset = offset;
+            Cols = cols;
+        }
+
+        public string Identifier { get; }
+        public Expression Source { get; }
+        public Expression Limit { get; }
+        public Expression Offset { get; }
+        public Expression Cols { get; }
+
+        public override async ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
+        {
+            var evaluatedSource = await Source.EvaluateAsync(context);
+
+            // Empty strings are treated as empty collections
+            if (evaluatedSource.Type == FluidValues.String && string.IsNullOrEmpty(evaluatedSource.ToStringValue()))
+            {
+                return Completion.Normal;
+            }
+
+            IReadOnlyList<FluidValue> source = evaluatedSource is ArrayValue array
+                ? array.Values
+                : evaluatedSource.Enumerate(context).ToList();
+
+            if (source.Count == 0)
+            {
+                return Completion.Normal;
+            }
+
+            // Apply options
+            var startIndex = 0;
+            if (Offset is not null)
+            {
+                startIndex = await EvaluateIntegerArgumentAsync("offset", Offset, context);
+            }
+
+            var count = Math.Max(0, source.Count - startIndex);
+
+            if (Limit is not null)
+            {
+                var limit = await EvaluateIntegerArgumentAsync("limit", Limit, context);
+                if (limit >= 0)
+                {
+                    count = Math.Min(count, limit);
+                }
+            }
+
+            if (count == 0)
+            {
+                return Completion.Normal;
+            }
+
+            // Determine number of columns (defaults to total items if not specified)
+            var cols = count;
+            if (Cols is not null)
+            {
+                cols = await EvaluateIntegerArgumentAsync("cols", Cols, context);
+                if (cols <= 0)
+                {
+                    cols = count;
+                }
+            }
+
+            context.EnterForLoopScope();
+
+            try
+            {
+                var tablerowloop = new TableRowLoopValue(count, cols);
+                context.LocalScope.SetOwnValue("tablerowloop", tablerowloop);
+
+                // Output first row opening
+                writer.Write("<tr class=\"row1\">\n");
+
+                for (var iteration = 0; iteration < count; iteration++)
+                {
+                    context.IncrementSteps();
+
+                    var itemIndex = startIndex + iteration;
+                    var item = source[itemIndex];
+
+                    context.LocalScope.SetOwnValue(Identifier, item);
+
+                    // Output cell opening tag
+                    writer.Write("<td class=\"col");
+                    writer.Write(tablerowloop.Col.ToString(CultureInfo.InvariantCulture));
+                    writer.Write("\">");
+
+                    var completion = Completion.Normal;
+
+                    for (var index = 0; index < Statements.Count; index++)
+                    {
+                        var statement = Statements[index];
+                        completion = await statement.WriteToAsync(writer, encoder, context);
+
+                        if (completion != Completion.Normal)
+                        {
+                            break;
+                        }
+                    }
+
+                    // Output cell closing tag
+                    writer.Write("</td>");
+
+                    if (completion == Completion.Break)
+                    {
+                        break;
+                    }
+
+                    // Handle row transitions
+                    if (tablerowloop.ColLast && !tablerowloop.Last)
+                    {
+                        writer.Write("</tr>\n<tr class=\"row");
+                        writer.Write((tablerowloop.Row + 1).ToString(CultureInfo.InvariantCulture));
+                        writer.Write("\">");
+                    }
+
+                    tablerowloop.Increment();
+
+                    if (completion == Completion.Continue)
+                    {
+                        continue;
+                    }
+                }
+
+                // Output final row closing
+                writer.Write("</tr>\n");
+            }
+            finally
+            {
+                context.ReleaseScope();
+            }
+
+            return Completion.Normal;
+        }
+
+        private static async ValueTask<int> EvaluateIntegerArgumentAsync(string name, Expression expression, TemplateContext context)
+        {
+            var value = await expression.EvaluateAsync(context);
+
+            if (value.Type == FluidValues.Number)
+            {
+                // Use (int) cast to truncate toward zero like Ruby's to_i
+                return (int)value.ToNumberValue();
+            }
+
+            if (value.Type == FluidValues.String)
+            {
+                var s = value.ToStringValue().Trim();
+                if (int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+                {
+                    return parsed;
+                }
+
+                throw new FluidException($"tablerow: {name} is not a number");
+            }
+
+            throw new FluidException($"tablerow: {name} must be a number");
+        }
+
+        protected internal override Statement Accept(AstVisitor visitor) => visitor.VisitTableRowStatement(this);
+    }
+}

--- a/Fluid/Filters/ArrayFilters.cs
+++ b/Fluid/Filters/ArrayFilters.cs
@@ -88,18 +88,30 @@ namespace Fluid.Filters
 
         public static async ValueTask<FluidValue> Map(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            if (input.Type != FluidValues.Array)
+            var member = arguments.At(0);
+
+            if (member.IsNil())
             {
-                return input;
+                return ArrayValue.Empty;
             }
 
-            var member = arguments.At(0).ToStringValue();
+            if (input.IsNil())
+            {
+                return ArrayValue.Empty;
+            }
 
             var list = new List<FluidValue>();
 
-            foreach (var item in input.Enumerate(context))
+            if (input.Type == FluidValues.Array)
             {
-                list.Add(await item.GetValueAsync(member, context));
+                foreach (var item in input.Enumerate(context))
+                {
+                    list.Add(await item.GetIndexAsync(member, context));
+                }
+            }
+            else
+            {
+                list.Add(await input.GetIndexAsync(member, context));
             }
 
             return new ArrayValue(list);

--- a/Fluid/Filters/MiscFilters.cs
+++ b/Fluid/Filters/MiscFilters.cs
@@ -310,12 +310,12 @@ namespace Fluid.Filters
 
         public static ValueTask<FluidValue> Escape(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            return new StringValue(WebUtility.HtmlEncode(input.ToStringValue()));
+            return new StringValue(WebUtility.HtmlEncode(input.ToStringValue()), encode: false);
         }
 
         public static ValueTask<FluidValue> EscapeOnce(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            return new StringValue(WebUtility.HtmlEncode(WebUtility.HtmlDecode(input.ToStringValue())));
+            return new StringValue(WebUtility.HtmlEncode(WebUtility.HtmlDecode(input.ToStringValue())), encode: false);
         }
 
         public static ValueTask<FluidValue> ChangeTimeZone(FluidValue input, FilterArguments arguments, TemplateContext context)

--- a/Fluid/Filters/MoneyFilters.cs
+++ b/Fluid/Filters/MoneyFilters.cs
@@ -1,0 +1,242 @@
+using Fluid.Utils;
+using Fluid.Values;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text;
+
+namespace Fluid.Filters
+{
+    /// <summary>
+    /// Implements the Shopify money filters. They are not registered by default, use
+    /// <see cref="WithMoneyFilters"/> to add them to a <see cref="FilterCollection"/>.
+    /// </summary>
+    public static class MoneyFilters
+    {
+        private const string FallbackCurrency = "USD";
+
+        private static readonly ConcurrentDictionary<string, string> _cultureCurrencies = new(StringComparer.Ordinal);
+
+        private enum MoneyStyle
+        {
+            Money,
+            WithCurrency,
+            WithoutCurrency,
+            WithoutTrailingZeros,
+        }
+
+        /// <summary>
+        /// Registers the <c>money</c>, <c>money_with_currency</c>, <c>money_without_currency</c>
+        /// and <c>money_without_trailing_zeros</c> filters.
+        /// </summary>
+        public static FilterCollection WithMoneyFilters(this FilterCollection filters)
+        {
+            if (filters is null)
+            {
+                ExceptionHelper.ThrowArgumentNullException(nameof(filters));
+            }
+
+            filters.AddFilter("money", Money);
+            filters.AddFilter("money_with_currency", MoneyWithCurrency);
+            filters.AddFilter("money_without_currency", MoneyWithoutCurrency);
+            filters.AddFilter("money_without_trailing_zeros", MoneyWithoutTrailingZeros);
+
+            return filters;
+        }
+
+        /// <summary>
+        /// Formats an amount with its currency symbol, e.g. <c>$10.00</c>.
+        /// </summary>
+        public static ValueTask<FluidValue> Money(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            return Format(input, arguments, context, "money", MoneyStyle.Money);
+        }
+
+        /// <summary>
+        /// Formats an amount with its currency symbol and its currency code, e.g. <c>$10.00 USD</c>.
+        /// </summary>
+        public static ValueTask<FluidValue> MoneyWithCurrency(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            return Format(input, arguments, context, "money_with_currency", MoneyStyle.WithCurrency);
+        }
+
+        /// <summary>
+        /// Formats an amount without its currency symbol, e.g. <c>10.00</c>.
+        /// </summary>
+        public static ValueTask<FluidValue> MoneyWithoutCurrency(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            return Format(input, arguments, context, "money_without_currency", MoneyStyle.WithoutCurrency);
+        }
+
+        /// <summary>
+        /// Formats an amount with its currency symbol, omitting the decimal separator and the
+        /// decimal digits when they are all zeros, e.g. <c>$10</c>.
+        /// </summary>
+        public static ValueTask<FluidValue> MoneyWithoutTrailingZeros(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            return Format(input, arguments, context, "money_without_trailing_zeros", MoneyStyle.WithoutTrailingZeros);
+        }
+
+        private static StringValue Format(FluidValue input, FilterArguments arguments, TemplateContext context, string filterName, MoneyStyle style)
+        {
+            if (arguments.Count > 1)
+            {
+                throw new FluidException($"Filter '{filterName}' expects at most one argument.");
+            }
+
+            if (input == null || input.IsNil() || input.Type == FluidValues.Blank || input.Type == FluidValues.Empty)
+            {
+                return StringValue.Empty;
+            }
+
+            var options = context.MoneyOptions ?? TemplateOptions.Default.MoneyOptions;
+            var culture = context.CultureInfo ?? CultureInfo.InvariantCulture;
+
+            var amount = input.ToNumberValue();
+
+            if (options.AmountsInCents)
+            {
+                amount /= 100M;
+            }
+
+            var currency = ResolveCurrency(arguments, options, culture);
+            var numberFormat = options.GetNumberFormat(culture, currency);
+
+            switch (style)
+            {
+                case MoneyStyle.WithoutCurrency:
+                    // The amount is rendered on its own, the configured formats always contain a currency symbol.
+                    return new StringValue(Round(amount, currency.DecimalDigits).ToString("N", numberFormat));
+
+                case MoneyStyle.WithoutTrailingZeros:
+                    var rounded = Round(amount, currency.DecimalDigits);
+                    var noDecimals = rounded % 1M == 0M;
+                    return new StringValue(FormatAmount(rounded, currency, numberFormat, options.ParsedMoneyFormat, noDecimals));
+
+                case MoneyStyle.WithCurrency:
+                    return new StringValue(FormatWithCurrency(amount, currency, numberFormat, options));
+
+                default:
+                    return new StringValue(FormatAmount(amount, currency, numberFormat, options.ParsedMoneyFormat, noDecimals: false));
+            }
+        }
+
+        private static string FormatWithCurrency(decimal amount, MoneyCurrency currency, NumberFormatInfo numberFormat, MoneyOptions options)
+        {
+            var template = options.ParsedMoneyWithCurrencyFormat;
+
+            if (template != null)
+            {
+                return Render(template, amount, currency, noDecimals: false);
+            }
+
+            // No dedicated format: append the currency code to the regular money format.
+            var money = FormatAmount(amount, currency, numberFormat, options.ParsedMoneyFormat, noDecimals: false);
+
+            var builder = new ValueStringBuilder(stackalloc char[64]);
+            builder.Append(money);
+            builder.Append(' ');
+            builder.Append(currency.Code);
+
+            return builder.ToString();
+        }
+
+        private static string FormatAmount(decimal amount, MoneyCurrency currency, NumberFormatInfo numberFormat, MoneyFormatTemplate template, bool noDecimals)
+        {
+            if (template != null)
+            {
+                return Render(template, amount, currency, noDecimals);
+            }
+
+            var digits = noDecimals ? 0 : currency.DecimalDigits;
+
+            return Round(amount, digits).ToString(noDecimals ? "C0" : "C", numberFormat);
+        }
+
+        private static string Render(MoneyFormatTemplate template, decimal amount, MoneyCurrency currency, bool noDecimals)
+        {
+            var builder = new ValueStringBuilder(stackalloc char[64]);
+            template.Render(ref builder, amount, currency, noDecimals);
+
+            return builder.ToString();
+        }
+
+        private static decimal Round(decimal amount, int digits)
+        {
+            // Shopify rounds half up, whereas .NET rounds half to even by default.
+            return Math.Round(amount, digits, MidpointRounding.AwayFromZero);
+        }
+
+        private static MoneyCurrency ResolveCurrency(FilterArguments arguments, MoneyOptions options, CultureInfo culture)
+        {
+            var argument = arguments["currency"];
+
+            if (argument.IsNil())
+            {
+                argument = arguments.At(0);
+            }
+
+            var code = argument.IsNil() ? null : argument.ToStringValue();
+
+            if (string.IsNullOrEmpty(code))
+            {
+                code = options.Currency;
+            }
+
+            if (string.IsNullOrEmpty(code))
+            {
+                code = GetCultureCurrency(culture);
+            }
+
+            if (options.Currencies.TryGetValue(code, out var currency))
+            {
+                return currency;
+            }
+
+            // An unknown currency is rendered with its code as the symbol.
+            return new MoneyCurrency(code, code, culture.NumberFormat.CurrencyDecimalDigits);
+        }
+
+        private static string GetCultureCurrency(CultureInfo culture)
+        {
+            var name = culture.Name;
+
+            if (string.IsNullOrEmpty(name))
+            {
+                // The invariant culture has no region, and its currency symbol is the generic '¤' sign.
+                return FallbackCurrency;
+            }
+
+            if (_cultureCurrencies.TryGetValue(name, out var code))
+            {
+                return code;
+            }
+
+            code = FindCultureCurrency(culture);
+            _cultureCurrencies[name] = code;
+
+            return code;
+        }
+
+        private static string FindCultureCurrency(CultureInfo culture)
+        {
+            try
+            {
+                return new RegionInfo(culture.Name).ISOCurrencySymbol;
+            }
+            catch (ArgumentException)
+            {
+                // Neutral cultures like 'de' have no region, resolve the specific culture first.
+            }
+
+            try
+            {
+                return new RegionInfo(CultureInfo.CreateSpecificCulture(culture.Name).Name).ISOCurrencySymbol;
+            }
+            catch (ArgumentException)
+            {
+                // CultureNotFoundException derives from ArgumentException.
+                return FallbackCurrency;
+            }
+        }
+    }
+}

--- a/Fluid/Filters/StringFilters.cs
+++ b/Fluid/Filters/StringFilters.cs
@@ -8,6 +8,13 @@ namespace Fluid.Filters
         private static readonly StringValue Ellipsis = new StringValue(EllipsisString);
         private static readonly NumberValue DefaultTruncateLength = NumberValue.Create(50);
 
+        private static StringValue CreateStringValue(string value, FluidValue input)
+        {
+            return input is StringValue stringValue
+                ? new StringValue(value, stringValue.Encode)
+                : new StringValue(value);
+        }
+
         public static FilterCollection WithStringFilters(this FilterCollection filters)
         {
             filters.AddFilter("append", Append);
@@ -36,7 +43,7 @@ namespace Fluid.Filters
 
         public static ValueTask<FluidValue> Append(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            return new StringValue(input.ToStringValue() + arguments.At(0).ToStringValue());
+            return CreateStringValue(input.ToStringValue() + arguments.At(0).ToStringValue(), input);
         }
 
         public static ValueTask<FluidValue> Capitalize(FluidValue input, FilterArguments arguments, TemplateContext context)
@@ -52,32 +59,34 @@ namespace Fluid.Filters
                 }
             }
 
-            return new StringValue(new string(source));
+            return CreateStringValue(new string(source), input);
         }
 
         public static ValueTask<FluidValue> Downcase(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            return new StringValue(input.ToStringValue().ToLower(context.CultureInfo));
+            return CreateStringValue(input.ToStringValue().ToLower(context.CultureInfo), input);
         }
 
         public static ValueTask<FluidValue> LStrip(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            return new StringValue(input.ToStringValue().TrimStart());
+            return CreateStringValue(input.ToStringValue().TrimStart(), input);
         }
 
         public static ValueTask<FluidValue> RStrip(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            return new StringValue(input.ToStringValue().TrimEnd());
+            return CreateStringValue(input.ToStringValue().TrimEnd(), input);
         }
 
         public static ValueTask<FluidValue> NewLineToBr(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            return new StringValue(input.ToStringValue().Replace("\r\n", "<br />").Replace("\n", "<br />"));
+            return CreateStringValue(input.ToStringValue()
+                .Replace("\r\n", "<br />")
+                .Replace("\n", "<br />"), input);
         }
 
         public static ValueTask<FluidValue> Prepend(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            return new StringValue(arguments.At(0).ToStringValue() + input.ToStringValue());
+            return CreateStringValue(arguments.At(0).ToStringValue() + input.ToStringValue(), input);
         }
 
         public static ValueTask<FluidValue> RemoveFirst(FluidValue input, FilterArguments arguments, TemplateContext context)
@@ -89,7 +98,7 @@ namespace Fluid.Filters
 
             if (index != -1)
             {
-                return new StringValue(value.Remove(index, remove.Length));
+                return CreateStringValue(value.Remove(index, remove.Length), input);
             }
 
             return input;
@@ -101,10 +110,10 @@ namespace Fluid.Filters
 
             if (String.IsNullOrEmpty(argument))
             {
-                return new StringValue(input.ToStringValue());
+                return CreateStringValue(input.ToStringValue(), input);
             }
 
-            return new StringValue(input.ToStringValue().Replace(argument, ""));
+            return CreateStringValue(input.ToStringValue().Replace(argument, ""), input);
         }
 
         public static ValueTask<FluidValue> RemoveLast(FluidValue input, FilterArguments arguments, TemplateContext context)
@@ -116,7 +125,7 @@ namespace Fluid.Filters
 
             if (index != -1)
             {
-                return new StringValue(value.Remove(index, remove.Length));
+                return CreateStringValue(value.Remove(index, remove.Length), input);
             }
 
             return input;
@@ -143,12 +152,14 @@ namespace Fluid.Filters
 #else
             var concat = string.Concat(value.Substring(0, index), arguments.At(1).ToStringValue(), value.Substring(index + remove.Length));
 #endif
-            return new StringValue(concat);
+            return CreateStringValue(concat, input);
         }
 
         public static ValueTask<FluidValue> Replace(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            return new StringValue(input.ToStringValue().Replace(arguments.At(0).ToStringValue(), arguments.At(1).ToStringValue()));
+            return CreateStringValue(
+                input.ToStringValue().Replace(arguments.At(0).ToStringValue(), arguments.At(1).ToStringValue()),
+                input);
         }
 
         public static ValueTask<FluidValue> ReplaceLast(FluidValue input, FilterArguments arguments, TemplateContext context)
@@ -172,7 +183,7 @@ namespace Fluid.Filters
 #else
             var concat = string.Concat(value.Substring(0, index), arguments.At(1).ToStringValue(), value.Substring(index + remove.Length));
 #endif
-            return new StringValue(concat);
+            return CreateStringValue(concat, input);
         }
 
         public static ValueTask<FluidValue> Slice(FluidValue input, FilterArguments arguments, TemplateContext context)
@@ -236,7 +247,7 @@ namespace Fluid.Filters
                     ? sourceStringLength - startIndex
                     : requestedLength;
 
-                return new StringValue(sourceString.Substring(startIndex, length));
+                return CreateStringValue(sourceString.Substring(startIndex, length), input);
             }
         }
 
@@ -272,7 +283,7 @@ namespace Fluid.Filters
 
         public static ValueTask<FluidValue> Strip(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            return new StringValue(input.ToStringValue().Trim());
+            return CreateStringValue(input.ToStringValue().Trim(), input);
         }
 
         public static ValueTask<FluidValue> StripNewLines(FluidValue input, FilterArguments arguments, TemplateContext context)
@@ -288,7 +299,7 @@ namespace Fluid.Filters
                 result = result.Replace("\n", "");
             }
 
-            return new StringValue(result);
+            return CreateStringValue(result, input);
         }
 
         public static ValueTask<FluidValue> Truncate(FluidValue input, FilterArguments arguments, TemplateContext context)
@@ -321,7 +332,7 @@ namespace Fluid.Filters
 #else
             var concat = string.Concat(inputStr.Substring(0, l), ellipsisStr);
 #endif
-            return new StringValue(concat);
+            return CreateStringValue(concat, input);
         }
 
         public static ValueTask<FluidValue> TruncateWords(FluidValue input, FilterArguments arguments, TemplateContext context)
@@ -355,12 +366,12 @@ namespace Fluid.Filters
                 chunks[^1] += ellipsis;
             }
 
-            return new StringValue(string.Join(" ", chunks));
+            return CreateStringValue(string.Join(" ", chunks), input);
         }
 
         public static ValueTask<FluidValue> Upcase(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            return new StringValue(input.ToStringValue().ToUpper(context.CultureInfo));
+            return CreateStringValue(input.ToStringValue().ToUpper(context.CultureInfo), input);
         }
     }
 }

--- a/Fluid/Filters/StringFilters.cs
+++ b/Fluid/Filters/StringFilters.cs
@@ -50,13 +50,9 @@ namespace Fluid.Filters
         {
             var source = input.ToStringValue().ToCharArray();
 
-            for (var i = 0; i < source.Length; i++)
+            if (source.Length > 0 && char.IsLetter(source[0]))
             {
-                char c;
-                if (i == 0 || char.IsWhiteSpace(c = source[i - 1]) || c == '-' || c == '.')
-                {
-                    source[i] = char.ToUpper(source[i], context.CultureInfo);
-                }
+                source[0] = char.ToUpper(source[0], context.CultureInfo);
             }
 
             return CreateStringValue(new string(source), input);

--- a/Fluid/Fluid.csproj
+++ b/Fluid/Fluid.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <IsPackable>true</IsPackable>
@@ -49,6 +49,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net9.0'">
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net10.0'">
   </ItemGroup>
 
   <PropertyGroup>

--- a/Fluid/FluidException.cs
+++ b/Fluid/FluidException.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Fluid
+{
+    /// <summary>
+    /// Represents errors that occur during Fluid template parsing or rendering.
+    /// </summary>
+    public class FluidException : Exception
+    {
+        public FluidException() { }
+
+        /// <inheritdoc/>
+        public FluidException(string message) : base(message) { }
+
+        /// <inheritdoc/>
+        public FluidException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/Fluid/FluidParser.cs
+++ b/Fluid/FluidParser.cs
@@ -78,6 +78,7 @@ namespace Fluid
 
         protected static readonly LiteralExpression EmptyKeyword = new LiteralExpression(EmptyValue.Instance);
         protected static readonly LiteralExpression BlankKeyword = new LiteralExpression(BlankValue.Instance);
+        protected static readonly LiteralExpression NilKeyword = new LiteralExpression(NilValue.Instance);
         protected static readonly LiteralExpression TrueKeyword = new LiteralExpression(BooleanValue.True);
         protected static readonly LiteralExpression FalseKeyword = new LiteralExpression(BooleanValue.False);
 
@@ -163,6 +164,8 @@ namespace Fluid
                         {
                             case "empty": return EmptyKeyword;
                             case "blank": return BlankKeyword;
+                            case "nil": return NilKeyword; // Both nil and null are supported for convenience
+                            case "null": return NilKeyword;
                             case "true": return TrueKeyword;
                             case "false": return FalseKeyword;
                         }

--- a/Fluid/FluidParser.cs
+++ b/Fluid/FluidParser.cs
@@ -490,6 +490,49 @@ namespace Fluid
                         ).ElseError("Invalid 'for' tag");
             ForTag.Name = "ForTag";
 
+            var TableRowTag = OneOf(
+                            Identifier
+                            .AndSkip(Terms.Text("in"))
+                            .And(Member)
+                            .And(ZeroOrMany(OneOf(
+                                Terms.Text("cols").SkipAnd(Colon).SkipAnd(Primary).Then(x => new TableRowModifier { IsCols = true, Value = x }),
+                                Terms.Text("limit").SkipAnd(Colon).SkipAnd(Primary).Then(x => new TableRowModifier { IsLimit = true, Value = x }),
+                                Terms.Text("offset").SkipAnd(Colon).SkipAnd(Primary).Then(x => new TableRowModifier { IsOffset = true, Value = x })
+                                )))
+                            .AndSkip(TagEnd)
+                            .And(AnyTagsList)
+                            .AndSkip(CreateTag("endtablerow").ElseError($"'{{% endtablerow %}}' was expected"))
+                            .Then<Statement>(x =>
+                            {
+                                var identifier = x.Item1;
+                                var member = x.Item2;
+                                var statements = x.Item4;
+                                var (colsResult, limitResult, offsetResult) = ReadTableRowStatementConfiguration(x.Item3);
+                                return new TableRowStatement(statements, identifier, member, limitResult, offsetResult, colsResult);
+                            }),
+
+                            Identifier
+                            .AndSkip(Terms.Text("in"))
+                            .And(Range)
+                            .And(ZeroOrMany(OneOf(
+                                Terms.Text("cols").SkipAnd(Colon).SkipAnd(Primary).Then(x => new TableRowModifier { IsCols = true, Value = x }),
+                                Terms.Text("limit").SkipAnd(Colon).SkipAnd(Primary).Then(x => new TableRowModifier { IsLimit = true, Value = x }),
+                                Terms.Text("offset").SkipAnd(Colon).SkipAnd(Primary).Then(x => new TableRowModifier { IsOffset = true, Value = x })
+                                )))
+                            .AndSkip(TagEnd)
+                            .And(AnyTagsList)
+                            .AndSkip(CreateTag("endtablerow").ElseError($"'{{% endtablerow %}}' was expected"))
+                            .Then<Statement>(x =>
+                            {
+                                var identifier = x.Item1;
+                                var range = x.Item2;
+                                var statements = x.Item4;
+                                var (colsResult, limitResult, offsetResult) = ReadTableRowStatementConfiguration(x.Item3);
+                                return new TableRowStatement(statements, identifier, range, limitResult, offsetResult, colsResult);
+                            })
+                        ).ElseError("Invalid 'tablerow' tag");
+            TableRowTag.Name = "TableRowTag";
+
             var LiquidTag = Literals.WhiteSpace(true) // {% liquid %} can start with new lines
                 .Then((context, x) => { ((FluidParseContext)context).InsideLiquidTag = true; return x; })
                 .SkipAnd(OneOrMany(OneOf(
@@ -535,6 +578,7 @@ namespace Fluid
             RegisteredTags["unless"] = UnlessTag;
             RegisteredTags["case"] = CaseTag;
             RegisteredTags["for"] = ForTag;
+            RegisteredTags["tablerow"] = TableRowTag;
             RegisteredTags["liquid"] = LiquidTag;
             RegisteredTags["echo"] = EchoTag;
 
@@ -577,6 +621,44 @@ namespace Fluid
                     return (limitResult, offsetResult, reversed);
                 }
 
+
+                return ReadFromList(modifiers);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            static (Expression colsResult, Expression limitResult, Expression offsetResult) ReadTableRowStatementConfiguration(IReadOnlyList<TableRowModifier> modifiers)
+            {
+                if (modifiers.Count == 0)
+                {
+                    return (null, null, null);
+                }
+
+                static (Expression colsResult, Expression limitResult, Expression offsetResult) ReadFromList(IReadOnlyList<TableRowModifier> modifiers)
+                {
+                    Expression colsResult = null;
+                    Expression limitResult = null;
+                    Expression offsetResult = null;
+                    for (var i = modifiers.Count - 1; i > -1; --i)
+                    {
+                        var l = modifiers[i];
+                        if (l.IsCols && colsResult is null)
+                        {
+                            colsResult = l.Value;
+                        }
+
+                        if (l.IsLimit && limitResult is null)
+                        {
+                            limitResult = l.Value;
+                        }
+
+                        if (l.IsOffset && offsetResult is null)
+                        {
+                            offsetResult = l.Value;
+                        }
+                    }
+
+                    return (colsResult, limitResult, offsetResult);
+                }
 
                 return ReadFromList(modifiers);
             }

--- a/Fluid/FluidParser.cs
+++ b/Fluid/FluidParser.cs
@@ -345,6 +345,14 @@ namespace Fluid
                         ;
             CycleTag.Name = "CycleTag";
 
+            var IfChangedTag = TagEnd
+                        .And(AnyTagsList)
+                        .AndSkip(CreateTag("endifchanged").ElseError($"'{{% endifchanged %}}' was expected"))
+                        .Then<Statement>(x => new IfChangedStatement(x.Item2))
+                        .ElseError("Invalid 'ifchanged' tag")
+                        ;
+            IfChangedTag.Name = "IfChangedTag";
+
             var DecrementTag = ZeroOrOne(Identifier).AndSkip(TagEnd)
                         .Then<Statement>(x => new DecrementStatement(x))
                         .ElseError("Invalid 'decrement' tag")
@@ -569,6 +577,7 @@ namespace Fluid
             RegisteredTags["capture"] = CaptureTag;
             RegisteredTags["cycle"] = CycleTag;
             RegisteredTags["decrement"] = DecrementTag;
+            RegisteredTags["ifchanged"] = IfChangedTag;
             RegisteredTags["include"] = IncludeTag;
             RegisteredTags["render"] = RenderTag;
             RegisteredTags["increment"] = IncrementTag;

--- a/Fluid/ITemplateOptionsMemberAccessorRegistrar.cs
+++ b/Fluid/ITemplateOptionsMemberAccessorRegistrar.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel;
+
+namespace Fluid
+{
+    /// <summary>
+    /// Registers source-generated member accessors for a <see cref="TemplateOptions"/> instance.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public interface ITemplateOptionsMemberAccessorRegistrar
+    {
+        /// <summary>
+        /// Registers source-generated member accessors for the specified <see cref="TemplateOptions"/> instance.
+        /// </summary>
+        /// <param name="options">The options instance to register accessors on.</param>
+        void RegisterMemberAccessors(TemplateOptions options);
+    }
+}

--- a/Fluid/MemberAccessStrategyExtensions.cs
+++ b/Fluid/MemberAccessStrategyExtensions.cs
@@ -1,5 +1,8 @@
 ﻿using Fluid.Accessors;
 using System.Collections.Concurrent;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -7,6 +10,12 @@ namespace Fluid
 {
     public static class MemberAccessStrategyExtensions
     {
+#if NET5_0_OR_GREATER
+        private const DynamicallyAccessedMemberTypes RegisteredMemberTypes = DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicMethods;
+#endif
+
+        private static readonly bool _dynamicCodeSupported = IsDynamicCodeSupported();
+
         // A cache of accessors so we don't rebuild them once they are added to global or contextual access strategies
         internal static ConcurrentDictionary<(Type Type, MemberNameStrategy MemberNameStrategy), Dictionary<string, IMemberAccessor>> _typeMembers = new ConcurrentDictionary<(Type, MemberNameStrategy), Dictionary<string, IMemberAccessor>>();
 
@@ -41,7 +50,9 @@ namespace Fluid
                     }
                     else
                     {
-                        list[memberNameStrategy(propertyInfo)] = new PropertyInfoAccessor(propertyInfo);
+                        list[memberNameStrategy(propertyInfo)] = _dynamicCodeSupported
+                            ? new PropertyInfoAccessor(propertyInfo)
+                            : new ReflectionPropertyInfoAccessor(propertyInfo);
                     }
                 }
 
@@ -58,7 +69,9 @@ namespace Fluid
                     }
                     else
                     {
-                        list[memberNameStrategy(fieldInfo)] = new DelegateAccessor((o, n) => fieldInfo.GetValue(o));
+                        list[memberNameStrategy(fieldInfo)] = _dynamicCodeSupported
+                            ? new DelegateAccessor((o, n) => fieldInfo.GetValue(o))
+                            : new ReflectionFieldInfoAccessor(fieldInfo);
                     }
                 }
 
@@ -84,7 +97,11 @@ namespace Fluid
         /// </summary>
         /// <typeparam name="T">The type to register.</typeparam>
         /// <param name="strategy">The <see cref="MemberAccessStrategy"/>.</param>
+#if NET5_0_OR_GREATER
+        public static void Register<[DynamicallyAccessedMembers(RegisteredMemberTypes)] T>(this MemberAccessStrategy strategy)
+#else
         public static void Register<T>(this MemberAccessStrategy strategy)
+#endif
         {
             Register(strategy, typeof(T));
         }
@@ -94,7 +111,11 @@ namespace Fluid
         /// </summary>
         /// <param name="strategy">The <see cref="MemberAccessStrategy"/>.</param>
         /// <param name="type">The type to register.</param>
+#if NET5_0_OR_GREATER
+        public static void Register(this MemberAccessStrategy strategy, [DynamicallyAccessedMembers(RegisteredMemberTypes)] Type type)
+#else
         public static void Register(this MemberAccessStrategy strategy, Type type)
+#endif
         {
             strategy.Register(type, GetTypeMembers(type, strategy.MemberNameStrategy));
         }
@@ -105,7 +126,11 @@ namespace Fluid
         /// <typeparam name="T">The type to register.</typeparam>
         /// <param name="strategy">The <see cref="MemberAccessStrategy"/>.</param>
         /// <param name="names">The names of the properties in the type to register.</param>
+#if NET5_0_OR_GREATER
+        public static void Register<[DynamicallyAccessedMembers(RegisteredMemberTypes)] T>(this MemberAccessStrategy strategy, params string[] names)
+#else
         public static void Register<T>(this MemberAccessStrategy strategy, params string[] names)
+#endif
         {
             strategy.Register(typeof(T), names);
         }
@@ -116,7 +141,11 @@ namespace Fluid
         /// <typeparam name="T">The type to register.</typeparam>
         /// <param name="strategy">The <see cref="MemberAccessStrategy"/>.</param>
         /// <param name="names">The property's expressions in the type to register.</param>
+#if NET5_0_OR_GREATER
+        public static void Register<[DynamicallyAccessedMembers(RegisteredMemberTypes)] T>(this MemberAccessStrategy strategy, params Expression<Func<T, object>>[] names)
+#else
         public static void Register<T>(this MemberAccessStrategy strategy, params Expression<Func<T, object>>[] names)
+#endif
         {
             strategy.Register<T>(names.Select(ExpressionHelper.GetPropertyName).ToArray());
         }
@@ -127,7 +156,11 @@ namespace Fluid
         /// <param name="strategy">The <see cref="MemberAccessStrategy"/>.</param>
         /// <param name="type">The type to register.</param>
         /// <param name="names">The names of the properties in the type to register.</param>
+#if NET5_0_OR_GREATER
+        public static void Register(this MemberAccessStrategy strategy, [DynamicallyAccessedMembers(RegisteredMemberTypes)] Type type, params string[] names)
+#else
         public static void Register(this MemberAccessStrategy strategy, Type type, params string[] names)
+#endif
         {
             var accessors = new Dictionary<string, IMemberAccessor>();
 
@@ -139,6 +172,34 @@ namespace Fluid
             strategy.Register(type, accessors);
         }
 
+        private static bool IsDynamicCodeSupported()
+        {
+#if NETSTANDARD2_0
+            var runtimeFeatureType = Type.GetType("System.Runtime.CompilerServices.RuntimeFeature, System.Runtime");
+            var property = runtimeFeatureType?.GetProperty("IsDynamicCodeSupported", BindingFlags.Public | BindingFlags.Static);
+
+            return property?.PropertyType != typeof(bool) || (bool)property.GetValue(null);
+#else
+            return System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported;
+#endif
+        }
+
+        /// <summary>
+        /// Registers a named property when accessing a type using an <see cref="IMemberAccessor"/>.
+        /// </summary>
+        /// <param name="strategy">The <see cref="MemberAccessStrategy"/>.</param>
+        /// <param name="type">The type to register.</param>
+        /// <param name="name">The name of the property to intercept.</param>
+        /// <param name="getter">The accessor used to retrieve the value.</param>
+#if NET5_0_OR_GREATER
+        public static void Register(this MemberAccessStrategy strategy, [DynamicallyAccessedMembers(RegisteredMemberTypes)] Type type, string name, IMemberAccessor getter)
+#else
+        public static void Register(this MemberAccessStrategy strategy, Type type, string name, IMemberAccessor getter)
+#endif
+        {
+            strategy.Register(type, [new KeyValuePair<string, IMemberAccessor>(name, getter)]);
+        }
+
         /// <summary>
         /// Registers a named property when accessing a type using a <see cref="IMemberAccessor"/>
         /// to retrieve the value. The name of the property doesn't have to exist on the object.
@@ -147,7 +208,11 @@ namespace Fluid
         /// <param name="strategy">The <see cref="MemberAccessStrategy"/>.</param>
         /// <param name="name">The name of the property to intercept.</param>
         /// <param name="getter">The <see cref="IMemberAccessor"/> instance used to retrieve the value.</param>
+#if NET5_0_OR_GREATER
+        public static void Register<[DynamicallyAccessedMembers(RegisteredMemberTypes)] T>(this MemberAccessStrategy strategy, string name, IMemberAccessor getter)
+#else
         public static void Register<T>(this MemberAccessStrategy strategy, string name, IMemberAccessor getter)
+#endif
         {
             strategy.Register(typeof(T), [new KeyValuePair<string, IMemberAccessor>(name, getter)]);
         }
@@ -159,7 +224,11 @@ namespace Fluid
         /// <typeparam name="T">The type to register.</typeparam>
         /// <param name="strategy">The <see cref="MemberAccessStrategy"/>.</param>
         /// <param name="getter">The <see cref="IMemberAccessor"/> instance used to retrieve the value.</param>
+#if NET5_0_OR_GREATER
+        public static void Register<[DynamicallyAccessedMembers(RegisteredMemberTypes)] T>(this MemberAccessStrategy strategy, IMemberAccessor getter)
+#else
         public static void Register<T>(this MemberAccessStrategy strategy, IMemberAccessor getter)
+#endif
         {
             strategy.Register(typeof(T), [new KeyValuePair<string, IMemberAccessor>("*", getter)]);
         }
@@ -171,7 +240,11 @@ namespace Fluid
         /// <param name="strategy">The <see cref="MemberAccessStrategy"/>.</param>
         /// <param name="type">The type to register.</param>
         /// <param name="getter">The <see cref="IMemberAccessor"/> instance used to retrieve the value.</param>
+#if NET5_0_OR_GREATER
+        public static void Register(this MemberAccessStrategy strategy, [DynamicallyAccessedMembers(RegisteredMemberTypes)] Type type, IMemberAccessor getter)
+#else
         public static void Register(this MemberAccessStrategy strategy, Type type, IMemberAccessor getter)
+#endif
         {
             strategy.Register(type, [new KeyValuePair<string, IMemberAccessor>("*", getter)]);
         }
@@ -184,7 +257,11 @@ namespace Fluid
         /// <typeparam name="TResult">The type to return.</typeparam>
         /// <param name="strategy">The <see cref="MemberAccessStrategy"/> to register.</param>
         /// <param name="accessor">The <see cref="T:Func{T, string, TResult}"/> instance used to retrieve the value.</param>
+#if NET5_0_OR_GREATER
+        public static void Register<[DynamicallyAccessedMembers(RegisteredMemberTypes)] T, TResult>(this MemberAccessStrategy strategy, Func<T, string, TResult> accessor)
+#else
         public static void Register<T, TResult>(this MemberAccessStrategy strategy, Func<T, string, TResult> accessor)
+#endif
         {
             Register<T, TResult>(strategy, (obj, name, ctx) => accessor(obj, name));
         }
@@ -197,7 +274,11 @@ namespace Fluid
         /// <typeparam name="TResult">The type to return.</typeparam>
         /// <param name="strategy">The <see cref="MemberAccessStrategy"/>.</param>
         /// <param name="accessor">The <see cref="T:Func{T, string, TemplateContext, TResult}"/> instance used to retrieve the value.</param>
+#if NET5_0_OR_GREATER
+        public static void Register<[DynamicallyAccessedMembers(RegisteredMemberTypes)] T, TResult>(this MemberAccessStrategy strategy, Func<T, string, TemplateContext, TResult> accessor)
+#else
         public static void Register<T, TResult>(this MemberAccessStrategy strategy, Func<T, string, TemplateContext, TResult> accessor)
+#endif
         {
             strategy.Register(typeof(T), [new KeyValuePair<string, IMemberAccessor>("*", new DelegateAccessor<T, TResult>(accessor))]);
         }
@@ -208,7 +289,11 @@ namespace Fluid
         /// </summary>
         /// <param name="strategy">The <see cref="MemberAccessStrategy"/>.</param>
         /// <param name="accessor">The <see cref="T:Func{T, string, Task{Object}}"/> instance used to retrieve the value.</param>
+#if NET5_0_OR_GREATER
+        public static void Register<[DynamicallyAccessedMembers(RegisteredMemberTypes)] T, TResult>(this MemberAccessStrategy strategy, Func<T, string, Task<TResult>> accessor)
+#else
         public static void Register<T, TResult>(this MemberAccessStrategy strategy, Func<T, string, Task<TResult>> accessor)
+#endif
         {
             Register<T, TResult>(strategy, (obj, name, ctx) => accessor(obj, name));
         }
@@ -219,7 +304,11 @@ namespace Fluid
         /// </summary>
         /// <param name="strategy">The <see cref="MemberAccessStrategy"/>.</param>
         /// <param name="accessor">The <see cref="T:Func{T, string, TemplateContext, Task{TResult}}"/> instance used to retrieve the value.</param>
+#if NET5_0_OR_GREATER
+        public static void Register<[DynamicallyAccessedMembers(RegisteredMemberTypes)] T, TResult>(this MemberAccessStrategy strategy, Func<T, string, TemplateContext, Task<TResult>> accessor)
+#else
         public static void Register<T, TResult>(this MemberAccessStrategy strategy, Func<T, string, TemplateContext, Task<TResult>> accessor)
+#endif
         {
             strategy.Register(typeof(T), [new KeyValuePair<string, IMemberAccessor>("*", new AsyncDelegateAccessor<T, TResult>(accessor))]);
         }
@@ -230,7 +319,11 @@ namespace Fluid
         /// <param name="strategy">The <see cref="MemberAccessStrategy"/>.</param>
         /// <param name="name">The name of the property.</param>
         /// <param name="accessor">The <see cref="T:Func{T, Task{TResult}}"/> instance used to retrieve the value.</param>
+#if NET5_0_OR_GREATER
+        public static void Register<[DynamicallyAccessedMembers(RegisteredMemberTypes)] T, TResult>(this MemberAccessStrategy strategy, string name, Func<T, Task<TResult>> accessor)
+#else
         public static void Register<T, TResult>(this MemberAccessStrategy strategy, string name, Func<T, Task<TResult>> accessor)
+#endif
         {
             Register<T, TResult>(strategy, name, (obj, ctx) => accessor(obj));
         }
@@ -241,7 +334,11 @@ namespace Fluid
         /// <param name="strategy">The <see cref="MemberAccessStrategy"/>.</param>
         /// <param name="name">The name of the property.</param>
         /// <param name="accessor">The <see cref="T:Func{T, TemplateContext, Task{Object}}"/> instance used to retrieve the value.</param>
+#if NET5_0_OR_GREATER
+        public static void Register<[DynamicallyAccessedMembers(RegisteredMemberTypes)] T, TResult>(this MemberAccessStrategy strategy, string name, Func<T, TemplateContext, Task<TResult>> accessor)
+#else
         public static void Register<T, TResult>(this MemberAccessStrategy strategy, string name, Func<T, TemplateContext, Task<TResult>> accessor)
+#endif
         {
             strategy.Register(typeof(T), [new KeyValuePair<string, IMemberAccessor>(name, new AsyncDelegateAccessor<T, TResult>((obj, propertyName, ctx) => accessor(obj, ctx)))]);
         }
@@ -252,7 +349,11 @@ namespace Fluid
         /// <param name="strategy">The <see cref="MemberAccessStrategy"/>.</param>
         /// <param name="name">The name of the property.</param>
         /// <param name="accessor">The <see cref="Func{T, TResult}"/> instance used to retrieve the value.</param>
+#if NET5_0_OR_GREATER
+        public static void Register<[DynamicallyAccessedMembers(RegisteredMemberTypes)] T, TResult>(this MemberAccessStrategy strategy, string name, Func<T, TResult> accessor)
+#else
         public static void Register<T, TResult>(this MemberAccessStrategy strategy, string name, Func<T, TResult> accessor)
+#endif
         {
             Register<T, TResult>(strategy, name, (obj, ctx) => accessor(obj));
         }
@@ -263,7 +364,11 @@ namespace Fluid
         /// <param name="strategy">The <see cref="MemberAccessStrategy"/>.</param>
         /// <param name="name">The name of the property.</param>
         /// <param name="accessor">The <see cref="Func{T, TemplateContext, TResult}"/> instance used to retrieve the value.</param>
+#if NET5_0_OR_GREATER
+        public static void Register<[DynamicallyAccessedMembers(RegisteredMemberTypes)] T, TResult>(this MemberAccessStrategy strategy, string name, Func<T, TemplateContext, TResult> accessor)
+#else
         public static void Register<T, TResult>(this MemberAccessStrategy strategy, string name, Func<T, TemplateContext, TResult> accessor)
+#endif
         {
             strategy.Register(typeof(T), [new KeyValuePair<string, IMemberAccessor>(name, new DelegateAccessor<T, TResult>((obj, propertyName, ctx) => accessor(obj, ctx)))]);
         }

--- a/Fluid/MoneyCurrency.cs
+++ b/Fluid/MoneyCurrency.cs
@@ -1,0 +1,50 @@
+namespace Fluid
+{
+    /// <summary>
+    /// Describes a currency used by the money filters.
+    /// </summary>
+    public sealed class MoneyCurrency
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MoneyCurrency"/> class.
+        /// </summary>
+        /// <param name="code">The ISO 4217 code of the currency, e.g. <c>USD</c>.</param>
+        /// <param name="symbol">The symbol of the currency, e.g. <c>$</c>. When <c>null</c> the code is used.</param>
+        /// <param name="decimalDigits">The number of decimal digits the currency is expressed with.</param>
+        public MoneyCurrency(string code, string symbol = null, int decimalDigits = 2)
+        {
+            if (code is null)
+            {
+                ExceptionHelper.ThrowArgumentNullException(nameof(code));
+            }
+
+#if NET8_0_OR_GREATER
+            ArgumentOutOfRangeException.ThrowIfNegative(decimalDigits);
+#else
+            if (decimalDigits < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(decimalDigits));
+            }
+#endif
+
+            Code = code;
+            Symbol = symbol ?? code;
+            DecimalDigits = decimalDigits;
+        }
+
+        /// <summary>
+        /// Gets the ISO 4217 code of the currency.
+        /// </summary>
+        public string Code { get; }
+
+        /// <summary>
+        /// Gets the symbol of the currency.
+        /// </summary>
+        public string Symbol { get; }
+
+        /// <summary>
+        /// Gets the number of decimal digits the currency is expressed with.
+        /// </summary>
+        public int DecimalDigits { get; }
+    }
+}

--- a/Fluid/MoneyOptions.cs
+++ b/Fluid/MoneyOptions.cs
@@ -1,0 +1,191 @@
+using Fluid.Utils;
+using System.Collections.Concurrent;
+using System.Globalization;
+
+namespace Fluid
+{
+    /// <summary>
+    /// Configures the money filters registered by <see cref="Filters.MoneyFilters.WithMoneyFilters"/>.
+    /// </summary>
+    /// <remarks>
+    /// Like <see cref="TemplateOptions"/> an instance is expected to be configured once, before any
+    /// template is rendered, and then shared. Formats and currencies are cached the first time they are used.
+    /// </remarks>
+    public class MoneyOptions
+    {
+        private string _moneyFormat;
+        private string _moneyWithCurrencyFormat;
+
+        private readonly ConcurrentDictionary<string, NumberFormatInfo> _numberFormats = new(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Gets or sets whether amounts are expressed in cents, like in Shopify where prices are stored as integers.
+        /// When <c>true</c>, the input of the money filters is divided by 100. The default is <c>false</c>.
+        /// </summary>
+        /// <example>
+        /// With <c>AmountsInCents</c> set to <c>true</c>, <c>{{ 1450 | money }}</c> renders <c>$14.50</c>.
+        /// </example>
+        public bool AmountsInCents { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ISO 4217 code of the currency to use, e.g. <c>EUR</c>.
+        /// When <c>null</c>, the currency of <see cref="TemplateOptions.CultureInfo"/> is used, falling back to <c>USD</c>.
+        /// </summary>
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// Gets or sets the format used by the <c>money</c> and <c>money_without_trailing_zeros</c> filters.
+        /// When <c>null</c>, the format is derived from <see cref="TemplateOptions.CultureInfo"/>.
+        /// </summary>
+        /// <remarks>
+        /// The supported placeholders are <c>{{amount}}</c>, <c>{{amount_no_decimals}}</c>,
+        /// <c>{{amount_with_comma_separator}}</c>, <c>{{amount_no_decimals_with_comma_separator}}</c>,
+        /// <c>{{amount_with_apostrophe_separator}}</c>, <c>{{amount_no_decimals_with_space_separator}}</c>,
+        /// <c>{{amount_with_space_separator}}</c>, <c>{{amount_with_period_and_space_separator}}</c>,
+        /// and the Fluid specific <c>{{currency}}</c> and <c>{{currency_symbol}}</c>.
+        /// Unknown placeholders are rendered verbatim.
+        /// </remarks>
+        /// <example><c>"${{amount}}"</c></example>
+        public string MoneyFormat
+        {
+            get => _moneyFormat;
+            set
+            {
+                _moneyFormat = value;
+                ParsedMoneyFormat = MoneyFormatTemplate.Parse(value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the format used by the <c>money_with_currency</c> filter. When <c>null</c>, the
+        /// format is derived from <see cref="MoneyFormat"/> when it is set, or from <see cref="TemplateOptions.CultureInfo"/>.
+        /// </summary>
+        /// <remarks>
+        /// Supports the same placeholders as <see cref="MoneyFormat"/>.
+        /// </remarks>
+        /// <example><c>"${{amount}} {{currency}}"</c></example>
+        public string MoneyWithCurrencyFormat
+        {
+            get => _moneyWithCurrencyFormat;
+            set
+            {
+                _moneyWithCurrencyFormat = value;
+                ParsedMoneyWithCurrencyFormat = MoneyFormatTemplate.Parse(value);
+            }
+        }
+
+        /// <summary>
+        /// Gets the currencies known to the money filters, keyed by their ISO 4217 code.
+        /// Entries can be added or replaced to support more currencies, or to use a different symbol.
+        /// A currency that is not in this collection is rendered using its code as the symbol.
+        /// </summary>
+        public IDictionary<string, MoneyCurrency> Currencies { get; } = CreateDefaultCurrencies();
+
+        internal MoneyFormatTemplate ParsedMoneyFormat { get; private set; }
+
+        internal MoneyFormatTemplate ParsedMoneyWithCurrencyFormat { get; private set; }
+
+        internal NumberFormatInfo GetNumberFormat(CultureInfo culture, MoneyCurrency currency)
+        {
+            var key = culture.Name + "|" + currency.Code;
+
+            if (_numberFormats.TryGetValue(key, out var numberFormat))
+            {
+                return numberFormat;
+            }
+
+            numberFormat = (NumberFormatInfo)culture.NumberFormat.Clone();
+
+            numberFormat.CurrencySymbol = currency.Symbol;
+            numberFormat.CurrencyDecimalDigits = currency.DecimalDigits;
+
+            // Prices are rendered with a minus sign instead of the accounting notation some cultures use,
+            // e.g. -$10.00 instead of ($10.00). The negative pattern is aligned on the positive one so the
+            // symbol stays at the same place. See https://learn.microsoft.com/dotnet/api/system.globalization.numberformatinfo.currencynegativepattern
+            numberFormat.CurrencyNegativePattern = numberFormat.CurrencyPositivePattern switch
+            {
+                1 => 5, // n$ -> -n$
+                2 => 9, // $ n -> -$ n
+                3 => 8, // n $ -> -n $
+                _ => 1, // $n -> -$n
+            };
+
+            numberFormat.NumberNegativePattern = 1; // -n
+
+            // The 'N' format is used to render amounts without their currency symbol. Align it on the
+            // currency formatting of the culture so both filters produce consistent separators.
+            numberFormat.NumberGroupSeparator = numberFormat.CurrencyGroupSeparator;
+            numberFormat.NumberDecimalSeparator = numberFormat.CurrencyDecimalSeparator;
+            numberFormat.NumberGroupSizes = numberFormat.CurrencyGroupSizes;
+            numberFormat.NumberDecimalDigits = currency.DecimalDigits;
+
+            numberFormat = NumberFormatInfo.ReadOnly(numberFormat);
+
+            _numberFormats[key] = numberFormat;
+
+            return numberFormat;
+        }
+
+        private static Dictionary<string, MoneyCurrency> CreateDefaultCurrencies()
+        {
+            MoneyCurrency[] currencies =
+            [
+                new("AED", "د.إ"),
+                new("ARS", "$"),
+                new("AUD", "$"),
+                new("BGN", "лв"),
+                new("BRL", "R$"),
+                new("CAD", "$"),
+                new("CHF", "CHF"),
+                new("CLP", "$", 0),
+                new("CNY", "¥"),
+                new("COP", "$"),
+                new("CZK", "Kč"),
+                new("DKK", "kr"),
+                new("EGP", "£"),
+                new("EUR", "€"),
+                new("GBP", "£"),
+                new("HKD", "$"),
+                new("HUF", "Ft"),
+                new("IDR", "Rp"),
+                new("ILS", "₪"),
+                new("INR", "₹"),
+                new("ISK", "kr", 0),
+                new("JPY", "¥", 0),
+                new("KRW", "₩", 0),
+                new("KWD", "د.ك", 3),
+                new("MAD", "د.م."),
+                new("MXN", "$"),
+                new("MYR", "RM"),
+                new("NGN", "₦"),
+                new("NOK", "kr"),
+                new("NZD", "$"),
+                new("PEN", "S/"),
+                new("PHP", "₱"),
+                new("PKR", "₨"),
+                new("PLN", "zł"),
+                new("RON", "lei"),
+                new("RUB", "₽"),
+                new("SAR", "﷼"),
+                new("SEK", "kr"),
+                new("SGD", "$"),
+                new("THB", "฿"),
+                new("TRY", "₺"),
+                new("TWD", "$"),
+                new("UAH", "₴"),
+                new("USD", "$"),
+                new("VND", "₫", 0),
+                new("ZAR", "R"),
+            ];
+
+            var result = new Dictionary<string, MoneyCurrency>(currencies.Length, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var currency in currencies)
+            {
+                result[currency.Code] = currency;
+            }
+
+            return result;
+        }
+    }
+}

--- a/Fluid/ParseException.cs
+++ b/Fluid/ParseException.cs
@@ -1,6 +1,6 @@
 ﻿namespace Fluid
 {
-    public sealed class ParseException : Exception
+    public sealed class ParseException : FluidException
     {
         //
         // Summary:

--- a/Fluid/Parser/CompositeFluidTemplate.cs
+++ b/Fluid/Parser/CompositeFluidTemplate.cs
@@ -1,27 +1,90 @@
-﻿using System.Text.Encodings.Web;
+﻿using Fluid.Ast;
+using System.Text.Encodings.Web;
 
 namespace Fluid.Parser
 {
-    public sealed class CompositeFluidTemplate : IFluidTemplate
+    public sealed class CompositeFluidTemplate : IFluidTemplate, IStatementList
     {
         public CompositeFluidTemplate(params IFluidTemplate[] templates)
         {
             Templates = new List<IFluidTemplate>(templates);
+            Statements = CollectStatements(templates);
         }
 
         public CompositeFluidTemplate(IReadOnlyList<IFluidTemplate> templates)
         {
             Templates = new List<IFluidTemplate>(templates);
+            Statements = CollectStatements(templates);
         }
 
         public IReadOnlyList<IFluidTemplate> Templates { get; }
 
-        public async ValueTask RenderAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
+        public IReadOnlyList<Statement> Statements { get; }
+
+        public ValueTask RenderAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
-            foreach (var template in Templates)
+            if (writer == null)
             {
-                await template.RenderAsync(writer, encoder, context);
+                ExceptionHelper.ThrowArgumentNullException(nameof(writer));
             }
+
+            if (encoder == null)
+            {
+                ExceptionHelper.ThrowArgumentNullException(nameof(encoder));
+            }
+
+            if (context == null)
+            {
+                ExceptionHelper.ThrowArgumentNullException(nameof(context));
+            }
+
+            var count = Statements.Count;
+            for (var i = 0; i < count; i++)
+            {
+                var task = Statements[i].WriteToAsync(writer, encoder, context);
+                if (!task.IsCompletedSuccessfully)
+                {
+                    return Awaited(
+                        task,
+                        writer,
+                        encoder,
+                        context,
+                        Statements,
+                        startIndex: i + 1);
+                }
+            }
+
+            return new ValueTask();
+        }
+
+        private static async ValueTask Awaited(
+            ValueTask<Completion> task,
+            TextWriter writer,
+            TextEncoder encoder,
+            TemplateContext context,
+            IReadOnlyList<Statement> statements,
+            int startIndex)
+        {
+            await task;
+            for (var i = startIndex; i < statements.Count; i++)
+            {
+                await statements[i].WriteToAsync(writer, encoder, context);
+            }
+        }
+
+        private static List<Statement> CollectStatements(IEnumerable<IFluidTemplate> templates)
+        {
+            var statements = new List<Statement>();
+            
+            foreach (var template in templates)
+            {
+                if (template is IStatementList statementList)
+                {
+                    statements.AddRange(statementList.Statements);
+                }
+            }
+            
+            return statements;
         }
     }
 }

--- a/Fluid/Parser/TagParsers.cs
+++ b/Fluid/Parser/TagParsers.cs
@@ -13,6 +13,14 @@ namespace Fluid.Parser
         public Expression Value;
     }
 
+    public struct TableRowModifier
+    {
+        public bool IsCols;
+        public bool IsLimit;
+        public bool IsOffset;
+        public Expression Value;
+    }
+
     public readonly struct TagResult
     {
         public static readonly TagResult TagOpen = new(true, false);

--- a/Fluid/TemplateContext.cs
+++ b/Fluid/TemplateContext.cs
@@ -145,13 +145,11 @@ namespace Fluid
         /// </summary>
         internal Scope RootScope { get; set; }
 
-        private Dictionary<string, object> _ambientValues;
-
         /// <summary>
         /// Used to define custom object on this instance to be used in filters and statements
         /// but which are not available from the template.
         /// </summary>
-        public Dictionary<string, object> AmbientValues => _ambientValues ??= new Dictionary<string, object>();
+        public Dictionary<string, object> AmbientValues => field ??= [];
 
         /// <summary>
         /// Gets or sets a model object that is used to resolve properties in a template. This object is used if local and

--- a/Fluid/TemplateContext.cs
+++ b/Fluid/TemplateContext.cs
@@ -54,6 +54,7 @@ namespace Fluid
             LocalScope = new Scope(options.Scope, forLoopScope: false, modelNamesComparer);
             RootScope = LocalScope;
             CultureInfo = options.CultureInfo;
+            MoneyOptions = options.MoneyOptions;
             TimeZone = options.TimeZone;
             Captured = options.Captured;
             Assigned = options.Assigned;
@@ -107,6 +108,12 @@ namespace Fluid
         /// Gets or sets the <see cref="CultureInfo"/> instance used to render locale values like dates and numbers.
         /// </summary>
         public CultureInfo CultureInfo { get; set; } = TemplateOptions.Default.CultureInfo;
+
+        /// <summary>
+        /// Gets or sets the options used by the money filters. Assigning a different instance allows
+        /// a currency to be selected per rendering, for example based on the current request.
+        /// </summary>
+        public MoneyOptions MoneyOptions { get; set; } = TemplateOptions.Default.MoneyOptions;
 
         /// <summary>
         /// Gets or sets the value to returned by the "now" keyword.

--- a/Fluid/TemplateOptions.cs
+++ b/Fluid/TemplateOptions.cs
@@ -100,6 +100,12 @@ namespace Fluid
         public CultureInfo CultureInfo { get; set; } = CultureInfo.InvariantCulture;
 
         /// <summary>
+        /// Gets or sets the options used by the money filters. These filters are not registered by default,
+        /// use <see cref="MoneyFilters.WithMoneyFilters(FilterCollection)"/> to add them to <see cref="Filters"/>.
+        /// </summary>
+        public MoneyOptions MoneyOptions { get; set; } = new MoneyOptions();
+
+        /// <summary>
         /// Gets or sets the value returned by the "now" keyword.
         /// </summary>
         public Func<DateTimeOffset> Now { get; set; } = static () => DateTimeOffset.Now;

--- a/Fluid/TemplateOptions.cs
+++ b/Fluid/TemplateOptions.cs
@@ -9,6 +9,8 @@ namespace Fluid
 {
     public class TemplateOptions
     {
+        private MemberAccessStrategy _memberAccessStrategy = new DefaultMemberAccessStrategy();
+
         /// <summary>
         /// When set to <c>true</c>, any access to an undefined variable during template rendering will
         /// immediately throw an <see cref="InvalidOperationException"/>. The default is <c>false</c>, which
@@ -56,7 +58,20 @@ namespace Fluid
         /// <summary>
         /// Gets ot sets the members than can be accessed in a template.
         /// </summary>
-        public MemberAccessStrategy MemberAccessStrategy { get; set; } = new DefaultMemberAccessStrategy();
+        public MemberAccessStrategy MemberAccessStrategy
+        {
+            get => _memberAccessStrategy;
+            set
+            {
+                if (value is null)
+                {
+                    ExceptionHelper.ThrowArgumentNullException(nameof(value));
+                }
+
+                _memberAccessStrategy = value;
+                RegisterGeneratedMemberAccessors();
+            }
+        }
 
         /// <summary>
         /// Gets or sets the <see cref="IFileProvider"/> used to access files for include and render statements.
@@ -193,6 +208,16 @@ namespace Fluid
                 .WithStringFilters()
                 .WithNumberFilters()
                 .WithMiscFilters();
+
+            RegisterGeneratedMemberAccessors();
+        }
+
+        private void RegisterGeneratedMemberAccessors()
+        {
+            if (this is ITemplateOptionsMemberAccessorRegistrar registrar)
+            {
+                registrar.RegisterMemberAccessors(this);
+            }
         }
     }
 }

--- a/Fluid/TemplateOptions.cs
+++ b/Fluid/TemplateOptions.cs
@@ -48,6 +48,16 @@ namespace Fluid
         public ITemplateCache TemplateCache { get; set; } = new TemplateCache();
 
         /// <summary>
+        /// Gets or sets the default file extension to use when loading templates with include and render statements.
+        /// If set, the file provider will first check if the file exists with the specified name, then try appending this extension.
+        /// If null or empty, the filename is used as-is without any extension appending.
+        /// </summary>
+        /// <value>
+        /// Default value is ".liquid"
+        /// </value>
+        public string DefaultFileExtension { get; set; } = ".liquid";
+
+        /// <summary>
         /// Gets or sets the maximum number of steps a script can execute. Leave to 0 for unlimited.
         /// </summary>
         public int MaxSteps { get; set; }

--- a/Fluid/TemplateOptions.cs
+++ b/Fluid/TemplateOptions.cs
@@ -25,6 +25,14 @@ namespace Fluid
         /// <returns>The value to use for the undefined value.</returns>
         public delegate ValueTask<FluidValue> UndefinedDelegate(string name);
 
+        /// <summary>
+        /// Represents the method that will handle the template parsed event.
+        /// </summary>
+        /// <param name="path">The path of the template that was parsed.</param>
+        /// <param name="template">The template that was parsed.</param>
+        /// <returns>The template to use, which may be modified by applying AST visitors or rewriters.</returns>
+        public delegate IFluidTemplate TemplateParsedDelegate(string path, IFluidTemplate template);
+
         public static readonly TemplateOptions Default = new();
 
         private static readonly JavaScriptEncoder DefaultJavaScriptEncoder = JavaScriptEncoder.Default;
@@ -129,6 +137,12 @@ namespace Fluid
             get => JsonSerializerOptions.Encoder;
             set => JsonSerializerOptions.Encoder = value;
         }
+
+        /// <summary>
+        /// Gets or sets the delegate to execute when a template is parsed during include or render statements.
+        /// This can be used to apply AST visitors or rewriters to modify templates before they are rendered or cached.
+        /// </summary>
+        public TemplateParsedDelegate TemplateParsed { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="JsonSerializerOptions"/> used by the <c>json</c> filter.

--- a/Fluid/TemplateOptions.cs
+++ b/Fluid/TemplateOptions.cs
@@ -9,6 +9,22 @@ namespace Fluid
 {
     public class TemplateOptions
     {
+        /// <summary>
+        /// When set to <c>true</c>, any access to an undefined variable during template rendering will
+        /// immediately throw an <see cref="InvalidOperationException"/>. The default is <c>false</c>, which
+        /// renders undefined variables as empty strings (unless an <see cref="Undefined"/> delegate is provided).
+        /// This property can be set at any time and is checked when undefined variables are accessed.
+        /// </summary>
+        public bool StrictVariables { get; set; }
+
+        /// <summary>
+        /// When set to <c>true</c>, using an unknown filter name in a template will
+        /// immediately throw an <see cref="InvalidOperationException"/> instead of
+        /// silently ignoring the filter or returning the input value. The default is <c>false</c>.
+        /// This can be toggled after construction to enforce stricter authoring rules.
+        /// </summary>
+        public bool StrictFilters { get; set; }
+
         /// <param name="identifier">The name of the property that is assigned.</param>
         /// <param name="value">The value that is assigned.</param>
         /// <param name="context">The <see cref="TemplateContext" /> instance used for rendering the template.</param>
@@ -162,6 +178,9 @@ namespace Fluid
         /// </summary>
         public bool Greedy { get; set; } = true;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemplateOptions"/> class.
+        /// </summary>
         public TemplateOptions()
         {
             Filters.WithArrayFilters()

--- a/Fluid/Utils/MoneyFormatTemplate.cs
+++ b/Fluid/Utils/MoneyFormatTemplate.cs
@@ -1,0 +1,231 @@
+using System.Globalization;
+using System.Text;
+
+namespace Fluid.Utils
+{
+    /// <summary>
+    /// The amount placeholders supported by a money format string. They are intentionally
+    /// culture independent, as defined by https://help.shopify.com/en/manual/payments/currency-formatting.
+    /// </summary>
+    internal enum MoneyAmountFormat
+    {
+        Amount = 0,
+        AmountNoDecimals = 1,
+        AmountWithCommaSeparator = 2,
+        AmountNoDecimalsWithCommaSeparator = 3,
+        AmountWithApostropheSeparator = 4,
+        AmountNoDecimalsWithSpaceSeparator = 5,
+        AmountWithSpaceSeparator = 6,
+        AmountWithPeriodAndSpaceSeparator = 7,
+    }
+
+    internal enum MoneySegmentKind
+    {
+        Literal,
+        Amount,
+        CurrencyCode,
+        CurrencySymbol,
+    }
+
+    internal readonly struct MoneyFormatSegment
+    {
+        public MoneyFormatSegment(string literal)
+        {
+            Kind = MoneySegmentKind.Literal;
+            Literal = literal;
+            Amount = default;
+        }
+
+        public MoneyFormatSegment(MoneyAmountFormat amount)
+        {
+            Kind = MoneySegmentKind.Amount;
+            Literal = null;
+            Amount = amount;
+        }
+
+        public MoneyFormatSegment(MoneySegmentKind kind)
+        {
+            Kind = kind;
+            Literal = null;
+            Amount = default;
+        }
+
+        public MoneySegmentKind Kind { get; }
+        public string Literal { get; }
+        public MoneyAmountFormat Amount { get; }
+    }
+
+    /// <summary>
+    /// A pre-parsed money format string, e.g. <c>${{amount}}</c>. Parsing happens once, when the
+    /// format is assigned on <see cref="MoneyOptions"/>, so that rendering never rescans the string.
+    /// </summary>
+    internal sealed class MoneyFormatTemplate
+    {
+        // Indexed by (int)MoneyAmountFormat * 2 + (noDecimals ? 1 : 0)
+        private static readonly NumberFormatInfo[] AmountFormats = CreateAmountFormats();
+
+        private readonly MoneyFormatSegment[] _segments;
+
+        private MoneyFormatTemplate(MoneyFormatSegment[] segments)
+        {
+            _segments = segments;
+        }
+
+        public static MoneyFormatTemplate Parse(string format)
+        {
+            if (format == null)
+            {
+                return null;
+            }
+
+            var segments = new List<MoneyFormatSegment>();
+
+            // The start of the literal text that hasn't been added to the segments yet.
+            var literalStart = 0;
+            var searchIndex = 0;
+
+            while (searchIndex < format.Length)
+            {
+                var start = format.IndexOf("{{", searchIndex, StringComparison.Ordinal);
+
+                if (start == -1)
+                {
+                    break;
+                }
+
+                var end = format.IndexOf("}}", start + 2, StringComparison.Ordinal);
+
+                if (end == -1)
+                {
+                    break;
+                }
+
+                var name = format.Substring(start + 2, end - start - 2).Trim();
+
+                if (!TryCreateSegment(name, out var segment))
+                {
+                    // Unknown placeholders are rendered verbatim, they stay part of the current literal.
+                    searchIndex = start + 2;
+                    continue;
+                }
+
+                if (start > literalStart)
+                {
+                    segments.Add(new MoneyFormatSegment(format.Substring(literalStart, start - literalStart)));
+                }
+
+                segments.Add(segment);
+                literalStart = end + 2;
+                searchIndex = literalStart;
+            }
+
+            if (literalStart < format.Length)
+            {
+                segments.Add(new MoneyFormatSegment(format.Substring(literalStart)));
+            }
+
+            return new MoneyFormatTemplate(segments.ToArray());
+        }
+
+        private static bool TryCreateSegment(string name, out MoneyFormatSegment segment)
+        {
+            switch (name)
+            {
+                case "amount": segment = new MoneyFormatSegment(MoneyAmountFormat.Amount); return true;
+                case "amount_no_decimals": segment = new MoneyFormatSegment(MoneyAmountFormat.AmountNoDecimals); return true;
+                case "amount_with_comma_separator": segment = new MoneyFormatSegment(MoneyAmountFormat.AmountWithCommaSeparator); return true;
+                case "amount_no_decimals_with_comma_separator": segment = new MoneyFormatSegment(MoneyAmountFormat.AmountNoDecimalsWithCommaSeparator); return true;
+                case "amount_with_apostrophe_separator": segment = new MoneyFormatSegment(MoneyAmountFormat.AmountWithApostropheSeparator); return true;
+                case "amount_no_decimals_with_space_separator": segment = new MoneyFormatSegment(MoneyAmountFormat.AmountNoDecimalsWithSpaceSeparator); return true;
+                case "amount_with_space_separator": segment = new MoneyFormatSegment(MoneyAmountFormat.AmountWithSpaceSeparator); return true;
+                case "amount_with_period_and_space_separator": segment = new MoneyFormatSegment(MoneyAmountFormat.AmountWithPeriodAndSpaceSeparator); return true;
+
+                // Fluid specific placeholders, used to support a currency that is resolved at rendering time.
+                case "currency": segment = new MoneyFormatSegment(MoneySegmentKind.CurrencyCode); return true;
+                case "currency_symbol": segment = new MoneyFormatSegment(MoneySegmentKind.CurrencySymbol); return true;
+
+                default: segment = default; return false;
+            }
+        }
+
+        /// <summary>
+        /// Renders the template.
+        /// </summary>
+        /// <param name="builder">The builder to render to.</param>
+        /// <param name="amount">The amount to render.</param>
+        /// <param name="currency">The currency used by the <c>currency</c> and <c>currency_symbol</c> placeholders.</param>
+        /// <param name="noDecimals">When <c>true</c> every amount placeholder is rendered without decimals.</param>
+        public void Render(ref ValueStringBuilder builder, decimal amount, MoneyCurrency currency, bool noDecimals)
+        {
+            foreach (var segment in _segments)
+            {
+                switch (segment.Kind)
+                {
+                    case MoneySegmentKind.Literal:
+                        builder.Append(segment.Literal);
+                        break;
+
+                    case MoneySegmentKind.Amount:
+                        AppendAmount(ref builder, amount, segment.Amount, noDecimals);
+                        break;
+
+                    case MoneySegmentKind.CurrencyCode:
+                        builder.Append(currency.Code);
+                        break;
+
+                    case MoneySegmentKind.CurrencySymbol:
+                        builder.Append(currency.Symbol);
+                        break;
+                }
+            }
+        }
+
+        private static void AppendAmount(ref ValueStringBuilder builder, decimal amount, MoneyAmountFormat format, bool noDecimals)
+        {
+            var numberFormat = AmountFormats[((int)format * 2) + (noDecimals ? 1 : 0)];
+            var rounded = Math.Round(amount, numberFormat.NumberDecimalDigits, MidpointRounding.AwayFromZero);
+
+            builder.Append(rounded.ToString("N", numberFormat));
+        }
+
+        private static NumberFormatInfo[] CreateAmountFormats()
+        {
+            // group separator, decimal separator, decimal digits
+            (string Group, string Decimal, int Digits)[] specifications =
+            [
+                (",", ".", 2), // amount
+                (",", ".", 0), // amount_no_decimals
+                (".", ",", 2), // amount_with_comma_separator
+                (".", ",", 0), // amount_no_decimals_with_comma_separator
+                ("'", ".", 2), // amount_with_apostrophe_separator
+                (" ", ".", 0), // amount_no_decimals_with_space_separator
+                (" ", ",", 2), // amount_with_space_separator
+                (" ", ".", 2), // amount_with_period_and_space_separator
+            ];
+
+            var result = new NumberFormatInfo[specifications.Length * 2];
+
+            for (var i = 0; i < specifications.Length; i++)
+            {
+                var specification = specifications[i];
+
+                result[i * 2] = CreateAmountFormat(specification.Group, specification.Decimal, specification.Digits);
+                result[(i * 2) + 1] = CreateAmountFormat(specification.Group, specification.Decimal, 0);
+            }
+
+            return result;
+        }
+
+        private static NumberFormatInfo CreateAmountFormat(string groupSeparator, string decimalSeparator, int decimalDigits)
+        {
+            var numberFormat = (NumberFormatInfo)CultureInfo.InvariantCulture.NumberFormat.Clone();
+
+            numberFormat.NumberGroupSeparator = groupSeparator;
+            numberFormat.NumberDecimalSeparator = decimalSeparator;
+            numberFormat.NumberDecimalDigits = decimalDigits;
+            numberFormat.NumberGroupSizes = [3];
+
+            return NumberFormatInfo.ReadOnly(numberFormat);
+        }
+    }
+}

--- a/Fluid/Utils/ValueStringBuilder.cs
+++ b/Fluid/Utils/ValueStringBuilder.cs
@@ -1,0 +1,261 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#nullable enable
+
+namespace System.Text
+{
+    internal ref partial struct ValueStringBuilder
+    {
+        private char[]? _arrayToReturnToPool;
+        private Span<char> _chars;
+        private int _pos;
+
+        public ValueStringBuilder(Span<char> initialBuffer)
+        {
+            _arrayToReturnToPool = null;
+            _chars = initialBuffer;
+            _pos = 0;
+        }
+
+        public ValueStringBuilder(int initialCapacity)
+        {
+            _arrayToReturnToPool = ArrayPool<char>.Shared.Rent(initialCapacity);
+            _chars = _arrayToReturnToPool;
+            _pos = 0;
+        }
+
+        public int Length
+        {
+            get => _pos;
+            set
+            {
+                Debug.Assert(value >= 0);
+                Debug.Assert(value <= _chars.Length);
+                _pos = value;
+            }
+        }
+
+        public int Capacity => _chars.Length;
+
+        public void EnsureCapacity(int capacity)
+        {
+            Debug.Assert(capacity >= 0);
+
+            if ((uint)capacity > (uint)_chars.Length)
+            {
+                Grow(capacity - _pos);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void NullTerminate()
+        {
+            EnsureCapacity(_pos + 1);
+            _chars[_pos] = '\0';
+        }
+
+        public ref char GetPinnableReference()
+        {
+            return ref MemoryMarshal.GetReference(_chars);
+        }
+
+        public ref char this[int index]
+        {
+            get
+            {
+                Debug.Assert(index < _pos);
+                return ref _chars[index];
+            }
+        }
+
+        public override string ToString()
+        {
+            var value = _chars.Slice(0, _pos).ToString();
+            Dispose();
+            return value;
+        }
+
+        public Span<char> RawChars => _chars;
+
+        public ReadOnlySpan<char> AsSpan() => _chars.Slice(0, _pos);
+
+        public ReadOnlySpan<char> AsSpan(int start) => _chars.Slice(start, _pos - start);
+
+        public ReadOnlySpan<char> AsSpan(int start, int length) => _chars.Slice(start, length);
+
+        public void Insert(int index, char value, int count)
+        {
+            if (_pos > _chars.Length - count)
+            {
+                Grow(count);
+            }
+
+            var remaining = _pos - index;
+            _chars.Slice(index, remaining).CopyTo(_chars.Slice(index + count));
+            _chars.Slice(index, count).Fill(value);
+            _pos += count;
+        }
+
+        public void Insert(int index, string? value)
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            var count = value.Length;
+
+            if (_pos > _chars.Length - count)
+            {
+                Grow(count);
+            }
+
+            var remaining = _pos - index;
+            _chars.Slice(index, remaining).CopyTo(_chars.Slice(index + count));
+            value
+#if !NET
+                .AsSpan()
+#endif
+                .CopyTo(_chars.Slice(index));
+            _pos += count;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(char value)
+        {
+            var pos = _pos;
+            var chars = _chars;
+            if ((uint)pos < (uint)chars.Length)
+            {
+                chars[pos] = value;
+                _pos = pos + 1;
+            }
+            else
+            {
+                GrowAndAppend(value);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(string? value)
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            var pos = _pos;
+            if (value.Length == 1 && (uint)pos < (uint)_chars.Length)
+            {
+                _chars[pos] = value[0];
+                _pos = pos + 1;
+            }
+            else
+            {
+                AppendSlow(value);
+            }
+        }
+
+        private void AppendSlow(string value)
+        {
+            var pos = _pos;
+            if (pos > _chars.Length - value.Length)
+            {
+                Grow(value.Length);
+            }
+
+            value
+#if !NET
+                .AsSpan()
+#endif
+                .CopyTo(_chars.Slice(pos));
+            _pos += value.Length;
+        }
+
+        public void Append(char value, int count)
+        {
+            if (_pos > _chars.Length - count)
+            {
+                Grow(count);
+            }
+
+            var destination = _chars.Slice(_pos, count);
+            for (var i = 0; i < destination.Length; i++)
+            {
+                destination[i] = value;
+            }
+
+            _pos += count;
+        }
+
+        public void Append(scoped ReadOnlySpan<char> value)
+        {
+            if (_pos > _chars.Length - value.Length)
+            {
+                Grow(value.Length);
+            }
+
+            value.CopyTo(_chars.Slice(_pos));
+            _pos += value.Length;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<char> AppendSpan(int length)
+        {
+            var originalPosition = _pos;
+            if (originalPosition > _chars.Length - length)
+            {
+                Grow(length);
+            }
+
+            _pos = originalPosition + length;
+            return _chars.Slice(originalPosition, length);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void GrowAndAppend(char value)
+        {
+            Grow(1);
+            Append(value);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Grow(int additionalCapacityBeyondPosition)
+        {
+            Debug.Assert(additionalCapacityBeyondPosition > 0);
+            Debug.Assert(_pos > _chars.Length - additionalCapacityBeyondPosition);
+
+            const uint ArrayMaxLength = 0x7FFFFFC7;
+            var newCapacity = (int)Math.Max(
+                (uint)(_pos + additionalCapacityBeyondPosition),
+                Math.Min((uint)_chars.Length * 2, ArrayMaxLength));
+
+            var poolArray = ArrayPool<char>.Shared.Rent(newCapacity);
+            _chars.Slice(0, _pos).CopyTo(poolArray);
+
+            var toReturn = _arrayToReturnToPool;
+            _chars = _arrayToReturnToPool = poolArray;
+            if (toReturn != null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Dispose()
+        {
+            var toReturn = _arrayToReturnToPool;
+            this = default;
+            if (toReturn != null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+        }
+    }
+}

--- a/Fluid/Values/BlankValue.cs
+++ b/Fluid/Values/BlankValue.cs
@@ -11,15 +11,17 @@ namespace Fluid.Values
         {
         }
 
-        public override FluidValues Type => FluidValues.Empty;
+        public override FluidValues Type => FluidValues.Blank;
 
         public override bool Equals(FluidValue other)
         {
             if (other == this) return true;
             if (other == BooleanValue.False) return true;
-            if (other == EmptyValue.Instance) return true;
+            if (other == EmptyValue.Instance) return false;
             if (other.ToObjectValue() == null) return true;
             if (other.Type == FluidValues.String && string.IsNullOrWhiteSpace(other.ToStringValue())) return true;
+            if (other.Type == FluidValues.Array && other.ToNumberValue() == 0) return true;
+            if (other.Type == FluidValues.Dictionary && other.ToNumberValue() == 0) return true;
 
             return false;
         }

--- a/Fluid/Values/EmptyValue.cs
+++ b/Fluid/Values/EmptyValue.cs
@@ -18,7 +18,7 @@ namespace Fluid.Values
             if (other.Type == FluidValues.String && other.ToStringValue() == "") return true;
             if (other.Type == FluidValues.Array && other.ToNumberValue() == 0) return true;
             if (other.Type == FluidValues.Dictionary && other.ToNumberValue() == 0) return true;
-            if (other == BlankValue.Instance) return true;
+            if (other == BlankValue.Instance) return false;
             if (other == EmptyValue.Instance) return true;
             if (other == NilValue.Instance) return false;
             if (other == UndefinedValue.Instance) return false;

--- a/Fluid/Values/FluidValue.cs
+++ b/Fluid/Values/FluidValue.cs
@@ -142,6 +142,12 @@ namespace Fluid.Values
 
             var typeOfValue = value.GetType();
 
+            // Check if the value is an enum and convert to string
+            if (typeOfValue.IsEnum)
+            {
+                return new StringValue(value.ToString());
+            }
+
             switch (System.Type.GetTypeCode(typeOfValue))
             {
                 case TypeCode.Boolean:

--- a/Fluid/Values/NumberValue.cs
+++ b/Fluid/Values/NumberValue.cs
@@ -48,6 +48,46 @@ namespace Fluid.Values
             return _value == other.ToNumberValue();
         }
 
+        public override ValueTask<FluidValue> GetIndexAsync(FluidValue index, TemplateContext context)
+        {
+            // Integer bit access (e.g. 2[1] == 1). Non-integer numeric values don't support indexers.
+            if (GetScale(_value) != 0)
+            {
+                return NilValue.Instance;
+            }
+
+            if (index.Type != FluidValues.Number || GetScale(index.ToNumberValue()) != 0)
+            {
+                throw new FluidException($"cannot select the property '{index.ToStringValue()}'");
+            }
+
+            var bitIndexAsDecimal = index.ToNumberValue();
+
+            if (bitIndexAsDecimal < 0 || bitIndexAsDecimal > int.MaxValue)
+            {
+                return Zero;
+            }
+
+            var bitIndex = (int)bitIndexAsDecimal;
+
+            long number;
+            try
+            {
+                number = decimal.ToInt64(_value);
+            }
+            catch (OverflowException)
+            {
+                return Zero;
+            }
+
+            if (bitIndex >= 63)
+            {
+                return number < 0 ? Create(1) : Zero;
+            }
+
+            return Create((number >> bitIndex) & 1L);
+        }
+
         public override bool ToBooleanValue()
         {
             return true;

--- a/Fluid/Values/ObjectValueBase.cs
+++ b/Fluid/Values/ObjectValueBase.cs
@@ -82,11 +82,14 @@ namespace Fluid.Values
                 return Create(accessor.Get(Value, name, context), context.Options);
             }
 
+            if (context.Options.StrictVariables)
+            {
+                throw new FluidException($"Undefined variable '{name}'");
+            }
             if (context.Undefined is not null)
             {
                 return context.Undefined.Invoke(name);
             }
-            
             return NilValue.Instance;
 
 
@@ -122,6 +125,10 @@ namespace Fluid.Values
 
                 if (accessor == null)
                 {
+                    if (context.Options.StrictVariables)
+                    {
+                        throw new FluidException($"Undefined variable '{string.Join(".", segments)}'");
+                    }
                     if (context.Undefined is not null)
                     {
                         return await context.Undefined.Invoke(string.Join(".", segments));

--- a/Fluid/Values/TableRowLoopValue.cs
+++ b/Fluid/Values/TableRowLoopValue.cs
@@ -1,0 +1,153 @@
+using System.Globalization;
+using System.Text.Encodings.Web;
+
+namespace Fluid.Values
+{
+    /// <summary>
+    /// Provides information about a parent tablerow loop.
+    /// </summary>
+    public sealed class TableRowLoopValue : FluidValue
+    {
+        private int _length;
+        private int _row;
+        private int _col;
+        private int _cols;
+        private int _index;
+
+        public TableRowLoopValue(int length, int cols)
+        {
+            _length = length;
+            _row = 1;
+            _col = 1;
+            _cols = cols;
+            _index = 0;
+        }
+
+        /// <summary>
+        /// The total number of iterations in the loop.
+        /// </summary>
+        public int Length => _length;
+
+        /// <summary>
+        /// The 1-based index of the current column.
+        /// </summary>
+        public int Col => _col;
+
+        /// <summary>
+        /// The 0-based index of the current column.
+        /// </summary>
+        public int Col0 => _col - 1;
+
+        /// <summary>
+        /// The 1-based index of current row.
+        /// </summary>
+        public int Row => _row;
+
+        /// <summary>
+        /// The 1-based index of the current iteration.
+        /// </summary>
+        public int Index => _index + 1;
+
+        /// <summary>
+        /// The 0-based index of the current iteration.
+        /// </summary>
+        public int Index0 => _index;
+
+        /// <summary>
+        /// The 1-based index of the current iteration, in reverse order.
+        /// </summary>
+        public int RIndex => _length - _index;
+
+        /// <summary>
+        /// The 0-based index of the current iteration, in reverse order.
+        /// </summary>
+        public int RIndex0 => _length - _index - 1;
+
+        /// <summary>
+        /// Returns true if the current iteration is the first.
+        /// </summary>
+        public bool First => _index == 0;
+
+        /// <summary>
+        /// Returns true if the current iteration is the last.
+        /// </summary>
+        public bool Last => _index == _length - 1;
+
+        /// <summary>
+        /// Returns true if the current column is the first in the row.
+        /// </summary>
+        public bool ColFirst => _col == 1;
+
+        /// <summary>
+        /// Returns true if the current column is the last in the row.
+        /// </summary>
+        public bool ColLast => _col == _cols;
+
+        internal void Increment()
+        {
+            _index++;
+
+            if (_col == _cols)
+            {
+                _col = 1;
+                _row++;
+            }
+            else
+            {
+                _col++;
+            }
+        }
+
+        public override FluidValues Type => FluidValues.Dictionary;
+
+        public override bool Equals(FluidValue other)
+        {
+            return false;
+        }
+
+        public override bool ToBooleanValue()
+        {
+            return false;
+        }
+
+        public override decimal ToNumberValue()
+        {
+            return _length;
+        }
+
+        public override object ToObjectValue()
+        {
+            return null;
+        }
+
+        public override string ToStringValue()
+        {
+            return "tablerowloop";
+        }
+
+        public override ValueTask<FluidValue> GetValueAsync(string name, TemplateContext context)
+        {
+            return name switch
+            {
+                "length" => NumberValue.Create(Length),
+                "col" => NumberValue.Create(Col),
+                "col0" => NumberValue.Create(Col0),
+                "row" => NumberValue.Create(Row),
+                "index" => NumberValue.Create(Index),
+                "index0" => NumberValue.Create(Index0),
+                "rindex" => NumberValue.Create(RIndex),
+                "rindex0" => NumberValue.Create(RIndex0),
+                "first" => BooleanValue.Create(First),
+                "last" => BooleanValue.Create(Last),
+                "col_first" => BooleanValue.Create(ColFirst),
+                "col_last" => BooleanValue.Create(ColLast),
+                _ => NilValue.Instance,
+            };
+        }
+
+        public override ValueTask WriteToAsync(TextWriter writer, TextEncoder encoder, CultureInfo cultureInfo)
+        {
+            return default;
+        }
+    }
+}

--- a/MinimalApis.LiquidViews/MinimalApis.LiquidViews.csproj
+++ b/MinimalApis.LiquidViews/MinimalApis.LiquidViews.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <IsPackable>true</IsPackable>
     <PackageIcon>logo_64x64.png</PackageIcon>

--- a/README.md
+++ b/README.md
@@ -264,8 +264,52 @@ var template = FluidTemplate.Parse("Hello {{ user.name }} in {{ city }}!");
 
 await template.RenderAsync(context);
 
+### Strict variables
+
+If you prefer templates to fail fast when they reference a variable that does not exist, enable strict variable mode by setting `TemplateOptions.StrictVariables` to `true`. When `StrictVariables` is `true`, any attempt to access an undefined variable throws a `FluidException` containing the variable name. This makes missing data issues visible immediately instead of silently rendering as an empty string.
+
+```csharp
+var options = new TemplateOptions { StrictVariables = true };
+var context = new TemplateContext(options);
+
+// Parsing a template that references an undefined variable
+var template = FluidTemplate.Parse("Hello {{ user.name }}!");
+
+// Throws FluidException: Undefined variable 'user'
+await template.RenderAsync(context);
+```
+
+When `StrictVariables` is disabled (the default), you can still track missing variables using the `Undefined` delegate described above, or provide fallback values by returning a custom `FluidValue`.
+
 // missingVariables now contains ["user.name", "city"]
 ```
+
+### Strict filters
+
+By default, applying an unknown filter simply returns the input value unchanged:
+
+```liquid
+{{ 'hello' | unknown }}  => hello
+```
+
+If you would rather fail fast when a template references a filter that has not been registered, enable strict filter mode by setting `TemplateOptions.StrictFilters` to `true`:
+
+```csharp
+var options = new TemplateOptions { StrictFilters = true };
+var context = new TemplateContext(options);
+
+var template = FluidTemplate.Parse("{{ 'hello' | unknown }}");
+// Throws FluidException: Undefined filter 'unknown'
+await template.RenderAsync(context);
+```
+
+Known filters continue to work normally when `StrictFilters` is enabled:
+
+```liquid
+{{ 'hello' | upcase }}  => HELLO
+```
+
+Use `StrictFilters` together with `StrictVariables` to enforce both variable and filter correctness during authoring.
 
 ### Returning custom values for undefined values
 

--- a/README.md
+++ b/README.md
@@ -1209,25 +1209,23 @@ var result = changed.Render();
 Console.WriteLine(result); // writes -1
 ```
 
-### Using visitors with the ViewEngine
+### Visiting templates parsed during rendering
 
-When using the Fluid ASP.NET MVC ViewEngine or the standalone ViewEngine, you can apply visitors and rewriters to templates before they are cached by using the `TemplateParsed` callback:
+You can apply visitors and rewriters to templates that are parsed before they are cached by using the `TemplateParsed` callback on `TemplateOptions`. This works for all template parsing scenarios including the ViewEngine, `include` and `render` statements.
 
 ```c#
-services.AddMvc().AddFluid(options =>
+var options = new TemplateOptions { FileProvider = fileProvider };
+options.TemplateParsed = (path, template) =>
 {
-    options.TemplateParsed = (path, template) =>
-    {
-        var visitor = new MyCustomVisitor();
-        return visitor.VisitTemplate(template);
-    };
-});
+    var visitor = new MyCustomVisitor();
+    return visitor.VisitTemplate(template);
+};
 ```
 
 The `TemplateParsed` callback is invoked after a template is parsed but before it is cached. This means:
 - The modified template is cached, improving performance
-- The callback applies to all templates including partials and ViewStarts
-- Each template is processed only once (when first parsed)
+- The callback applies to all templates including partials, includes, and ViewStarts
+- Each template is processed only once (when first parsed, not when retrieved from cache)
 
 ### Custom parsers
 

--- a/README.md
+++ b/README.md
@@ -1209,6 +1209,26 @@ var result = changed.Render();
 Console.WriteLine(result); // writes -1
 ```
 
+### Using visitors with the ViewEngine
+
+When using the Fluid ASP.NET MVC ViewEngine or the standalone ViewEngine, you can apply visitors and rewriters to templates before they are cached by using the `TemplateParsed` callback:
+
+```c#
+services.AddMvc().AddFluid(options =>
+{
+    options.TemplateParsed = (path, template) =>
+    {
+        var visitor = new MyCustomVisitor();
+        return visitor.VisitTemplate(template);
+    };
+});
+```
+
+The `TemplateParsed` callback is invoked after a template is parsed but before it is cached. This means:
+- The modified template is cached, improving performance
+- The callback applies to all templates including partials and ViewStarts
+- Each template is processed only once (when first parsed)
+
 ### Custom parsers
 
 The [custom statements and expressions](#custom-parsers) can also be visited by using one of these methods:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ For a high-level overview, read [The Four Levels of Fluid Development](https://d
 - [Converting CLR types](#converting-clr-types)
 - [Encoding](#encoding)
 - [Localization](#localization)
+- [Money filters](#money-filters)
 - [Time zones](#time-zones)
 - [Customizing tags and blocks](#customizing-tags-and-blocks)
 - [ASP.NET MVC View Engine](#aspnet-mvc-view-engine)
@@ -542,6 +543,126 @@ var result = template.Render(context);
 ```html
 1234.56
 Tuesday, August 1, 2017
+```
+
+<br>
+
+## Money filters
+
+Fluid implements the [Shopify money filters](https://shopify.dev/docs/api/liquid/filters/money). They are not registered by default, add them to the filters of the `TemplateOptions` instance.
+
+```csharp
+var options = new TemplateOptions();
+options.Filters.WithMoneyFilters();
+```
+
+| Filter | Source | Result |
+| --- | --- | --- |
+| `money` | `{{ 1134.65 \| money }}` | `$1,134.65` |
+| `money_with_currency` | `{{ 1134.65 \| money_with_currency }}` | `$1,134.65 USD` |
+| `money_without_currency` | `{{ 1134.65 \| money_without_currency }}` | `1,134.65` |
+| `money_without_trailing_zeros` | `{{ 10.00 \| money_without_trailing_zeros }}` | `$10` |
+
+Amounts are rounded away from zero, so `10.005` is rendered as `$10.01`.
+
+### Cultures and currencies
+
+By default, the currency and the way amounts are formatted are derived from `TemplateOptions.CultureInfo`. The default culture is the invariant one, which has no currency, in which case `USD` is used.
+
+```csharp
+options.CultureInfo = new CultureInfo("de-DE");
+```
+
+```Liquid
+{{ 1134.65 | money_with_currency }}
+```
+
+```html
+1.134,65 € EUR
+```
+
+A specific currency can be set with `MoneyOptions.Currency`, using its [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) code. It is also accepted as an argument of every money filter, which is useful when a single template renders multiple currencies.
+
+```csharp
+options.MoneyOptions.Currency = "EUR";
+```
+
+```Liquid
+{{ 10 | money }}
+{{ 10 | money: 'GBP' }}
+{{ 10 | money: currency: 'JPY' }}
+```
+
+```html
+€10.00
+£10.00
+¥10
+```
+
+The symbol and the number of decimal digits of the most common currencies are known to Fluid. Others can be added, or replaced, in `MoneyOptions.Currencies`. A currency that is not registered is rendered using its code as the symbol.
+
+```csharp
+options.MoneyOptions.Currencies["BTC"] = new MoneyCurrency("BTC", "₿", decimalDigits: 8);
+```
+
+### Amounts stored in cents
+
+Shopify stores prices as integers representing cents. Set `MoneyOptions.AmountsInCents` to divide the input of the money filters by 100, which makes it possible to reuse Shopify templates as-is.
+
+```csharp
+options.MoneyOptions.AmountsInCents = true;
+```
+
+```Liquid
+{{ 1450 | money }}
+```
+
+```html
+$14.50
+```
+
+### Custom formats
+
+`MoneyOptions.MoneyFormat` and `MoneyOptions.MoneyWithCurrencyFormat` override the culture based formatting, using the same placeholders as the [Shopify currency formatting settings](https://help.shopify.com/en/manual/payments/currency-formatting). These placeholders are culture independent.
+
+| Placeholder | Result for `1134.65` |
+| --- | --- |
+| `{{amount}}` | `1,134.65` |
+| `{{amount_no_decimals}}` | `1,135` |
+| `{{amount_with_comma_separator}}` | `1.134,65` |
+| `{{amount_no_decimals_with_comma_separator}}` | `1.135` |
+| `{{amount_with_apostrophe_separator}}` | `1'134.65` |
+| `{{amount_no_decimals_with_space_separator}}` | `1 135` |
+| `{{amount_with_space_separator}}` | `1 134,65` |
+| `{{amount_with_period_and_space_separator}}` | `1 134.65` |
+| `{{currency}}` | the ISO 4217 code of the currency, e.g. `USD` |
+| `{{currency_symbol}}` | the symbol of the currency, e.g. `$` |
+
+`{{currency}}` and `{{currency_symbol}}` are specific to Fluid, and let a single format be used with the currency that is resolved when the template is rendered. Unknown placeholders are rendered verbatim.
+
+```csharp
+options.MoneyOptions.MoneyFormat = "{{amount_with_comma_separator}} kr";
+```
+
+```Liquid
+{{ 1134.65 | money }}
+```
+
+```html
+1.134,65 kr
+```
+
+`money_without_currency` always renders the amount on its own and ignores these formats. When `MoneyWithCurrencyFormat` is not set, `money_with_currency` uses `MoneyFormat` followed by the currency code.
+
+### Rendering a different currency per request
+
+`MoneyOptions` is application-wide configuration and is expected to be configured once. To use a different currency for a single rendering, assign a `MoneyOptions` instance on the `TemplateContext`.
+
+```csharp
+var context = new TemplateContext(options)
+{
+    MoneyOptions = new MoneyOptions { Currency = "EUR" }
+};
 ```
 
 <br>

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ For a high-level overview, read [The Four Levels of Fluid Development](https://d
 ## Contents
 - [Features](#features)
 - [Using Fluid in your project](#using-fluid-in-your-project)
+- [NativeAOT and trimming](#nativeaot-and-trimming)
 - [Allow-listing object members](#allow-listing-object-members)
 - [Handling undefined variables](#handling-undefined-variables)
 - [Execution limits](#execution-limits)
@@ -139,6 +140,73 @@ A `FluidParser` instance is thread-safe, and should be shared by the whole appli
 A `IFluidTemplate` instance is thread-safe and can be cached and reused by multiple threads concurrently.
 
 A `TemplateContext` instance is __not__ thread-safe and an instance should be created every time an `IFluidTemplate` instance is used.
+
+<br>
+
+## NativeAOT and trimming
+
+Fluid works when targeting NativeAOT and trimmed deployments.
+
+- If dynamic code is not supported at runtime, Fluid automatically switches to reflection-based member accessors.
+- Existing `MemberAccessStrategy.Register<T...>` APIs are preserved.
+- No interceptor setup is required.
+
+### Recommended usage when targeting NativeAOT
+
+1. Reuse `TemplateOptions` instances (for example, at app startup).
+2. If you use runtime `MemberAccessStrategy.Register<T...>` calls, execute them during application startup before rendering templates.
+3. Prefer `[FluidRegister]` on a custom `TemplateOptions` subclass for model types known at compile time.
+4. Validate your app with AOT/trim publish settings:
+
+```shell
+dotnet publish -c Release -r <RID> -p:PublishAot=true
+```
+
+### Source generation (optional)
+
+When the `Fluid.SourceGenerator` analyzer is enabled, Fluid can generate strongly-typed member accessors for types declared with `FluidRegisterAttribute`.
+
+The recommended pattern is to declare a custom `TemplateOptions` subclass and add one `FluidRegisterAttribute` per model type:
+
+```csharp
+using Fluid;
+
+[FluidRegister(typeof(Person))]
+[FluidRegister(typeof(Address))]
+public partial class PublicTemplateOptions : TemplateOptions
+{
+}
+```
+
+Use the generated options type like any other `TemplateOptions` instance:
+
+```csharp
+var options = new PublicTemplateOptions();
+```
+
+The generated registrations are instance-scoped and are applied automatically to each `PublicTemplateOptions` instance. Runtime registrations still work and can be added normally:
+
+```csharp
+options.MemberAccessStrategy.Register<Product, object>((product, name) => product.Name);
+```
+
+Alternatively, explicit profile methods can apply generated registrations to any `TemplateOptions` instance:
+
+```csharp
+public static partial class FluidProfiles
+{
+    [FluidRegister(typeof(Person))]
+    [FluidRegister(typeof(Address))]
+    public static partial void ApplyPublic(TemplateOptions options);
+}
+```
+
+Use it with any options instance:
+
+```csharp
+var options = new TemplateOptions();
+FluidProfiles.ApplyPublic(options);
+```
 
 <br>
 

--- a/Versions.props
+++ b/Versions.props
@@ -2,7 +2,7 @@
   <!-- This file define constants that can be changed per TFM -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <SystemTextJsonPackageVersion>8.0.5</SystemTextJsonPackageVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>6.0.1</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>8.0.0</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
@@ -11,5 +11,9 @@
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>9.0.0</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>10.0.0</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
   </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "10.0.100",
     "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
## Summary

Backports the non-breaking fixes and features selected from `main` after v2.31.0. Each source PR is preserved as a distinct commit and adapted to the 2.x rendering and member-access APIs where necessary.

- Runtime and packaging: #855, security-relevant subset of #974, #935, #973
- Template loading and callbacks: #858, #869, #873
- Liquid behavior and fixes: #859, #866, #874, #880, #924, #925, #943, #949
- New compatible features: #906, #910, #934, #963
- Enables PR checks for the existing `release/**` branch convention

## Validation

- Release build across all target frameworks
- 1,492 tests on .NET 10
- 1,492 tests with the compiled Parlot grammar
- Source-generator package contains only `analyzers/dotnet/cs/Fluid.SourceGenerator.dll`