### PR TITLE
Update Parlot to 1.5.8

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
 
     <!-- Common to all TFMs -->
-    <PackageVersion Include="Parlot" Version="1.5.2" />
+    <PackageVersion Include="Parlot" Version="1.5.8" />
     <PackageVersion Include="TimeZoneConverter" Version="7.2.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
     <!-- Benchmarks -->


### PR DESCRIPTION
Parlot 1.5.8 includes parser fixes and improvements released since the 1.5.2 version currently used by Fluid. This updates the centrally managed package version while preserving the existing dependency wiring.

## Benchmark

`Fluid.Benchmarks.FluidBenchmarks.Parse` on .NET 10.0.11, Apple M4 Pro:

| Version | Mean | Allocated |
|---|---:|---:|
| Parlot 1.5.2 | 1.519 us | 2.77 KB |
| Parlot 1.5.8 | 1.602 us | 2.92 KB |

The measured parse path is 5.5% slower and allocates 5.4% more. Profiling attributes most of the added allocation and part of the CPU cost to recursion-cycle detection introduced after 1.5.2; follow-up optimization is being evaluated in Parlot.

## Validation

- Fluid.Tests on net10.0: 1,492 passed
- All Fluid target frameworks build successfully