### PR TITLE
Add extensible time zone resolution

### DIFF
--- a/Fluid.Tests/GoldendLiquidTests.cs
+++ b/Fluid.Tests/GoldendLiquidTests.cs
@@ -9,7 +9,6 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using TimeZoneConverter;
 using Xunit;
 using Xunit.Sdk;
 
@@ -17,7 +16,7 @@ namespace Fluid.Tests
 {
     public class GoldenLiquidTests
     {
-        private static readonly TimeZoneInfo Pacific = TZConvert.GetTimeZoneInfo("America/Los_Angeles");
+        private static readonly TimeZoneInfo Pacific = TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles");
         private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions { WriteIndented = true, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
         private static readonly Dictionary<string, string> _skippedTests = new()
         {

--- a/Fluid.Tests/MiscFiltersTests.cs
+++ b/Fluid.Tests/MiscFiltersTests.cs
@@ -9,15 +9,14 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using TimeZoneConverter;
 using Xunit;
 
 namespace Fluid.Tests
 {
     public class MiscFiltersTests
     {
-        private static readonly TimeZoneInfo Pacific = TZConvert.GetTimeZoneInfo("America/Los_Angeles");
-        private static readonly TimeZoneInfo Eastern = TZConvert.GetTimeZoneInfo("America/New_York");
+        private static readonly TimeZoneInfo Pacific = TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles");
+        private static readonly TimeZoneInfo Eastern = TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
         private static readonly string RoundTripDateTimePattern = "%Y-%m-%dT%H:%M:%S.%L%Z"; // Equivalent to "o" format
 
         [Fact]
@@ -378,6 +377,30 @@ namespace Fluid.Tests
             Assert.Equal(expected, ((DateTimeOffset)result.ToObjectValue()).ToString("yyyy-MM-ddTHH:mm:ssK"));
         }
 
+        [Fact]
+        public async Task ChangeTimeZoneUsesConfiguredResolver()
+        {
+            var input = new DateTimeValue(DateTimeOffset.Parse("2020-05-18T02:13:09+00:00"));
+            var arguments = new FilterArguments(new StringValue("Custom"));
+            var customTimeZone = TimeZoneInfo.CreateCustomTimeZone("Custom", TimeSpan.FromHours(3), "Custom", "Custom");
+            var resolvedId = "";
+            var options = new TemplateOptions
+            {
+                TimeZoneResolver = id =>
+                {
+                    resolvedId = id;
+                    return customTimeZone;
+                }
+            };
+
+            var result = await MiscFilters.ChangeTimeZone(input, arguments, new TemplateContext(options));
+
+            Assert.Equal("Custom", resolvedId);
+            Assert.Equal(
+                "2020-05-18T05:13:09+03:00",
+                ((DateTimeOffset)result.ToObjectValue()).ToString("yyyy-MM-ddTHH:mm:ssK"));
+        }
+
         [Theory]
         [InlineData("2022-12-13T21:02:18.399+00:00", "utc", "2022-12-13T21:02:18.399+00:00")]
         [InlineData("2022-12-13T21:02:18.399+00:00", "America/New_York", "2022-12-13T21:02:18.399+00:00")]
@@ -392,7 +415,7 @@ namespace Fluid.Tests
             // - When no TZ is provided, we assume the local offset (context.TimeZone)
 
             var input = new StringValue(initialDateTime);
-            var context = new TemplateContext { TimeZone = TZConvert.GetTimeZoneInfo(timeZone) };
+            var context = new TemplateContext { TimeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZone) };
 
             var date = await MiscFilters.Date(input, new FilterArguments(new StringValue(RoundTripDateTimePattern)), context);
 

--- a/Fluid.Tests/TemplateTests.cs
+++ b/Fluid.Tests/TemplateTests.cs
@@ -22,8 +22,8 @@ namespace Fluid.Tests
         private static FluidParser _parser = new FluidParser();
 #endif
 
-        private static readonly TimeZoneInfo Eastern = TimeZoneConverter.TZConvert.GetTimeZoneInfo("America/New_York");
-        private static readonly TimeZoneInfo Paris = TimeZoneConverter.TZConvert.GetTimeZoneInfo("Europe/Paris");
+        private static readonly TimeZoneInfo Eastern = TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
+        private static readonly TimeZoneInfo Paris = TimeZoneInfo.FindSystemTimeZoneById("Europe/Paris");
 
         private object _products = new[]
         {

--- a/Fluid/Filters/MiscFilters.cs
+++ b/Fluid/Filters/MiscFilters.cs
@@ -6,7 +6,6 @@ using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
-using TimeZoneConverter;
 
 namespace Fluid.Filters
 {
@@ -482,9 +481,20 @@ namespace Fluid.Filters
             {
                 timeZoneInfo = context.TimeZone;
             }
-            else if (!TZConvert.TryGetTimeZoneInfo(timeZone, out timeZoneInfo))
+            else
             {
-                return new DateTimeValue(value);
+                try
+                {
+                    timeZoneInfo = context.Options.TimeZoneResolver(timeZone);
+                }
+                catch (TimeZoneNotFoundException)
+                {
+                    return new DateTimeValue(value);
+                }
+                catch (InvalidTimeZoneException)
+                {
+                    return new DateTimeValue(value);
+                }
             }
 
             var result = TimeZoneInfo.ConvertTime(value, timeZoneInfo);

--- a/Fluid/Fluid.csproj
+++ b/Fluid/Fluid.csproj
@@ -35,6 +35,9 @@
   <ItemGroup>
     <PackageReference Include="Parlot" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="TimeZoneConverter" />
   </ItemGroup>
 

--- a/Fluid/TemplateOptions.cs
+++ b/Fluid/TemplateOptions.cs
@@ -149,9 +149,26 @@ namespace Fluid
         public TimeZoneInfo TimeZone { get; set; } = TimeZoneInfo.Local;
 
         /// <summary>
+        /// Gets or sets the function used by the <c>time_zone</c> filter to resolve a time zone identifier.
+        /// </summary>
+        /// <remarks>
+        /// The default uses <see cref="TimeZoneInfo.FindSystemTimeZoneById(string)"/> on .NET 6 and later.
+        /// </remarks>
+        public Func<string, TimeZoneInfo> TimeZoneResolver { get; set; } = ResolveTimeZone;
+
+        /// <summary>
         /// Gets or sets the maximum depth of recursions a script can execute. 100 by default.
         /// </summary>
         public int MaxRecursion { get; set; } = 100;
+
+        private static TimeZoneInfo ResolveTimeZone(string id)
+        {
+#if NET6_0_OR_GREATER
+            return TimeZoneInfo.FindSystemTimeZoneById(id);
+#else
+            return TimeZoneConverter.TZConvert.GetTimeZoneInfo(id);
+#endif
+        }
 
         /// <summary>
         /// Gets the collection of filters available in the templates.

--- a/README.md
+++ b/README.md
@@ -995,7 +995,7 @@ Wed Dec 31 19:00:00 -08:00 1969
 
 ### Converting time zones
 
-Dates and times can be converted to specific time zones using the `time_zone: <iana>` filter.
+Dates and times can be converted to specific time zones using the `time_zone` filter. On .NET 6 and later, identifiers are resolved with `TimeZoneInfo.FindSystemTimeZoneById`. The `netstandard2.0` asset uses TimeZoneConverter by default.
 
 #### Example
 
@@ -1006,6 +1006,16 @@ context.SetValue("published", DateTime.UtcNow);
 
 ```Liquid
 {{ published | time_zone: 'America/New_York' | date: '%+' }}
+```
+
+On Windows, IANA identifiers require ICU globalization data. Resolution can fail on Windows versions that do not include ICU unless the application deploys it app-locally with the `Microsoft.ICU.ICU4C.Runtime` package. IANA identifiers are also unavailable when globalization invariant mode is enabled (`System.Globalization.Invariant`) or Windows NLS is forced (`System.Globalization.UseNls`). In these configurations, configure a custom resolver. For example, with the `TimeZoneConverter` package:
+
+```csharp
+var options = new TemplateOptions
+{
+    TimeZoneResolver = id => TimeZoneConverter.TZConvert.GetTimeZoneInfo(id)
+};
+var context = new TemplateContext(options);
 ```
 
 #### Result

--- a/TimeZones.md
+++ b/TimeZones.md
@@ -6,6 +6,7 @@ This guide explains how time zones work in Fluid templates, covering parsing, re
 - [Understanding Time Zone Behavior](#understanding-time-zone-behavior)
 - [The TimeZone Property](#the-timezone-property)
 - [Converting Time Zones During Rendering](#converting-time-zones-during-rendering)
+- [Resolving Time Zone Identifiers](#resolving-time-zone-identifiers)
 - [Automatic Conversion with Value Converters](#automatic-conversion-with-value-converters)
 - [Common Patterns and Examples](#common-patterns-and-examples)
 
@@ -170,6 +171,33 @@ Explicit timezone: Wednesday, 02 February 2022 14:00:00
 
 Notice that the `time_zone` filter must be combined with the `date` filter to properly display the converted time. The first line shows the UTC time, while the filtered versions show the time converted to 14:00 in the Uzhgorod timezone (UTC+2).
 
+## Resolving Time Zone Identifiers
+
+On .NET 6 and later, the `time_zone` filter resolves identifiers with `TimeZoneInfo.FindSystemTimeZoneById`. Both IANA identifiers such as `America/Los_Angeles` and Windows identifiers such as `Pacific Standard Time` are supported across platforms when ICU globalization data is available. Fluid's `netstandard2.0` asset uses [TimeZoneConverter](https://github.com/mattjohnsonpint/TimeZoneConverter) as its default resolver for compatibility with older runtimes.
+
+```csharp
+var options = new TemplateOptions();
+var context = new TemplateContext(options);
+
+var template = parser.Parse(
+    "{{ published | time_zone: 'America/Los_Angeles' | date: '%+' }}");
+```
+
+IANA identifiers are not available through `TimeZoneInfo` on Windows when globalization invariant mode or NLS mode is enabled. You can replace the resolver through `TemplateOptions.TimeZoneResolver`. For example, an application using the [TimeZoneConverter](https://github.com/mattjohnsonpint/TimeZoneConverter) package can configure:
+
+```csharp
+using TimeZoneConverter;
+
+var options = new TemplateOptions
+{
+    TimeZoneResolver = id => TZConvert.GetTimeZoneInfo(id)
+};
+
+var context = new TemplateContext(options);
+```
+
+The resolver is used for explicit identifiers passed to the `time_zone` filter. The special `local` identifier still uses `TemplateContext.TimeZone`.
+
 ## Automatic Conversion with Value Converters
 
 If you want to automatically convert all DateTime values to a specific time zone without using the `time_zone` filter everywhere, you can use a value converter:
@@ -304,10 +332,12 @@ The date string will be interpreted as Pacific time, not UTC.
 
 ## Time Zone Identifiers
 
-Fluid uses the [TimeZoneConverter](https://github.com/mattjohnsonpint/TimeZoneConverter) library, which supports:
+Fluid uses `TimeZoneInfo` on .NET 6 and later and TimeZoneConverter on `netstandard2.0`. The default resolver supports:
 - IANA time zone IDs (e.g., "America/New_York", "Europe/London")
 - Windows time zone IDs (e.g., "Pacific Standard Time", "GMT Standard Time")
-- Cross-platform conversion between IANA and Windows identifiers
+- Cross-platform resolution on .NET 6 and later when ICU globalization data is available
+
+Use `TemplateOptions.TimeZoneResolver` when your runtime does not provide the identifiers your templates need.
 
 ### Finding Time Zone IDs
 
@@ -343,13 +373,15 @@ foreach (var tz in TimeZoneInfo.GetSystemTimeZones())
 | Parse date strings without time zone info | Set `TemplateContext.TimeZone` |
 | Display dates in a specific time zone | Use `{{ date \| time_zone: 'timezone-id' }}` filter |
 | Display dates in the context's time zone | Use `{{ date \| time_zone: 'local' }}` filter |
+| Resolve identifiers with a custom library | Set `TemplateOptions.TimeZoneResolver` |
 | Automatically convert all dates | Use a `ValueConverter` |
 | Display dates in multiple time zones | Use multiple `time_zone` filters with different IDs |
 
 ## Additional Resources
 
 - [Ruby date and time format strings](https://ruby-doc.org/core-3.0.0/Time.html#method-i-strftime) - Used by the `date` filter
-- [TimeZoneConverter Library](https://github.com/mattjohnsonpint/TimeZoneConverter) - Cross-platform time zone support
+- [TimeZoneInfo.FindSystemTimeZoneById](https://learn.microsoft.com/dotnet/api/system.timezoneinfo.findsystemtimezonebyid) - Default time zone resolution
+- [TimeZoneConverter Library](https://github.com/mattjohnsonpint/TimeZoneConverter) - Optional resolver for additional compatibility
 - [IANA Time Zone Database](https://www.iana.org/time-zones) - Standard time zone identifiers
 - [Fluid README - Time zones section](README.md#time-zones) - Quick reference
 - [Fluid README - Value Converters section](README.md#adding-a-value-converter) - More on value converters


### PR DESCRIPTION
Modern .NET can resolve IANA time zone IDs directly when ICU is available, so Fluid should not require TimeZoneConverter on those targets. Applications still need an escape hatch for Windows configurations without ICU and for custom compatibility requirements.

## Changes

- Add `TemplateOptions.TimeZoneResolver` and use it for explicit `time_zone` filter identifiers.
- Default to `TimeZoneInfo.FindSystemTimeZoneById` on modern targets while retaining TimeZoneConverter for `netstandard2.0`.
- Preserve existing behavior for unknown or invalid identifiers.
- Document Windows ICU requirements, invariant and NLS modes, and custom TimeZoneConverter configuration.
- Cover custom resolver behavior and use platform resolution in modern-target tests.

## Validation

- Built all Fluid target frameworks.
- Ran `MiscFiltersTests` with both interpreted and compiled parser configurations.